### PR TITLE
Fix remove build keychain after build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,11 +47,13 @@ github {
 }
 
 repositories {
+    mavenCentral()
     maven { url 'https://repo.gradle.org/gradle/libs-releases' }
 }
 
 dependencies {
     compile "org.gradle:gradle-tooling-api:+"
     compile 'gradle.plugin.net.wooga.gradle:atlas-unity:1.3.0'
+    compile 'xmlwise:xmlwise:1.2.11'
     testCompile 'org.apache.commons:commons-text:1.3'
 }

--- a/src/integrationTest/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginIntegrationSpec.groovy
@@ -62,8 +62,12 @@ class IOSBuildPluginIntegrationSpec extends IntegrationSpec {
     }
 
     boolean keychainIsAdded(File keychain) {
-        def lookupPlist = new File(System.getProperty("user.home"), "Library/Preferences/com.apple.security.plist")
-        lookupPlist.text.contains(keychain.path)
+        def listOut = File.createTempFile("security", "list")
+        def p = new ProcessBuilder("security", "list-keychains", "-d", "user")
+        p.redirectOutput(listOut)
+        p.start().waitFor()
+
+        listOut.text.contains(keychain.path)
     }
 
     def removeKeychain(File keychain) {

--- a/src/integrationTest/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginIntegrationSpec.groovy
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.build.unity.ios
+
+import spock.lang.Shared
+import spock.lang.Unroll
+import wooga.gradle.build.IntegrationSpec
+
+class IOSBuildPluginIntegrationSpec extends IntegrationSpec {
+
+    @Shared
+    File xcProject
+
+    @Shared
+    File xcProjectConfig
+
+    @Shared
+    File buildKeychain
+
+    static String certPassword = "test password"
+
+    def createTestCertificate(File cert, String password) {
+        def certInfo = new File(projectDir, "certInfo")
+        certInfo << """
+        DE
+        Germany
+        Berlin
+        Wooga GmbH
+        Gradle tests
+        Test CA certificate
+        jenkins@wooga.net
+        .
+        .
+        """.stripIndent().trim()
+
+        def createScript = new File(projectDir, "certCreate.sh")
+        createScript << """
+        <${certInfo.path} openssl req -new -x509 -outform PEM -newkey rsa:2048 -nodes -keyout /tmp/ca.key -keyform PEM -out /tmp/ca.crt -days 365
+        echo "${password}" | openssl pkcs12 -export -in /tmp/ca.crt -inkey /tmp/ca.key -out ${cert.path} -name \"Test CA\" -passout stdin
+        """.stripIndent()
+
+        new ProcessBuilder("sh", createScript.path).start().waitFor()
+        createScript.delete()
+        certInfo.delete()
+    }
+
+    boolean keychainIsAdded(File keychain) {
+        def lookupPlist = new File(System.getProperty("user.home"), "Library/Preferences/com.apple.security.plist")
+        lookupPlist.text.contains(keychain.path)
+    }
+
+    def removeKeychain(File keychain) {
+        def listOut = File.createTempFile("security", "list")
+        def p = new ProcessBuilder("security", "list-keychains", "-d", "user")
+        p.redirectOutput(listOut)
+        p.start().waitFor()
+
+        List<String> command = ["security", "list-keychains", "-d", "user", "-s"]
+        def keychains = listOut.readLines().findAll({ !it.contains(keychain.path) })
+        keychains = keychains.collect { it.trim().replaceAll('"', '') }
+        command.addAll(keychains)
+        p = new ProcessBuilder(command)
+        p.start().waitFor()
+
+        assert !keychainIsAdded(keychain)
+    }
+
+    def setup() {
+        buildFile << """
+            ${applyPlugin(IOSBuildPlugin)}
+
+            iosBuild {
+                certificatePassphrase = "$certPassword"
+                keychainPassword = "$certPassword"
+            }
+        """.stripIndent()
+
+        xcProject = new File(projectDir, "test.xcodeproj")
+        xcProject.mkdirs()
+        xcProjectConfig = new File(xcProject, "project.pbxproj")
+        xcProjectConfig << ""
+
+        buildKeychain = new File(projectDir, 'build/sign/keychains/build.keychain')
+
+        createTestCertificate(new File(projectDir, "test_ca.p12"), certPassword)
+
+    }
+
+    def "creates custom build keychain"() {
+        given: "default project"
+
+        when:
+        def result = runTasksSuccessfully("addKeychain")
+
+        then:
+        !result.wasUpToDate("addKeychain")
+        buildKeychain.exists()
+        keychainIsAdded(buildKeychain)
+
+        cleanup:
+        removeKeychain(buildKeychain)
+    }
+
+    def "removes custom build keychain"() {
+        given: "an added build keychain"
+        def result = runTasksSuccessfully("addKeychain")
+        assert !result.wasUpToDate("addKeychain")
+        assert buildKeychain.exists()
+        assert keychainIsAdded(buildKeychain)
+
+        when:
+        runTasksSuccessfully("removeKeychain")
+
+        then:
+        buildKeychain.exists()
+        !keychainIsAdded(buildKeychain)
+
+        cleanup:
+        removeKeychain(buildKeychain)
+    }
+
+    @Unroll
+    def "removes custom build keychain when build #message"() {
+        given: "project which will succeed/fail the assemble task"
+        //skip these tasks to succeed the build
+        buildFile << """
+            project.xcodeArchive.onlyIf({${!success}})
+            project.xcodeExport.onlyIf({${!success}})
+            project.importProvisioningProfiles.onlyIf({${!success}})
+        """.stripIndent()
+
+        when:
+        def result = runTasks("assemble")
+
+        then:
+        result.success == success
+        result.wasExecuted("addKeychain")
+        result.wasExecuted("removeKeychain")
+        buildKeychain.exists()
+        !keychainIsAdded(buildKeychain)
+
+        cleanup:
+        removeKeychain(buildKeychain)
+
+        where:
+        message    || success
+        "fails"    || false
+        "succeeds" || true
+    }
+}

--- a/src/integrationTest/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginIntegrationSpec.groovy
@@ -17,10 +17,12 @@
 
 package wooga.gradle.build.unity.ios
 
+import spock.lang.Requires
 import spock.lang.Shared
 import spock.lang.Unroll
 import wooga.gradle.build.IntegrationSpec
 
+@Requires({os.macOs})
 class IOSBuildPluginIntegrationSpec extends IntegrationSpec {
 
     @Shared

--- a/src/integrationTest/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginIntegrationSpec.groovy
@@ -17,6 +17,8 @@
 
 package wooga.gradle.build.unity.ios
 
+import org.junit.ClassRule
+import org.junit.contrib.java.lang.system.ProvideSystemProperty
 import spock.lang.Requires
 import spock.lang.Shared
 import spock.lang.Unroll
@@ -34,6 +36,10 @@ class IOSBuildPluginIntegrationSpec extends IntegrationSpec {
 
     @Shared
     File buildKeychain
+
+    @Shared
+    KeychainLookupList keychainLookupList = new KeychainLookupList()
+
 
     static String certPassword = "test password"
 
@@ -63,6 +69,7 @@ class IOSBuildPluginIntegrationSpec extends IntegrationSpec {
     }
 
     def setup() {
+        SecurityUtil.getKeychainConfigFile().parentFile.mkdirs()
         buildFile << """
             ${applyPlugin(IOSBuildPlugin)}
 
@@ -92,10 +99,10 @@ class IOSBuildPluginIntegrationSpec extends IntegrationSpec {
         then:
         !result.wasUpToDate("addKeychain")
         buildKeychain.exists()
-        SecurityUtil.keychainIsAdded(buildKeychain)
+        keychainLookupList.contains(buildKeychain)
 
         cleanup:
-        SecurityUtil.removeKeychain(buildKeychain)
+        keychainLookupList.remove(buildKeychain)
     }
 
     def "removes custom build keychain"() {
@@ -110,10 +117,10 @@ class IOSBuildPluginIntegrationSpec extends IntegrationSpec {
 
         then:
         buildKeychain.exists()
-        !SecurityUtil.keychainIsAdded(buildKeychain)
+        !keychainLookupList.contains(buildKeychain)
 
         cleanup:
-        SecurityUtil.removeKeychain(buildKeychain)
+        keychainLookupList.remove(buildKeychain)
     }
 
     @Unroll
@@ -134,10 +141,10 @@ class IOSBuildPluginIntegrationSpec extends IntegrationSpec {
         result.wasExecuted("addKeychain")
         result.wasExecuted("removeKeychain")
         buildKeychain.exists()
-        !SecurityUtil.keychainIsAdded(buildKeychain)
+        !keychainLookupList.contains(buildKeychain)
 
         cleanup:
-        SecurityUtil.removeKeychain(buildKeychain)
+        keychainLookupList.remove(buildKeychain)
 
         where:
         message    || success

--- a/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPlugin.groovy
@@ -160,12 +160,14 @@ class IOSBuildPlugin implements Plugin<Project> {
 
         def importProvisioningProfiles = tasks.create(maybeBaseName(baseName, "importProvisioningProfiles"), ImportProvisioningProfile) {
             it.dependsOn addKeychain, unlockKeychain
+            it.finalizedBy removeKeychain, lockKeychain
             it.mobileProvisioningProfile = project.file("${maybeBaseName(baseName, 'ci')}.mobileprovision")
         }
 
         def xcodeArchive = tasks.create(maybeBaseName(baseName, "xcodeArchive"), XCodeArchiveTask) {
-            it.dependsOn unlockKeychain
-            it.finalizedBy lockKeychain
+            it.dependsOn addKeychain, unlockKeychain
+            removeKeychain.mustRunAfter it
+            lockKeychain.mustRunAfter it
 
             it.provisioningProfile = importProvisioningProfiles
             it.projectPath = xcodeProject
@@ -190,6 +192,6 @@ class IOSBuildPlugin implements Plugin<Project> {
         }
 
         archiveDSYM.mustRunAfter xcodeExport // not to spend time archiving if export fails
-        project.tasks.getByName(BasePlugin.ASSEMBLE_TASK_NAME).dependsOn xcodeExport, archiveDSYM, removeKeychain
+        project.tasks.getByName(BasePlugin.ASSEMBLE_TASK_NAME).dependsOn xcodeExport, archiveDSYM
     }
 }

--- a/src/main/groovy/wooga/gradle/build/unity/ios/KeychainLookupList.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/KeychainLookupList.groovy
@@ -1,0 +1,312 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.build.unity.ios
+
+import wooga.gradle.build.unity.ios.internal.utils.SecurityUtil
+import xmlwise.Plist
+
+class KeychainLookupList implements List<File> {
+
+    private class KeychainLookupIterator implements Iterator<File> {
+        private Iterator<File> innerIterator
+        private File current
+
+        KeychainLookupIterator(Iterator<File> innerIterator) {
+            this.innerIterator = innerIterator
+        }
+
+        @Override
+        boolean hasNext() {
+            return innerIterator.hasNext()
+        }
+
+        @Override
+        File next() {
+            current = innerIterator.next()
+            return current
+        }
+
+        @Override
+        void remove() {
+            remove(current)
+        }
+    }
+
+    private class KeychainLookupListIterator implements ListIterator<File> {
+        private ListIterator<File> innerIterator
+        private File current
+
+        KeychainLookupListIterator(ListIterator<File> innerIterator) {
+            this.innerIterator = innerIterator
+        }
+
+        @Override
+        boolean hasNext() {
+            return innerIterator.hasNext()
+        }
+
+        @Override
+        File next() {
+            current = innerIterator.next()
+            return current
+        }
+
+        @Override
+        void remove() {
+            remove(current)
+        }
+
+        @Override
+        boolean hasPrevious() {
+            return innerIterator.hasPrevious()
+        }
+
+        @Override
+        File previous() {
+            current = innerIterator.previous()
+            return current
+        }
+
+        @Override
+        int nextIndex() {
+            return innerIterator.nextIndex()
+        }
+
+        @Override
+        int previousIndex() {
+            return innerIterator.previousIndex()
+        }
+
+        @Override
+        void set(File file) {
+            throw new UnsupportedOperationException()
+        }
+
+        @Override
+        void add(File file) {
+            throw new UnsupportedOperationException()
+        }
+    }
+
+    private static String DLDBSearchList = 'DLDBSearchList'
+    private static String DbName = 'DbName'
+
+    @Override
+    int size() {
+        def l = innerLookUpList()
+        if (l) {
+            return l.size()
+        }
+        return 0
+    }
+
+    @Override
+    boolean isEmpty() {
+        return size() == 0
+    }
+
+    @Override
+    boolean contains(Object o) {
+        Objects.requireNonNull(o)
+
+        if (!File.isInstance(o)) {
+            throw new ClassCastException("expect object of type java.io.File")
+        }
+
+        File keychain = o as File
+
+        return SecurityUtil.keychainIsAdded(keychain)
+    }
+
+    @Override
+    Iterator<File> iterator() {
+        def l = innerLookUpList() ?: new ArrayList<File>()
+        new KeychainLookupIterator(l.iterator())
+    }
+
+    @Override
+    Object[] toArray() {
+        return toArray(new Object[0])
+    }
+
+    @Override
+    <T> T[] toArray(T[] a) {
+        Objects.requireNonNull(a)
+
+        def l = innerLookUpList() ?: new ArrayList<File>()
+
+        if (a.length < l.size()) {
+            return (T[]) Arrays.copyOf(l.toArray(), l.size(), a.getClass())
+        }
+
+        System.arraycopy(l.toArray(), 0, a, 0, l.size())
+        if (a.size() > l.size()) {
+            a[l.size()] = null
+        }
+
+        return a
+    }
+
+    @Override
+    boolean add(File keychain) {
+        SecurityUtil.addKeychain(keychain)
+    }
+
+    @Override
+    boolean remove(Object keychain) {
+        Objects.requireNonNull(keychain)
+
+        if (!File.isInstance(keychain)) {
+            throw new ClassCastException("expect object of type java.io.File")
+        }
+
+        File k = keychain as File
+
+        SecurityUtil.removeKeychain(k)
+        return !SecurityUtil.keychainIsAdded(k)
+    }
+
+    @Override
+    boolean containsAll(Collection<?> c) {
+        Objects.requireNonNull(c)
+
+        for (Object o : c) {
+            if (!File.isInstance(o)) {
+                throw new ClassCastException("expect object of type java.io.File")
+            }
+        }
+
+        return SecurityUtil.allKeychainsAdded(c as Collection<File>)
+    }
+
+    @Override
+    boolean addAll(Collection<? extends File> c) {
+        Objects.requireNonNull(c)
+
+        return SecurityUtil.addKeychains(c)
+    }
+
+    @Override
+    boolean addAll(int index, Collection<? extends File> c) {
+        throw new UnsupportedOperationException()
+    }
+
+    @Override
+    boolean removeAll(Collection<?> c) {
+        Objects.requireNonNull(c)
+        boolean modified = false
+        Iterator<?> it = iterator()
+        while (it.hasNext()) {
+            if (c.contains(it.next())) {
+
+                it.remove()
+                modified = true
+            }
+        }
+
+        return modified
+    }
+
+    @Override
+    boolean retainAll(Collection<?> c) {
+        throw new UnsupportedOperationException()
+    }
+
+    @Override
+    void clear() {
+        File keychainConfigFile = new File(System.getProperty("user.home"), "Library/Preferences/com.apple.security.plist")
+        keychainConfigFile.delete()
+    }
+
+    @Override
+    File get(int index) {
+        def l = innerLookUpList() ?: new ArrayList<File>()
+        l.get(index)
+    }
+
+    @Override
+    File set(int index, File element) {
+        throw new UnsupportedOperationException()
+    }
+
+    @Override
+    void add(int index, File element) {
+        throw new UnsupportedOperationException()
+    }
+
+    @Override
+    File remove(int index) {
+        throw new UnsupportedOperationException()
+    }
+
+    @Override
+    int indexOf(Object o) {
+        Objects.requireNonNull(o)
+
+        if (!File.isInstance(o)) {
+            throw new ClassCastException("expect object of type java.io.File")
+        }
+
+        File keychain = o as File
+        def l = innerLookUpList() ?: new ArrayList<File>()
+        l.indexOf(keychain)
+    }
+
+    @Override
+    int lastIndexOf(Object o) {
+        Objects.requireNonNull(o)
+
+        if (!File.isInstance(o)) {
+            throw new ClassCastException("expect object of type java.io.File")
+        }
+
+        File keychain = o as File
+        def l = innerLookUpList() ?: new ArrayList<File>()
+        l.lastIndexOf(keychain)
+    }
+
+    @Override
+    ListIterator<File> listIterator() {
+        listIterator(0)
+    }
+
+    @Override
+    ListIterator<File> listIterator(int index) {
+        def l = innerLookUpList() ?: new ArrayList<File>()
+        new KeychainLookupListIterator(l.listIterator(index))
+    }
+
+    //This implementation has not the desired effect for now.
+    @Override
+    List<File> subList(int fromIndex, int toIndex) {
+        def l = innerLookUpList() ?: new ArrayList<File>()
+        l.subList(fromIndex, toIndex)
+    }
+
+    private static List<File> innerLookUpList() {
+        List<File> lookupList
+        File keychainConfigFile = new File(System.getProperty("user.home"), "Library/Preferences/com.apple.security.plist")
+        if (keychainConfigFile.exists()) {
+            def config = Plist.load(keychainConfigFile)
+            if (config[DLDBSearchList]) {
+                lookupList = (config[DLDBSearchList] as List<Object>).collect { new File(it[DbName] as String) }
+            }
+        }
+        lookupList
+    }
+}

--- a/src/main/groovy/wooga/gradle/build/unity/ios/internal/utils/SecurityUtil.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/internal/utils/SecurityUtil.groovy
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.build.unity.ios.internal.utils
+
+import org.w3c.dom.Document
+import org.xml.sax.InputSource
+import xmlwise.Plist
+
+import javax.xml.parsers.DocumentBuilderFactory
+import javax.xml.transform.OutputKeys
+import javax.xml.transform.Transformer
+import javax.xml.transform.TransformerFactory
+import javax.xml.transform.dom.DOMSource
+import javax.xml.transform.stream.StreamResult
+import javax.xml.xpath.XPath
+import javax.xml.xpath.XPathConstants
+import javax.xml.xpath.XPathFactory
+import java.nio.file.Path
+
+class SecurityUtil {
+
+    private static File keychainConfigFile = new File(System.getProperty("user.home"), "Library/Preferences/com.apple.security.plist")
+
+    private static String DLDBSearchList = 'DLDBSearchList'
+    private static String DbName = 'DbName'
+    private static String GUID = 'GUID'
+    private static String SubserviceType = 'SubserviceType'
+
+    static boolean keychainIsAdded(File keychain) {
+        findAllKeychains([keychain]).size() != 0
+    }
+
+    static boolean allKeychainsAdded(Iterable<File> keychains) {
+        findAllKeychains(keychains).size() != 0
+    }
+
+    static void removeKeychain(File keychain) {
+        removeKeychains([keychain])
+    }
+
+    static void removeKeychains(Iterable<File> keychains) {
+        def keychainConfig = keychainConfigFile
+
+        if (keychainConfig.exists()) {
+            def config = Plist.load(keychainConfig)
+            List<HashMap> dbSearchList = config[DLDBSearchList] as List<HashMap>
+            dbSearchList.removeAll(findAllKeychains(keychains))
+
+            if(dbSearchList.empty) {
+                keychainConfig.delete()
+            }
+            else {
+                keychainConfigFile.text = prettyXML(Plist.toPlist(config))
+            }
+        }
+
+        assert !allKeychainsAdded(keychains)
+    }
+
+    static void addKeychain(File keychain) {
+        addKeychains([keychain])
+    }
+
+    static void addKeychains(Iterable<File> keychains) {
+        if(keychains.size() == 0 || allKeychainsAdded(keychains)) {
+            return
+        }
+
+        def keychainConfig = keychainConfigFile
+        def config
+        if (keychainConfig.exists()) {
+            config = Plist.load(keychainConfig)
+        } else {
+            config = new HashMap<String, Object>()
+            config[DLDBSearchList] = new ArrayList<HashMap>()
+        }
+
+        keychains.each { keychain ->
+            if (!keychainIsAdded(keychain)) {
+                def item = new HashMap(3)
+                item[DbName] = keychain.path
+                item[GUID] = "{${UUID.randomUUID().toString()}}".toString()
+                item[SubserviceType] = 6
+
+                (config[DLDBSearchList] as List<HashMap>).add(item)
+            }
+        }
+
+        keychainConfigFile.text = prettyXML(Plist.toPlist(config))
+        assert allKeychainsAdded(keychains)
+    }
+
+    private static List<Object> findAllKeychains(Iterable<File> keychains) {
+        def keychainConfig = keychainConfigFile
+        def result = new ArrayList<>()
+        if (keychainConfig.exists()) {
+            def config = Plist.load(keychainConfig)
+            List<HashMap> dbSearchList = config[DLDBSearchList] as List<HashMap>
+            result = dbSearchList.findAll { db ->
+                File dbName = new File((String) db[DbName])
+
+                dbName = expandPath(dbName)
+                keychains.find { keychain ->
+                    keychain = expandPath(keychain)
+
+                    Path k = keychain.toPath()
+                    Path p = dbName.toPath()
+
+                    p = p.toAbsolutePath()
+                    k = k.toAbsolutePath()
+                    p.equals(k)
+                } != null
+            }
+        }
+        result
+    }
+
+    protected static String prettyXML(String xml) {
+
+        Document document = DocumentBuilderFactory.newInstance()
+                .newDocumentBuilder()
+                .parse(new InputSource(new ByteArrayInputStream(xml.getBytes("utf-8"))))
+
+        XPath xPath = XPathFactory.newInstance().newXPath();
+        org.w3c.dom.NodeList  nodeList = (org.w3c.dom.NodeList ) xPath.evaluate("//text()[normalize-space()='']",
+                document,
+                XPathConstants.NODESET)
+
+        for (int i = 0; i < nodeList.getLength(); ++i) {
+            org.w3c.dom.Node node = nodeList.item(i)
+            node.getParentNode().removeChild(node)
+        }
+
+        Transformer transformer = TransformerFactory.newInstance().newTransformer()
+        transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8")
+        transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes")
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes")
+        transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4")
+
+        StringWriter stringWriter = new StringWriter()
+        StreamResult streamResult = new StreamResult(stringWriter)
+
+        transformer.transform(new DOMSource(document), streamResult)
+
+        stringWriter.toString()
+
+    }
+
+    protected static String expandPath(String path) {
+        if (path.startsWith("~" + File.separator)) {
+            path = System.getProperty("user.home") + path.substring(1)
+        }
+        path
+    }
+
+    protected static File expandPath(File path) {
+        new File(expandPath(path.path))
+    }
+}

--- a/src/main/groovy/wooga/gradle/build/unity/ios/tasks/KeychainTask.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/tasks/KeychainTask.groovy
@@ -142,15 +142,15 @@ class KeychainTask extends ConventionTask {
         }
 
         List<String> commands = new ArrayList()
-        commands << "create-keychain -p ${getPassword()} ${getTempKeychainPath()}"
-        commands << "unlock-keychain -p ${getPassword()} ${getTempKeychainPath()}"
+        commands << "create-keychain -p '${getPassword()}' ${getTempKeychainPath()}"
+        commands << "unlock-keychain -p '${getPassword()}' ${getTempKeychainPath()}"
         commands << "set-keychain-settings ${getTempKeychainPath()}"
 
         certificates.files.each { File file ->
             def keychain = getTempKeychainPath()
             def password = getCertificatePassword()
             commands << ""
-            commands << "import $file -k $keychain -P $password -f pkcs12 -t cert -T /usr/bin/codesign"
+            commands << "import $file -k $keychain -P '$password' -f pkcs12 -t cert -T /usr/bin/codesign"
             commands << ""
         }
 

--- a/src/main/groovy/wooga/gradle/build/unity/ios/tasks/ListKeychainTask.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/tasks/ListKeychainTask.groovy
@@ -24,6 +24,7 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.TaskAction
 import org.gradle.util.GUtil
+import wooga.gradle.build.unity.ios.internal.utils.SecurityUtil
 
 class ListKeychainTask extends DefaultTask {
 
@@ -33,7 +34,6 @@ class ListKeychainTask extends DefaultTask {
     }
 
     private Action action
-    private List<String> activeKeychains
     private List<Object> keychains = new ArrayList<Object>()
 
     @Input
@@ -80,46 +80,19 @@ class ListKeychainTask extends DefaultTask {
         outputs.upToDateWhen(new Spec<ListKeychainTask>() {
             @Override
             boolean isSatisfiedBy(ListKeychainTask element) {
-                def activeKeychains = element.getActiveKeychains()
-                def contains = activeKeychains.containsAll(getKeychains().getFiles().collect { it.path })
-                return contains == (getAction() == Action.add)
+                return SecurityUtil.allKeychainsAdded(getKeychains().getFiles()) == (getAction() == Action.add)
             }
         })
     }
 
-    protected List<String> getActiveKeychains() {
-        if (!activeKeychains) {
-            def listOutput = new ByteArrayOutputStream()
-            project.exec {
-                executable "security"
-                args "list-keychains"
-                args "-d", "user"
-                standardOutput = listOutput
-            }
-            activeKeychains = listOutput.toString().readLines().collect { it.replace('"', '').trim() }
-        }
-        activeKeychains
-    }
-
     @TaskAction
     protected list() {
-        def activeKeychains = getActiveKeychains().clone()
-        def keychains = getKeychains().files.collect { it.path }
+        def keychains = getKeychains().files
 
         if (getAction() == Action.add) {
-            activeKeychains.addAll(keychains)
+            SecurityUtil.addKeychains(keychains)
         } else {
-            activeKeychains.removeAll(keychains)
-        }
-
-        project.exec {
-            executable "security"
-            args "list-keychains"
-            args "-d", "user"
-            args "-s"
-            activeKeychains.unique().each {
-                args it
-            }
+            SecurityUtil.removeKeychains(keychains)
         }
     }
 }

--- a/src/main/groovy/wooga/gradle/build/unity/ios/tasks/ListKeychainTask.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/tasks/ListKeychainTask.groovy
@@ -24,7 +24,7 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.TaskAction
 import org.gradle.util.GUtil
-import wooga.gradle.build.unity.ios.internal.utils.SecurityUtil
+import wooga.gradle.build.unity.ios.KeychainLookupList
 
 class ListKeychainTask extends DefaultTask {
 
@@ -35,6 +35,7 @@ class ListKeychainTask extends DefaultTask {
 
     private Action action
     private List<Object> keychains = new ArrayList<Object>()
+    protected KeychainLookupList lookupList = new KeychainLookupList()
 
     @Input
     Action getAction() {
@@ -80,7 +81,7 @@ class ListKeychainTask extends DefaultTask {
         outputs.upToDateWhen(new Spec<ListKeychainTask>() {
             @Override
             boolean isSatisfiedBy(ListKeychainTask element) {
-                return SecurityUtil.allKeychainsAdded(getKeychains().getFiles()) == (getAction() == Action.add)
+                lookupList.containsAll(getKeychains().files) == (getAction() == Action.add)
             }
         })
     }
@@ -90,9 +91,9 @@ class ListKeychainTask extends DefaultTask {
         def keychains = getKeychains().files
 
         if (getAction() == Action.add) {
-            SecurityUtil.addKeychains(keychains)
+            lookupList.addAll(keychains)
         } else {
-            SecurityUtil.removeKeychains(keychains)
+            lookupList.removeAll(keychains)
         }
     }
 }

--- a/src/main/groovy/wooga/gradle/build/unity/ios/tasks/XCodeExportTask.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/tasks/XCodeExportTask.groovy
@@ -33,7 +33,7 @@ class XCodeExportTask extends DefaultTask {
         new AbstractPublishArtifact(this) {
             @Override
             String getName() {
-                return null
+                return getFile().getName()
             }
 
             @Override

--- a/src/test/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginActivationSpec.groovy
+++ b/src/test/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginActivationSpec.groovy
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.build.unity.ios
+
+import nebula.test.PluginProjectSpec
+
+class IOSBuildPluginActivationSpec extends PluginProjectSpec {
+    @Override
+    String getPluginName() {
+        return 'net.wooga.build-unity-ios'
+    }
+}

--- a/src/test/groovy/wooga/gradle/build/unity/ios/KeychainLookupListSpec.groovy
+++ b/src/test/groovy/wooga/gradle/build/unity/ios/KeychainLookupListSpec.groovy
@@ -1,0 +1,600 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.build.unity.ios
+
+import org.junit.ClassRule
+import org.junit.contrib.java.lang.system.ProvideSystemProperty
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+import spock.util.environment.RestoreSystemProperties
+import wooga.gradle.build.unity.ios.internal.utils.SecurityUtil
+
+@RestoreSystemProperties
+class KeychainLookupListSpec extends Specification {
+
+    @Shared
+    File newHome = File.createTempDir("user", "home")
+
+    @Shared
+    @ClassRule
+    public ProvideSystemProperty myPropertyHasMyValue = new ProvideSystemProperty("user.home", newHome.path)
+
+    @Shared
+    KeychainLookupList subject = new KeychainLookupList()
+
+
+    def setup() {
+        SecurityUtil.getKeychainConfigFile().parentFile.mkdirs()
+        SecurityUtil.getKeychainConfigFile().delete()
+    }
+
+    def cleanup() {
+        SecurityUtil.getKeychainConfigFile().delete()
+    }
+
+    def "if keychain config doesn't exist it will be created"() {
+        given: "non existing keychain config file"
+        assert !SecurityUtil.getKeychainConfigFile().exists()
+
+        when:
+        subject.add(new File("path/to//test.keychain"))
+
+        then:
+        SecurityUtil.getKeychainConfigFile().exists()
+    }
+
+    def "empty list has size 0"() {
+        given: "a empty lookup list"
+
+        expect:
+        subject.size() == 0
+        subject.isEmpty()
+    }
+
+    def "populated list has size != 0"() {
+        given: "a populated list"
+        subject.add(new File("path/to/test.keychain"))
+        subject.add(new File("path/to/test2.keychain"))
+
+        expect:
+        subject.size() != 0
+        !subject.isEmpty()
+    }
+
+    def "adds a single keychain to the lookup list"() {
+        given: "a empty lookup list"
+        assert subject.size() == 0
+
+        when:
+        def result = subject.add(new File("path/to/test.keychain"))
+
+        then:
+        result
+        subject.size() == 1
+        subject.contains(new File("path/to/test.keychain"))
+
+        when:
+        result = subject.add(new File("path/to/test2.keychain"))
+
+        then:
+        result
+        subject.size() == 2
+        subject.contains(new File("path/to/test2.keychain"))
+        subject.contains(new File("path/to/test.keychain"))
+    }
+
+    def "adds multiple keychains to the lookup list"() {
+        given: "a empty lookup list"
+        assert subject.size() == 0
+
+        when:
+        def result = subject.addAll([new File("path/to/test.keychain"), new File("path/to/test2.keychain")])
+
+        then:
+        result
+        subject.size() == 2
+        subject.contains(new File("path/to/test.keychain"))
+        subject.contains(new File("path/to/test2.keychain"))
+
+        when:
+        result = subject.addAll([new File("path/to/test3.keychain"), new File("path/to/test4.keychain")])
+
+        then:
+        result
+        subject.size() == 4
+        subject.contains(new File("path/to/test.keychain"))
+        subject.contains(new File("path/to/test2.keychain"))
+        subject.contains(new File("path/to/test3.keychain"))
+        subject.contains(new File("path/to/test4.keychain"))
+    }
+
+    @Unroll
+    def "doesn't add duplicate entries when #message"() {
+        given: "lookup list with one entry"
+        subject.add(new File("~/path/to/test.keychain"))
+        assert subject.size() == 1
+
+        when:
+        def result = subject.add(new File(fileToAdd))
+
+        then:
+        !result
+        subject.size() == 1
+
+        where:
+        fileToAdd                                       | message
+        "~/path/to/test.keychain"                       | "path is equal"
+        "~/path/../path/to/test.keychain"               | "resolved path is equal"
+        "${newHome.path}/path/../path/to/test.keychain" | "expanded ~/ path is equal"
+    }
+
+    @Unroll
+    def "#method throws #error when #message"() {
+        when:
+        subject.invokeMethod(method, testObject)
+
+        then:
+        thrown(error)
+
+        where:
+        method        | testObject | error                     | message
+        "contains"    | null       | NullPointerException      | "object is null"
+        "indexOf"     | null       | NullPointerException      | "object is null"
+        "lastIndexOf" | null       | NullPointerException      | "object is null"
+        "contains"    | "test"     | ClassCastException        | "object is not a java.io.File"
+        "remove"      | "test"     | ClassCastException        | "object is not a java.io.File"
+        "indexOf"     | "test"     | ClassCastException        | "object is not a java.io.File"
+        "lastIndexOf" | "test"     | ClassCastException        | "object is not a java.io.File"
+        "add"         | "test"     | ClassCastException        | "object is not a java.io.File"
+        "get"         | 22         | IndexOutOfBoundsException | "index is out of bounds"
+    }
+
+    // need to unroll these cases by hand because `invokeMethod` calls them with:
+    // - non null default arguments
+    // or
+    // - doesn't know which overload to call
+
+    def "retainAll throws UnsupportedOperationException"() {
+        when:
+        subject.retainAll(null)
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+
+    def "set(int,File) throws UnsupportedOperationException"() {
+        when:
+        subject.set(0, new File('some/file'))
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+
+    def "add(int,File) throws UnsupportedOperationException"() {
+        when:
+        subject.add(0, new File('some/file'))
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+
+    def "remove(int) throws UnsupportedOperationException"() {
+        when:
+        subject.remove(0)
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+
+    def "addAll(int, Collection<? extends File>) throws UnsupportedOperationException"() {
+        when:
+        subject.addAll(0, [new File('some/file')])
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+
+
+    def "remove throws NullPointerException when object is null"() {
+        when:
+        subject.remove(null)
+
+        then:
+        thrown(NullPointerException)
+    }
+
+    def "add throws NullPointerException when object is null"() {
+        when:
+        subject.add(null)
+
+        then:
+        thrown(NullPointerException)
+    }
+
+    def "addAll throws NullPointerException when object is null"() {
+        when:
+        subject.addAll(null as Collection)
+
+        then:
+        thrown(NullPointerException)
+    }
+
+    def "addAll throws NullPointerException when one or more objects in list are null"() {
+        when:
+        subject.addAll([new File('some/file'), null])
+
+        then:
+        thrown(NullPointerException)
+    }
+
+    def "removeAll throws NullPointerException when object is null"() {
+        when:
+        subject.removeAll(null)
+
+        then:
+        thrown(NullPointerException)
+    }
+
+    def "containsAll throws NullPointerException when object is null"() {
+        when:
+        subject.containsAll(null)
+
+        then:
+        thrown(NullPointerException)
+    }
+
+    def "containsAll throws ClassCastException when one or more objects in list are not of type java.io.File"() {
+        when:
+        subject.containsAll([new File('some/file'), "a String"])
+
+        then:
+        thrown(ClassCastException)
+    }
+
+    def "toArray throws NullPointerException when object is null"() {
+        when:
+        subject.toArray(null)
+
+        then:
+        thrown(NullPointerException)
+    }
+
+    def "toArray throws ArrayStoreException when object is not a java.io.File[] array"() {
+        given: "lookup list with multiple entries"
+        subject.add(new File("~/path/to/test.keychain"))
+
+        when:
+        subject.toArray(new String[0])
+
+        then:
+        thrown(ArrayStoreException)
+    }
+
+    @Unroll
+    def "contains checks if resolved path are equal when #message"() {
+        given: "lookup list with one entry"
+        subject.add(new File("~/path/to/test.keychain"))
+        assert subject.size() == 1
+
+        expect:
+        subject.contains(new File(fileToCheck))
+
+        where:
+        fileToCheck                                     | message
+        "~/path/to/test.keychain"                       | "path is equal"
+        "~/path/../path/to/test.keychain"               | "resolved path is equal"
+        "${newHome.path}/path/../path/to/test.keychain" | "expanded ~/ path is equal"
+    }
+
+    @Unroll
+    def "containsAll checks if all keychains provided are in the list"() {
+        given: "lookup list with multiple entries"
+        subject.add(new File("~/path/to/test.keychain"))
+        subject.add(new File("~/path/to/test2.keychain"))
+        subject.add(new File("~/path/to/test3.keychain"))
+        assert subject.size() == 3
+
+        expect:
+        subject.containsAll(check) == expectedValue
+
+        where:
+        check                                                                       || expectedValue
+        [new File("~/path/to/test.keychain")]                                       || true
+        [new File("~/path/to/test.keychain"), new File("~/path/to/test2.keychain")] || true
+        [new File("~/path/to/test.keychain"), new File("~/path/to/test4.keychain")] || false
+        [new File("~/path/to/test4.keychain")]                                      || false
+    }
+
+    @Unroll
+    def "clear delete all items"() {
+        given: "lookup list with multiple entries"
+        subject.add(new File("~/path/to/test.keychain"))
+        subject.add(new File("~/path/to/test2.keychain"))
+        subject.add(new File("~/path/to/test3.keychain"))
+        assert subject.size() == 3
+
+        when:
+        subject.clear()
+
+        then:
+        subject.isEmpty()
+    }
+
+    @Unroll
+    def "removes items from the list when #message"() {
+        given: "lookup list with multiple entries"
+        subject.add(new File("~/path/to/test.keychain"))
+        subject.add(new File("~/path/to/test2.keychain"))
+        subject.add(new File("~/path/to/test3.keychain"))
+        assert subject.size() == 3
+
+        when:
+        def result = subject.remove(new File(fileToRemove))
+
+        then:
+        result
+        subject.size() == 2
+        !subject.contains(new File(fileToRemove))
+
+        where:
+        fileToRemove                                    | message
+        "~/path/to/test.keychain"                       | "path is equal"
+        "~/path/../path/to/test.keychain"               | "resolved path is equal"
+        "${newHome.path}/path/../path/to/test.keychain" | "expanded ~/ path is equal"
+    }
+
+    @Unroll
+    def "removes multiple items from the list"() {
+        given: "lookup list with multiple entries"
+        subject.add(new File("~/path/to/test.keychain"))
+        subject.add(new File("~/path/to/test2.keychain"))
+        subject.add(new File("~/path/to/test3.keychain"))
+        assert subject.size() == 3
+
+        when:
+        def result = subject.removeAll(filesToRemove)
+
+        then:
+        result == hasChanges
+        subject.size() == expectedSize
+        !subject.containsAll(filesToRemove)
+
+        where:
+        filesToRemove                                                               || expectedSize | hasChanges
+        [new File("~/path/to/test.keychain")]                                       || 2            | true
+        [new File("~/path/to/test.keychain"), new File("~/path/to/test2.keychain")] || 1            | true
+        [new File("~/path/to/test.keychain"), new File("~/path/to/test4.keychain")] || 2            | true
+        [new File("~/path/to/test4.keychain")]                                      || 3            | false
+    }
+
+    @Unroll
+    def "creates #type over items"() {
+        given: "lookup list with multiple entries"
+        subject.add(new File("~/path/to/test.keychain"))
+        subject.add(new File("~/path/to/test2.keychain"))
+        subject.add(new File("~/path/to/test3.keychain"))
+        assert subject.size() == 3
+
+        and: "a check counter"
+        def checkList = []
+
+        when:
+        def iter = subject.invokeMethod(method, null)
+        while (iter.hasNext()) {
+            checkList.add(iter.next())
+        }
+
+        then:
+        checkList.size() == subject.size()
+        subject.containsAll(checkList)
+
+        where:
+        type            | method
+        "iterator"      | "iterator"
+        "list iterator" | "listIterator"
+    }
+
+    @Unroll
+    def "list iterator can move in both directions"() {
+        given: "lookup list with multiple entries"
+        subject.add(new File("~/path/to/test.keychain"))
+        subject.add(new File("~/path/to/test2.keychain"))
+        subject.add(new File("~/path/to/test3.keychain"))
+        assert subject.size() == 3
+
+        and: "a check counter"
+        def checkList = []
+
+        when:
+        def iter = subject.listIterator(3)
+        while (iter.hasPrevious()) {
+            iter.previousIndex()
+            checkList.add(iter.previous())
+        }
+
+        then:
+        checkList.size() == subject.size()
+        subject.containsAll(checkList)
+
+        when:
+        checkList.clear()
+        iter = subject.listIterator(0)
+        while (iter.hasNext()) {
+            iter.nextIndex()
+            checkList.add(iter.next())
+        }
+
+        then:
+        checkList.size() == subject.size()
+        subject.containsAll(checkList)
+    }
+
+    def "list iterator doesn't support set(File)"() {
+        given: "lookup list with multiple entries"
+        subject.add(new File("~/path/to/test.keychain"))
+        subject.add(new File("~/path/to/test2.keychain"))
+        subject.add(new File("~/path/to/test3.keychain"))
+        assert subject.size() == 3
+
+        when:
+        def iter = subject.listIterator()
+        iter.next()
+        iter.set(new File("some/file"))
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+
+    def "list iterator doesn't support add(File)"() {
+        given: "lookup list with multiple entries"
+        subject.add(new File("~/path/to/test.keychain"))
+        subject.add(new File("~/path/to/test2.keychain"))
+        subject.add(new File("~/path/to/test3.keychain"))
+        assert subject.size() == 3
+
+        when:
+        def iter = subject.listIterator()
+        iter.next()
+        iter.add(new File("some/file"))
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+
+    @Unroll
+    def "#type can modify lookup list"() {
+        given: "lookup list with multiple entries"
+        subject.add(new File("~/path/to/test.keychain"))
+        subject.add(new File("~/path/to/test2.keychain"))
+        subject.add(new File("~/path/to/test3.keychain"))
+        assert subject.size() == 3
+
+        when:
+        def iter = subject.invokeMethod(method, null)
+        while (iter.hasNext()) {
+            if (iter.next() == new File("~/path/to/test2.keychain")) {
+                iter.remove()
+            }
+        }
+
+        then:
+        subject.size() == 2
+        !subject.contains(new File("~/path/to/test2.keychain"))
+
+        where:
+        type            | method
+        "iterator"      | "iterator"
+        "list iterator" | "listIterator"
+    }
+
+    def "creates Object[] array copy of items"() {
+        given: "lookup list with multiple entries"
+        subject.add(new File("~/path/to/test.keychain"))
+        subject.add(new File("~/path/to/test2.keychain"))
+        subject.add(new File("~/path/to/test3.keychain"))
+        assert subject.size() == 3
+
+        when:
+        def arr = subject.toArray()
+
+        then:
+        arr.length == subject.size()
+        subject.containsAll(arr)
+
+        when:
+        arr = subject.toArray()
+        subject.remove(new File("~/path/to/test2.keychain"))
+
+        then:
+        arr.length != subject.size()
+        !subject.containsAll(arr)
+    }
+
+    @Unroll
+    def "creates File[] array copy of items with #testArr"() {
+        given: "lookup list with multiple entries"
+        subject.add(new File("~/path/to/test.keychain"))
+        subject.add(new File("~/path/to/test2.keychain"))
+        subject.add(new File("~/path/to/test3.keychain"))
+        assert subject.size() == 3
+
+        and:
+        def expectSameSize = testArr.length <= subject.size()
+
+        when:
+        def arr = subject.toArray(testArr)
+
+        then:
+        (arr.length == subject.size()) == expectSameSize
+        subject.containsAll(arr.findAll {it != null})
+
+        when:
+        arr = subject.toArray()
+        subject.remove(new File("~/path/to/test2.keychain"))
+
+        then:
+        arr.length != subject.size()
+        !subject.containsAll(arr.findAll {it != null})
+
+        where:
+        testArr << [new File[0], new File[3], new File[5]]
+    }
+
+    def "retrieves item by index"() {
+        given: "lookup list with multiple entries"
+        subject.add(new File("~/path/to/test.keychain"))
+        subject.add(new File("~/path/to/test2.keychain"))
+        subject.add(new File("~/path/to/test3.keychain"))
+        assert subject.size() == 3
+
+        expect:
+        subject[1] == new File("~/path/to/test2.keychain")
+    }
+
+    @Unroll
+    def "#method returns #message"() {
+        given: "lookup list with multiple entries"
+        subject.add(new File("~/path/to/test.keychain"))
+        subject.add(new File("~/path/to/test2.keychain"))
+        subject.add(new File("~/path/to/test3.keychain"))
+        assert subject.size() == 3
+
+        expect:
+        subject.invokeMethod(method, item) == expectedIndex
+
+        where:
+        method        | item                                 | message                               || expectedIndex
+        "indexOf"     | new File("~/path/to/test2.keychain") | "index when item is contained in list" | 1
+        "indexOf"     | new File("~/path/to/test4.keychain") | "-1 when item can not be found"        | -1
+        "lastIndexOf" | new File("~/path/to/test2.keychain") | "index when item is contained in list" | 1
+        "lastIndexOf" | new File("~/path/to/test4.keychain") | "-1 when item can not be found"        | -1
+    }
+
+    def "creates a faulty sublist"() {
+        given: "lookup list with multiple entries"
+        subject.add(new File("~/path/to/test.keychain"))
+        subject.add(new File("~/path/to/test2.keychain"))
+        subject.add(new File("~/path/to/test3.keychain"))
+        assert subject.size() == 3
+
+        expect:
+        subject.subList(1,2).size() == 1
+    }
+
+}


### PR DESCRIPTION
## Description

The custom build keychain was only removed from the keychain lockup list when the build succeeded. This patch changes the internal task setup to ensure that the task `:removeKeychain` runs always when executing the whole pipeline (`:assemble`)

## Changes

![FIX] ensure `:removeKeychain` gets executed even if build fails
![ADD] test specs for keychain behavior
![FIX] keychain creation commands by wrapping password values in `'`

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
