### PR TITLE
Refactor iOS task input outputs

### DIFF
--- a/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPlugin.groovy
@@ -57,9 +57,7 @@ class IOSBuildPlugin implements Plugin<Project> {
                 def conventionMapping = task.getConventionMapping()
                 conventionMapping.map("version", { project.version })
                 conventionMapping.map("clean", { false })
-                conventionMapping.map("destinationDir", {
-                    project.file("${project.buildDir}/outputs/archives")
-                })
+                conventionMapping.map("destinationDir", { task.temporaryDir })
                 conventionMapping.map("baseName", { project.name })
                 conventionMapping.map("extension", { "xcarchive" })
                 conventionMapping.map("scheme", { extension.getScheme() })

--- a/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPlugin.groovy
@@ -176,8 +176,7 @@ class IOSBuildPlugin implements Plugin<Project> {
 
         def xcodeExport = tasks.create(maybeBaseName(baseName, "xcodeExport"), XCodeExportTask) {
             it.exportOptionsPlist project.file("exportOptions.plist")
-            it.archivePath xcodeArchive
-            it.exportPath project.file("${project.buildDir}/exports")
+            it.xcarchivePath xcodeArchive
         }
 
         removeKeychain.mustRunAfter([xcodeArchive, xcodeExport])
@@ -189,7 +188,7 @@ class IOSBuildPlugin implements Plugin<Project> {
         }
 
         project.artifacts {
-            archives(xcodeExport.artifact)
+            archives(xcodeExport)
             archives(archiveDSYM)
         }
 

--- a/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPlugin.groovy
@@ -81,6 +81,19 @@ class IOSBuildPlugin implements Plugin<Project> {
             }
         })
 
+        project.tasks.withType(XCodeExportTask.class, new Action<XCodeExportTask>() {
+            @Override
+            void execute(XCodeExportTask task) {
+                def conventionMapping = task.getConventionMapping()
+                conventionMapping.map("version", { project.version })
+                conventionMapping.map("destinationDir", {
+                    project.file("${project.buildDir}/outputs")
+                })
+                conventionMapping.map("baseName", { project.name })
+                conventionMapping.map("extension", { "ipa" })
+            }
+        })
+
         project.tasks.withType(KeychainTask.class, new Action<KeychainTask>() {
             @Override
             void execute(KeychainTask task) {

--- a/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPlugin.groovy
@@ -80,7 +80,6 @@ class IOSBuildPlugin implements Plugin<Project> {
                 conventionMapping.map("extension", { "zip" })
             }
         })
-        //it.destinationDir = project.file("${project.buildDir}/outputs")
 
         project.tasks.withType(KeychainTask.class, new Action<KeychainTask>() {
             @Override
@@ -104,6 +103,8 @@ class IOSBuildPlugin implements Plugin<Project> {
                 conventionMapping.map("password", { extension.fastlaneCredentials.password })
                 conventionMapping.map("teamId", { extension.getTeamId() })
                 conventionMapping.map("appIdentifier", { extension.getAppIdentifier() })
+                conventionMapping.map("destinationDir", { task.getTemporaryDir() })
+                conventionMapping.map("profileName", { 'signing.mobileprovision' })
             }
         })
 
@@ -161,7 +162,7 @@ class IOSBuildPlugin implements Plugin<Project> {
         def importProvisioningProfiles = tasks.create(maybeBaseName(baseName, "importProvisioningProfiles"), ImportProvisioningProfile) {
             it.dependsOn addKeychain, unlockKeychain
             it.finalizedBy removeKeychain, lockKeychain
-            it.mobileProvisioningProfile = project.file("${maybeBaseName(baseName, 'ci')}.mobileprovision")
+            it.profileName = "${maybeBaseName(baseName, 'signing')}.mobileprovision"
         }
 
         def xcodeArchive = tasks.create(maybeBaseName(baseName, "xcodeArchive"), XCodeArchiveTask) {

--- a/src/main/groovy/wooga/gradle/build/unity/ios/tasks/KeychainTask.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/tasks/KeychainTask.groovy
@@ -115,9 +115,13 @@ class KeychainTask extends ConventionTask {
         this
     }
 
-    @OutputFile
+    @OutputFiles
+    protected FileCollection getOutputFiles() {
+        project.fileTree(getDestinationDir()) {it.include(getKeychainName())}
+    }
+
     File getOutputPath() {
-        new File(getDestinationDir(), getKeychainName())
+        getOutputFiles().singleFile
     }
 
     @Internal

--- a/src/main/groovy/wooga/gradle/build/unity/ios/tasks/LockKeychainTask.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/tasks/LockKeychainTask.groovy
@@ -77,7 +77,6 @@ class LockKeychainTask extends DefaultTask {
         project.files(keychain)
     }
 
-    @InputFile
     File getKeychain() {
         project.files(keychain).getSingleFile()
     }

--- a/src/main/groovy/wooga/gradle/build/unity/ios/tasks/XCodeArchiveTask.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/tasks/XCodeArchiveTask.groovy
@@ -51,7 +51,7 @@ class XCodeArchiveTask extends ConventionTask {
     @Optional
     @InputFiles
     protected FileCollection getInputFiles() {
-        def files = [projectPath, buildKeychain, provisioningProfile].findAll {it != null}
+        def files = [projectPath, buildKeychain, provisioningProfile].findAll { it != null }
         project.files(*files.toArray())
     }
 
@@ -61,7 +61,7 @@ class XCodeArchiveTask extends ConventionTask {
         def s = new HashSet<XCAction>()
         s << XCAction.archive
 
-        if(getClean()) {
+        if (getClean()) {
             s << XCAction.clean
         }
         s
@@ -84,7 +84,12 @@ class XCodeArchiveTask extends ConventionTask {
     @Optional
     @InputFile
     File getBuildKeychain() {
-        project.files(buildKeychain).getSingleFile()
+        def files = project.files(buildKeychain)
+        def fileList = files.files
+        if (fileList) {
+            return files.getSingleFile()
+        }
+        null
     }
 
     void setBuildKeychain(Object keyChain) {
@@ -98,7 +103,12 @@ class XCodeArchiveTask extends ConventionTask {
     @Optional
     @InputFile
     File getProvisioningProfile() {
-        project.files(provisioningProfile).getSingleFile()
+        def files = project.files(provisioningProfile)
+        def fileList = files.files
+        if (fileList) {
+            return files.getSingleFile()
+        }
+        null
     }
 
     void setProvisioningProfile(Object profile) {
@@ -273,25 +283,25 @@ class XCodeArchiveTask extends ConventionTask {
             arguments << it.toString()
         }
 
-        if(getProjectPath()) {
+        if (getProjectPath()) {
             arguments << "-project" << getProjectPath().getPath()
         }
 
-        if(getScheme()) {
+        if (getScheme()) {
             arguments << "-scheme" << getScheme()
         }
 
-        if(getConfiguration()) {
+        if (getConfiguration()) {
             arguments << "-configuration" << getConfiguration()
         }
 
-        if(getBuildKeychain()) {
+        if (getBuildKeychain()) {
             arguments << "OTHER_CODE_SIGN_FLAGS=--keychain ${getBuildKeychain()}"
         }
 
         arguments << "-archivePath" << getArchivePath().getPath()
 
-        def derivedDataPath = new File(project.buildDir,"derivedData")
+        def derivedDataPath = new File(project.buildDir, "derivedData")
         derivedDataPath.mkdirs()
 
         arguments << "-derivedDataPath" << derivedDataPath.getPath()

--- a/src/main/groovy/wooga/gradle/build/unity/ios/tasks/XCodeArchiveTask.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/tasks/XCodeArchiveTask.groovy
@@ -310,10 +310,5 @@ class XCodeArchiveTask extends ConventionTask {
             executable "/usr/bin/xcrun"
             args = arguments
         }
-
-        project.copy {
-            from getArchivePath()
-            into project.file("${project.buildDir}/intermediate/${getArchiveName()}")
-        }
     }
 }

--- a/src/main/groovy/wooga/gradle/build/unity/ios/tasks/XCodeArchiveTask.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/tasks/XCodeArchiveTask.groovy
@@ -257,7 +257,7 @@ class XCodeArchiveTask extends ConventionTask {
 
     @OutputDirectory
     File getArchivePath() {
-        return new File(getDestinationDir(), getArchiveName())
+        new File(getDestinationDir(), getArchiveName())
     }
 
     @Internal("Represented as part of archivePath")

--- a/src/main/groovy/wooga/gradle/build/unity/ios/tasks/XCodeExportTask.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/tasks/XCodeExportTask.groovy
@@ -17,59 +17,25 @@
 
 package wooga.gradle.build.unity.ios.tasks
 
-import org.apache.commons.io.FilenameUtils
-import org.gradle.api.DefaultTask
-import org.gradle.api.artifacts.PublishArtifact
+import org.gradle.api.Project
 import org.gradle.api.file.FileCollection
-import org.gradle.api.internal.artifacts.publish.AbstractPublishArtifact
+import org.gradle.api.internal.file.copy.CopyAction
+import org.gradle.api.internal.file.copy.CopyActionProcessingStream
 import org.gradle.api.tasks.*
+import org.gradle.api.tasks.bundling.AbstractArchiveTask
+import org.gradle.workers.internal.DefaultWorkResult
 
-class XCodeExportTask extends DefaultTask {
-    private Object archivePath
-    private Object exportPath
-    private Object exportOptionsPlist
+class XCodeExportTask extends AbstractArchiveTask {
 
-    PublishArtifact getArtifact() {
-        new AbstractPublishArtifact(this) {
-            @Override
-            String getName() {
-                return getFile().getName()
-            }
-
-            @Override
-            String getExtension() {
-                return "ipa"
-            }
-
-            @Override
-            String getType() {
-                return "iOS application archive"
-            }
-
-            @Override
-            String getClassifier() {
-                return null
-            }
-
-            @Override
-            File getFile() {
-                return project.fileTree("${project.buildDir}/outputs"){ it.include "*.ipa"}.singleFile
-            }
-
-            @Override
-            Date getDate() {
-                return null
-            }
-        }
-    }
+    private Object exportOptionsPlist;
+    private Object xcarchivePath;
 
     @SkipWhenEmpty
     @InputFiles
     protected FileCollection getInputFiles() {
-        project.files(this.archivePath, this.exportOptionsPlist)
+        project.files(xcarchivePath, exportOptionsPlist)
     }
 
-    @InputFile
     File getExportOptionsPlist() {
         project.files(exportOptionsPlist).getSingleFile()
     }
@@ -82,34 +48,44 @@ class XCodeExportTask extends DefaultTask {
         setExportOptionsPlist(path)
     }
 
-    @InputDirectory
-    File getArchivePath() {
-        project.files(archivePath).getSingleFile()
+    File getXcarchivePath() {
+        project.files(xcarchivePath).getSingleFile()
     }
 
-    void setArchivePath(Object path) {
-        archivePath = path
+    void setXcarchivePath(Object path) {
+        xcarchivePath = path
     }
 
-    XCodeExportTask archivePath(Object path) {
-        setArchivePath(path)
+    XCodeExportTask xcarchivePath(Object path) {
+        setXcarchivePath(path)
     }
 
-    @OutputDirectory
-    File getExportPath() {
-        project.file(exportPath)
+    @Override
+    protected CopyAction createCopyAction() {
+        def outputPath = new File(this.getDestinationDir(), this.getArchiveName())
+        new XCodeExportAction(getTemporaryDir(), outputPath, getExportOptionsPlist(), getXcarchivePath(), project)
+    }
+}
+
+class XCodeExportAction implements CopyAction {
+
+    File exportPath
+    File exportOptionsPlist
+    File archivePath
+    File outputPath
+    Project project
+
+    XCodeExportAction(File exportPath, File outputPath, File exportOptionsPlist, File archivePath, Project project) {
+        this.exportPath = exportPath
+        this.outputPath = outputPath
+        this.exportOptionsPlist = exportOptionsPlist
+        this.archivePath = archivePath
+        this.project = project
     }
 
-    void setExportPath(Object path) {
-        exportPath = path
-    }
+    @Override
+    WorkResult execute(CopyActionProcessingStream copyActionProcessingStream) {
 
-    XCodeExportTask exportPath(Object path) {
-        setExportPath(path)
-    }
-
-    @TaskAction
-    protected void export() {
         List<String> arguments = new ArrayList<String>()
         arguments << "xcodebuild"
         arguments << "-exportArchive"
@@ -117,18 +93,26 @@ class XCodeExportTask extends DefaultTask {
         arguments << "-exportOptionsPlist" << getExportOptionsPlist().getPath()
         arguments << "-archivePath" << getArchivePath().getPath()
 
-        project.exec {
+        def result = project.exec {
             executable "/usr/bin/xcrun"
             args = arguments
+            ignoreExitValue = true
         }
 
-        project.copy {
-            from getExportPath()
-            include "*.ipa"
-            into project.file("$project.buildDir/outputs")
-            it.rename { filename ->
-                FilenameUtils.getBaseName(getArchivePath().getPath()) + '.ipa'
-            }
+        if (result.getExitValue() != 0) {
+            return new DefaultWorkResult(false, null)
         }
+
+//        project.copy {
+//            from getExportPath()
+//            include "*.ipa"
+//            into project.file("$project.buildDir/outputs")
+//            it.rename { filename ->
+//                FilenameUtils.getBaseName(getArchivePath().getPath()) + '.ipa'
+//            }
+//        }
+
+
+        return new DefaultWorkResult(true, null)
     }
 }

--- a/src/main/groovy/wooga/gradle/build/unity/ios/tasks/XCodeExportTask.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/tasks/XCodeExportTask.groovy
@@ -17,6 +17,7 @@
 
 package wooga.gradle.build.unity.ios.tasks
 
+import org.apache.commons.io.FilenameUtils
 import org.gradle.api.Project
 import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.file.copy.CopyAction
@@ -103,16 +104,13 @@ class XCodeExportAction implements CopyAction {
             return new DefaultWorkResult(false, null)
         }
 
-//        project.copy {
-//            from getExportPath()
-//            include "*.ipa"
-//            into project.file("$project.buildDir/outputs")
-//            it.rename { filename ->
-//                FilenameUtils.getBaseName(getArchivePath().getPath()) + '.ipa'
-//            }
-//        }
-
-
-        return new DefaultWorkResult(true, null)
+        project.copy {
+            from getExportPath()
+            include "*.ipa"
+            into outputPath.parent
+            it.rename { filename ->
+                FilenameUtils.getBaseName(getOutputPath().getPath()) + '.ipa'
+            }
+        }
     }
 }


### PR DESCRIPTION
## Description
Update the structure of the `build` directory after a gradle run.

```
build
├── archives
│  └── GradleUnityBuildTest-0.4.0.xcarchive
├── derivedData
│  └── ...
├── ipas
│  └── GradleUnityBuildTest-0.4.0.ipa
├── outputs
│  ├── GradleUnityBuildTest-0.4.0-dSYM.zip
│  └── GradleUnityBuildTest-0.4.0.ipa
├── sign
│  └── keychains
├── symbols
│  └── GradleUnityBuildTest-0.4.0-dSYM.zip
└── tmp
   └── ...
```

* archives contains all compiled `xcarchives` (not getting cleaned)
* ipas contains all exported `ipa` packages (not getting cleaned)
* symbols contains all zipped DSYM files (not getting cleaned)
* outputs contains the `ipa` and symbols of the last successful build

## Changes
* ![IMPROVE]![IOS] `build` directory structure
* ![FIX] multiple `ipa` packages in `outputs` directory

resolves #4 

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
