### PR TITLE
Pass loglevel from main gradle project to the sub projects

### DIFF
--- a/src/main/groovy/wooga/gradle/build/unity/tasks/GradleBuild.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/tasks/GradleBuild.groovy
@@ -18,6 +18,7 @@
 package wooga.gradle.build.unity.tasks
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.logging.LogLevel
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
@@ -74,6 +75,22 @@ class GradleBuild extends DefaultTask {
 
     @TaskAction
     protected exec() {
+        def args = []
+        args.addAll(getBuildArguments())
+
+        def startParameter = this.project.gradle.startParameter
+        switch (startParameter.logLevel) {
+            case LogLevel.DEBUG:
+                args << '--debug'
+                break
+            case LogLevel.INFO:
+                args << '--info'
+                break
+            case LogLevel.QUIET:
+                args << '--quiet'
+                break
+        }
+
         ProjectConnection connection = GradleConnector.newConnector()
                 .forProjectDirectory(getDir())
                 .connect()
@@ -81,7 +98,7 @@ class GradleBuild extends DefaultTask {
         try {
             connection.newBuild()
                     .forTasks(*getTasks().toArray(new String[0]))
-                    .withArguments(getBuildArguments())
+                    .withArguments(args)
                     .setColorOutput(false)
                     .setStandardOutput(System.out)
                     .setStandardError(System.out)


### PR DESCRIPTION
## Description

If you choose to build the whole unity project with `--info` loglevel than this log setting isn't passed down to the exported sub-projects. This patch adds this functionality by reading the log level from the
`StartParameter` object and setting the matching commandline switches. 

The only supported levels are:

* debug
* info
* quiet

## Changes

![FIX] log-level settings passed to exported sub projects

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
