### PR TITLE
Fix up-to-date check for task :buildKeychain

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/build/unity/ios/tasks/KeychainTaskSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/unity/ios/tasks/KeychainTaskSpec.groovy
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.build.unity.ios.tasks
+
+import spock.lang.Requires
+import spock.lang.Shared
+import wooga.gradle.build.IntegrationSpec
+import wooga.gradle.build.unity.ios.IOSBuildPlugin
+import wooga.gradle.build.unity.ios.KeychainLookupList
+import wooga.gradle.build.unity.ios.internal.utils.SecurityUtil
+
+@Requires({ os.macOs })
+class KeychainTaskSpec extends IntegrationSpec {
+    @Shared
+    File xcProject
+
+    @Shared
+    File xcProjectConfig
+
+    @Shared
+    File buildKeychain
+
+    @Shared
+    KeychainLookupList keychainLookupList = new KeychainLookupList()
+    static String certPassword = "test password"
+
+    //TODO: remove duplicate code
+    def createTestCertificate(File cert, String password) {
+        def certInfo = new File(projectDir, "certInfo")
+        certInfo << """
+        DE
+        Germany
+        Berlin
+        Wooga GmbH
+        Gradle tests
+        Test CA certificate
+        jenkins@wooga.net
+        .
+        .
+        """.stripIndent().trim()
+
+        def createScript = new File(projectDir, "certCreate.sh")
+        createScript << """
+        <${certInfo.path} openssl req -new -x509 -outform PEM -newkey rsa:2048 -nodes -keyout /tmp/ca.key -keyform PEM -out /tmp/ca.crt -days 365
+        echo "${password}" | openssl pkcs12 -export -in /tmp/ca.crt -inkey /tmp/ca.key -out ${cert.path} -name \"Test CA\" -passout stdin
+        """.stripIndent()
+
+        new ProcessBuilder("sh", createScript.path).start().waitFor()
+        createScript.delete()
+        certInfo.delete()
+    }
+
+    def setup() {
+        SecurityUtil.getKeychainConfigFile().parentFile.mkdirs()
+        buildFile << """
+            ${applyPlugin(IOSBuildPlugin)}
+
+            iosBuild {
+                certificatePassphrase = "$certPassword"
+                keychainPassword = "$certPassword"
+            }
+        """.stripIndent()
+
+        xcProject = new File(projectDir, "test.xcodeproj")
+        xcProject.mkdirs()
+        xcProjectConfig = new File(xcProject, "project.pbxproj")
+        xcProjectConfig << ""
+
+        buildKeychain = new File(projectDir, 'build/sign/keychains/build.keychain')
+
+        createTestCertificate(new File(projectDir, "test_ca.p12"), certPassword)
+
+    }
+
+    def "buildKeychain caches task outputs"() {
+        given: "a gradle run with buildKeychain"
+        runTasksSuccessfully('buildKeychain')
+
+        when:
+        def result = runTasksSuccessfully('buildKeychain')
+
+        then:
+        result.wasUpToDate('buildKeychain')
+    }
+}

--- a/src/main/groovy/wooga/gradle/build/unity/ios/tasks/ImportProvisioningProfile.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/tasks/ImportProvisioningProfile.groovy
@@ -140,7 +140,7 @@ class ImportProvisioningProfile extends ConventionTask {
 
     @OutputFiles
     protected FileCollection getOutputFiles() {
-        project.fileTree(getDestinationDir()) { it.include getProfileName()}
+        project.files(new File(getDestinationDir(), getProfileName()))
     }
 
     ImportProvisioningProfile() {

--- a/src/main/groovy/wooga/gradle/build/unity/ios/tasks/KeychainTask.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/tasks/KeychainTask.groovy
@@ -117,9 +117,10 @@ class KeychainTask extends ConventionTask {
 
     @OutputFiles
     protected FileCollection getOutputFiles() {
-        project.fileTree(getDestinationDir()) {it.include(getKeychainName())}
+        project.files(new File(getDestinationDir(), getKeychainName()))
     }
 
+    @Internal
     File getOutputPath() {
         getOutputFiles().singleFile
     }


### PR DESCRIPTION
## Description

The `up-to-date` check for the `:buildKeychain` task always returned `false` because gradle believed the output file wasn't generated by gradle. I made a simple mistake in the `OutputFiles` definition for the task. I used a `FileTree` to create the `FileCollection` which yields a size `0` list when building a clean build. Next build would delete the output file because gradle never recorded it as a output file. So this pattern happens over and over again with each rebuild.

I switched from `project.fileTree` to `project.files` and pass in a `File` object. I can't remember why I used the fileTree in the first place. I also changed that for `:importProvisioningProfiles`. I added a testspec for the keychain task but not yet for the provisioning profiles one because of `fastlane`.

## Changes

![FIX] ![IOS] `up-to-date` check for task `:buildKeychain`

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
