### PR TITLE
Fix up-to-date check for export task when project version changes

### DIFF
--- a/src/main/groovy/wooga/gradle/build/unity/UnityBuildPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/UnityBuildPlugin.groovy
@@ -52,6 +52,7 @@ class UnityBuildPlugin implements Plugin<Project> {
             @Override
             void execute(UnityBuildPlayerTask task) {
                 def conventionMapping = task.getConventionMapping()
+                conventionMapping.map("version", {project.version})
                 conventionMapping.map("exportMethodName", {extension.getExportMethodName()})
                 conventionMapping.map("buildEnvironment", {extension.getDefaultEnvironment()})
                 conventionMapping.map("buildPlatform", {extension.getDefaultPlatform()})

--- a/src/main/groovy/wooga/gradle/build/unity/tasks/UnityBuildPlayerTask.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/tasks/UnityBuildPlayerTask.groovy
@@ -30,6 +30,8 @@ import wooga.gradle.unity.batchMode.BatchModeFlags
 import wooga.gradle.unity.batchMode.BuildTarget
 import wooga.gradle.unity.tasks.internal.AbstractUnityProjectTask
 
+import java.util.concurrent.Callable
+
 class UnityBuildPlayerTask extends AbstractUnityProjectTask {
 
     UnityBuildPlayerTask() {
@@ -148,6 +150,22 @@ class UnityBuildPlayerTask extends AbstractUnityProjectTask {
         setToolsVersion(version)
     }
 
+    private Object version
+
+    @Input
+    String getVersion() {
+        convertToString(version)
+    }
+
+    void setVersion(String value) {
+        version = value
+    }
+
+    UnityBuildPlayerTask version(String version) {
+        setVersion(version)
+        this
+    }
+
     @Override
     protected void exec() {
         File out = getOutputDirectory()
@@ -155,7 +173,7 @@ class UnityBuildPlayerTask extends AbstractUnityProjectTask {
         String customArgs = "-CustomArgs:platform=${getBuildPlatform()};"
         customArgs += "environment=${getBuildEnvironment()};"
         customArgs += "outputPath=${out.getPath()};"
-        customArgs += "version=${project.version};"
+        customArgs += "version=${getVersion()};"
 
         if(getToolsVersion()) {
             customArgs += "toolsVersion=${getToolsVersion()}"
@@ -168,5 +186,18 @@ class UnityBuildPlayerTask extends AbstractUnityProjectTask {
             args BatchModeFlags.BUILD_TARGET, getBuildPlatform()
         }
         super.exec()
+    }
+
+    //TODO: move duplicate code
+    private static String convertToString(Object value) {
+        if (!value) {
+            return null
+        }
+
+        if (value instanceof Callable) {
+            value = ((Callable) value).call()
+        }
+
+        value.toString()
     }
 }


### PR DESCRIPTION
## Description

During task execution of `UnityBuildPlayerTask` aka `export${Platform}${Environment}`, the version passed to unity was fetched from the project. If the project version changes the task has no tracking information of the old value so it things the task is still `up-to-date`.

This patch adds a new `Input` property called `version` to the `UnityBuildPlayerTask` class and maps the default value to `project.version`.

## Changes

![FIX] `UnityBuildPlayerTask` **up-to-date** check.

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
