### PR TITLE
Fix UnityBuildPlugin inputFiles handling

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,6 @@ pipeline {
 
                     post {
                         success {
-                            gradleWrapper "jacocoTestReport coveralls"
                             publishHTML([
                                 allowMissing: true,
                                 alwaysLinkToLastBuild: true,

--- a/src/integrationTest/groovy/wooga/gradle/build/unity/tasks/UnityBuildPlayerTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/unity/tasks/UnityBuildPlayerTaskIntegrationSpec.groovy
@@ -144,18 +144,39 @@ class UnityBuildPlayerTaskIntegrationSpec extends UnityIntegrationSpec {
 
     @Shared
     def mockProjectFiles = [
-            new File("Assets/Source.cs"),
-            new File("Assets/Plugins/iOS/somefile.m"),
-            new File("Assets/Nested/Plugins/iOS/somefile.m"),
-            new File("Assets/Plugins/WebGL/somefile.ts"),
-            new File("Assets/Nested/Plugins/WebGL/somefile.ts"),
-            new File("Assets/Editor/somefile.cs"),
-            new File("Assets/Nested/Editor/somefile.cs"),
-            new File("Assets/Plugins/Android/somefile.java"),
-            new File("Assets/Nested/Plugins/Android/somefile.java"),
-            new File("ProjectSettings/SomeSettings.asset"),
-            new File("Library/SomeCache.asset"),
-            new File("UnityPackageManager/manifest.json")
+            [new File("Assets/Plugins.meta"), false],
+            [new File("Library/SomeCache.asset"), true],
+            [new File("ProjectSettings/SomeSettings.asset"), false],
+            [new File("UnityPackageManager/manifest.json"), false],
+            [new File("Assets/Plugins/iOS.meta"), true],
+            [new File("Assets/Plugins/iOS/somefile.m"), true],
+            [new File("Assets/Plugins/iOS/somefile.m.meta"), true],
+            [new File("Assets/Nested.meta"), false],
+            [new File("Assets/Nested/Plugins.meta"), false],
+            [new File("Assets/Nested/Plugins/iOS.meta"), true],
+            [new File("Assets/Nested/Plugins/iOS/somefile.m"), true],
+            [new File("Assets/Nested/Plugins/iOS/somefile.m.meta"), true],
+            [new File("Assets/Plugins/WebGL.meta"), true],
+            [new File("Assets/Plugins/WebGL/somefile.ts"), true],
+            [new File("Assets/Plugins/WebGL/somefile.ts.meta"), true],
+            [new File("Assets/Nested/Plugins/WebGL.meta"), true],
+            [new File("Assets/Nested/Plugins/WebGL/somefile.ts"), true],
+            [new File("Assets/Nested/Plugins/WebGL/somefile.ts.meta"), true],
+            [new File("Assets/Editor.meta"), false],
+            [new File("Assets/Editor/somefile.cs"), false],
+            [new File("Assets/Editor/somefile.cs.meta"), false],
+            [new File("Assets/Nested/Editor/somefile.cs"), false],
+            [new File("Assets/Source.cs"), false],
+            [new File("Assets/Source.cs.meta"), false],
+            [new File("Assets/Nested/LevelEditor.meta"), false],
+            [new File("Assets/Nested/LevelEditor/somefile.cs"), false],
+            [new File("Assets/Nested/LevelEditor/somefile.cs.meta"), false],
+            [new File("Assets/Plugins/Android.meta"), false],
+            [new File("Assets/Plugins/Android/somefile.java"), false],
+            [new File("Assets/Plugins/Android/somefile.java.meta"), false],
+            [new File("Assets/Nested/Plugins/Android.meta"), false],
+            [new File("Assets/Nested/Plugins/Android/somefile.java"), false],
+            [new File("Assets/Nested/Plugins/Android/somefile.java.meta"), false],
     ]
 
     @Unroll
@@ -188,9 +209,8 @@ class UnityBuildPlayerTaskIntegrationSpec extends UnityIntegrationSpec {
         result.wasUpToDate('exportCustom') == status
 
         where:
-        files = mockProjectFiles
-        file << mockProjectFiles
-        status << [false, true, true, true, true, true, true, false, false, false, true, false]
+        files = mockProjectFiles.collect { it[0] }
+        [file, status] << mockProjectFiles
         statusMessage = (status) ? "is" : "is not"
     }
 }

--- a/src/integrationTest/groovy/wooga/gradle/build/unity/tasks/UnityBuildPlayerTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/unity/tasks/UnityBuildPlayerTaskIntegrationSpec.groovy
@@ -175,8 +175,8 @@ class UnityBuildPlayerTaskIntegrationSpec extends UnityIntegrationSpec {
             [new File("Assets/Plugins/Android/somefile.java"), false],
             [new File("Assets/Plugins/Android/somefile.java.meta"), false],
             [new File("Assets/Nested/Plugins/Android.meta"), false],
-            [new File("Assets/Nested/Plugins/Android/somefile.java"), false],
-            [new File("Assets/Nested/Plugins/Android/somefile.java.meta"), false],
+            [new File("Assets/Nested/Plugins/Android/s.java"), false],
+            [new File("Assets/Nested/Plugins/Android/s.java.meta"), false],
     ]
 
     @Unroll

--- a/src/main/groovy/wooga/gradle/build/unity/UnityBuildPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/UnityBuildPlugin.groovy
@@ -22,8 +22,10 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.file.FileCollection
+import org.gradle.api.file.FileTreeElement
 import org.gradle.api.plugins.BasePlugin
 import org.gradle.api.publish.plugins.PublishingPlugin
+import org.gradle.api.specs.Spec
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import wooga.gradle.unity.UnityPlugin
 import wooga.gradle.build.unity.internal.DefaultUnityBuildPluginExtension
@@ -58,6 +60,40 @@ class UnityBuildPlugin implements Plugin<Project> {
                 conventionMapping.map("buildPlatform", {extension.getDefaultPlatform()})
                 conventionMapping.map("toolsVersion", {extension.getToolsVersion()})
                 conventionMapping.map("outputDirectoryBase", {extension.getOutputDirectoryBase()})
+                conventionMapping.map("inputFiles", {
+
+                    def assetsDir = new File(task.getProjectPath(),"Assets")
+                    def assetsFileTree = project.fileTree(assetsDir)
+
+                    assetsFileTree.include(new Spec<FileTreeElement>() {
+                        @Override
+                        boolean isSatisfiedBy(FileTreeElement element) {
+                            if(element.path.toLowerCase().contains("plugins") && element.name.toLowerCase() != "plugins") {
+                                /*
+                                 Why can we use / here? Because {@code element} is a {@code FileTreeElement} object.
+                                 The getPath() method is not the same as {@code File.getPath()}
+                                 From the docs:
+
+                                 * Returns the path of this file, relative to the root of the containing file tree. Always uses '/' as the hierarchy
+                                 * separator, regardless of platform file separator. Same as calling <code>getRelativePath().getPathString()</code>.
+                                 *
+                                 * @return The path. Never returns null.
+                                 */
+                                return element.path.toLowerCase().contains("plugins/" + task.getBuildPlatform().toLowerCase())
+                            }
+
+                            return !element.path.toLowerCase().contains("editor/")
+                        }
+                    })
+
+                    def projectSettingsDir = new File(task.getProjectPath(), "ProjectSettings")
+                    def projectSettingsFileTree = project.fileTree(projectSettingsDir)
+
+                    def packageManagerDir = new File(task.getProjectPath(), "UnityPackageManager")
+                    def packageManagerDirFileTree = project.fileTree(packageManagerDir)
+
+                    project.files(assetsFileTree, projectSettingsFileTree, packageManagerDirFileTree)
+                })
             }
         })
 

--- a/src/main/groovy/wooga/gradle/build/unity/UnityBuildPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/UnityBuildPlugin.groovy
@@ -62,13 +62,17 @@ class UnityBuildPlugin implements Plugin<Project> {
                 conventionMapping.map("outputDirectoryBase", {extension.getOutputDirectoryBase()})
                 conventionMapping.map("inputFiles", {
 
-                    def assetsDir = new File(task.getProjectPath(),"Assets")
+                    def assetsDir = new File(task.getProjectPath(), "Assets")
                     def assetsFileTree = project.fileTree(assetsDir)
 
                     assetsFileTree.include(new Spec<FileTreeElement>() {
                         @Override
                         boolean isSatisfiedBy(FileTreeElement element) {
-                            if(element.path.toLowerCase().contains("plugins") && element.name.toLowerCase() != "plugins") {
+                            def path = element.path.toLowerCase()
+                            def name = element.name.toLowerCase()
+                            def status = true
+                            if (path.contains("plugins")
+                                    && !((name == "plugins") || (name == "plugins.meta"))) {
                                 /*
                                  Why can we use / here? Because {@code element} is a {@code FileTreeElement} object.
                                  The getPath() method is not the same as {@code File.getPath()}
@@ -79,10 +83,10 @@ class UnityBuildPlugin implements Plugin<Project> {
                                  *
                                  * @return The path. Never returns null.
                                  */
-                                return element.path.toLowerCase().contains("plugins/" + task.getBuildPlatform().toLowerCase())
+                                status = path.contains("plugins/" + task.getBuildPlatform().toLowerCase())
                             }
 
-                            return !element.path.toLowerCase().contains("editor/")
+                            status
                         }
                     })
 

--- a/src/main/groovy/wooga/gradle/build/unity/tasks/UnityBuildPlayerTask.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/tasks/UnityBuildPlayerTask.groovy
@@ -26,6 +26,7 @@ import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.OutputFiles
+import org.gradle.api.tasks.SkipWhenEmpty
 import wooga.gradle.unity.batchMode.BatchModeFlags
 import wooga.gradle.unity.batchMode.BuildTarget
 import wooga.gradle.unity.tasks.internal.AbstractUnityProjectTask
@@ -38,33 +39,22 @@ class UnityBuildPlayerTask extends AbstractUnityProjectTask {
         super(UnityBuildPlayerTask.class)
     }
 
+    private FileCollection inputFiles
+
+    @SkipWhenEmpty
     @InputFiles
     FileCollection getInputFiles() {
-        def base = new File(getProjectPath(), "Assets")
-        logger.info(base.path)
-        def tree = project.fileTree(base)
-
-        tree.include(new Spec<FileTreeElement>() {
-            @Override
-            boolean isSatisfiedBy(FileTreeElement element) {
-                if(element.path.toLowerCase().contains("plugins") && element.name.toLowerCase() != "plugins") {
-                    return element.path.toLowerCase().contains("plugins" + File.separator + getBuildPlatform().toLowerCase())
-                }
-                return true
-            }
-        })
-
-        tree
+        inputFiles
     }
 
-//    @OutputFiles
-//    FileCollection getOutputFiles() {
-//        project.fileTree(getOutputDirectory()) {
-//            it.exclude("build", ".gradle", "**/*.meta")
-//        }
-//    }
+    void setInputFiles(FileCollection files) {
+        this.inputFiles = files
+    }
 
-    //@Internal("Base path of outputFiles")
+    void inputFiles(FileCollection files) {
+        setInputFiles(files)
+    }
+
     @OutputDirectory
     File getOutputDirectory() {
         project.file("${getOutputDirectoryBase()}/${getBuildPlatform()}/${getBuildEnvironment()}/project")


### PR DESCRIPTION
## Description

The task had only a getter for the inputFiles property. This getter returned a `FileTree` containing only files within `Assets` directory. This patch moves the default definition into a convention map closure in `UnityBuildPlugin`. The `inputFiles` is also now annotated with `SkipWhenEmpty`. Convention mapping sets a wider `FileCollection` containing files from `Assets`, `ProjectSettings` and `UnityPackageManager` directory. The `Assets` directory tree is still filtered. So plugin sources from different build platforms don't trigger an input file changed. I also added `Editor` folders to this filter.

See `UnityBuildPlayerTaskIntegrationSpec` for test cases.

## Changes

![FIX] `UnityBuildPlugin` inputFiles handling

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
