### PR TITLE
Improve GradleBuild task interface and specs

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/build/unity/tasks/GradleBuildIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/unity/tasks/GradleBuildIntegrationSpec.groovy
@@ -91,6 +91,38 @@ class GradleBuildIntegrationSpec extends IntegrationSpec {
         result.standardOutput.contains("bar executed")
     }
 
+    def "task fails when dir is not a valid gradle project"() {
+        given: "build script with exernal execution task"
+        buildFile << """
+            task("externalGradle", type:wooga.gradle.build.unity.tasks.GradleBuild) {
+                dir "${escapedPath(File.createTempDir().path)}"
+                tasks = ['foo', 'bar']
+            }
+        """.stripIndent()
+
+        when:
+        def result = runTasksWithFailure('externalGradle')
+
+        then:
+        result.standardError.contains("Task 'foo' not found")
+    }
+
+    def "task fails when task is not part of external build"() {
+        given: "build script with exernal execution task"
+        buildFile << """
+            task("externalGradle", type:wooga.gradle.build.unity.tasks.GradleBuild) {
+                dir "${escapedPath(externalDir.path)}"
+                tasks = ['baz']
+            }
+        """.stripIndent()
+
+        when:
+        def result = runTasksWithFailure('externalGradle')
+
+        then:
+        result.standardError.contains("Task 'baz' not found")
+    }
+
     @Unroll
     def "passes current loglevel #level down to external build"() {
         given: "build script with exernal execution task"
@@ -119,13 +151,131 @@ class GradleBuildIntegrationSpec extends IntegrationSpec {
         def result = runTasksSuccessfully('externalGradle', "--$level")
 
         then:
-        contains.every { logLevel -> result.standardOutput.contains("foo $logLevel message") }
-        containsNot.every { logLevel -> !result.standardOutput.contains("foo $logLevel message") }
+        contains.every { logLevel ->
+            (result.standardOutput + result.standardError).contains("foo $logLevel message")
+        }
+        containsNot.every { logLevel ->
+            !(result.standardOutput + result.standardError).contains("foo $logLevel message")
+        }
 
         where:
         level   | contains                                                 | containsNot
         'debug' | ['debug', 'error', 'info', 'lifecycle', 'quiet', 'warn'] | []
         'info'  | ['error', 'info', 'lifecycle', 'quiet', 'warn']          | ['debug']
         'quiet' | ['error', 'quiet']                                       | ['debug', 'info', 'lifecycle', 'warn']
+    }
+
+    @Unroll
+    def "skips passing down loglevel when buildArguments contains --#level2"() {
+        given: "build script with exernal execution task"
+        buildFile << """
+            task("externalGradle", type:wooga.gradle.build.unity.tasks.GradleBuild) {
+                dir "${escapedPath(externalDir.path)}"
+                tasks = ['foo']
+                buildArguments = ['--$level2']
+            }
+        """.stripIndent()
+
+        and: "print custom log messages"
+        externalGradle << """
+            foo {
+                doLast {
+                    logger.debug('foo debug message')
+                    logger.error('foo error message')
+                    logger.info('foo info message')
+                    logger.lifecycle('foo lifecycle message')
+                    logger.quiet('foo quiet message')
+                    logger.warn('foo warn message')
+                }
+            }
+        """.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully('externalGradle', "--$level")
+
+        then:
+        contains.every { logLevel ->
+            (result.standardOutput + result.standardError).contains("foo $logLevel message")
+        }
+        containsNot.every { logLevel ->
+            !(result.standardOutput + result.standardError).contains("foo $logLevel message")
+        }
+
+
+        where:
+        level   | level2  | contains                                                 | containsNot
+        'debug' | 'info'  | ['error', 'info', 'lifecycle', 'quiet', 'warn']          | ['debug']
+        'info'  | 'quiet' | ['error', 'quiet']                                       | ['debug', 'info', 'lifecycle', 'warn']
+        'quiet' | 'debug' | ['debug', 'error', 'info', 'lifecycle', 'quiet', 'warn'] | []
+    }
+
+    @Unroll
+    def "can set custom buildArguments with #method(#type)"() {
+        given: "build script with exernal execution task"
+        buildFile << """
+            task("externalGradle", type:wooga.gradle.build.unity.tasks.GradleBuild) {
+                dir "${escapedPath(externalDir.path)}"
+                $method($value) 
+                tasks = ['foo']
+            }
+        """.stripIndent()
+
+        and: "print custom log messages"
+        externalGradle << """
+            foo {
+                doLast {
+                    println("test-param-one:" + project['testParam1'])
+                    println("test-param-two:" + project['testParam2'])
+                }
+            }
+        """.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully('externalGradle', '--quiet')
+
+        then:
+        result.standardOutput.contains("test-param-one:foo")
+        result.standardOutput.contains("test-param-two:bar")
+
+
+        where:
+        type               | value                                                   | useSetter
+        'List<String>'     | "['-PtestParam1=foo', '-PtestParam2=bar']"              | false
+        'List<String>'     | "['-PtestParam1=foo', '-PtestParam2=bar']"              | true
+        'Iterable<String>' | "new HashSet(['-PtestParam1=foo', '-PtestParam2=bar'])" | false
+        'Iterable<String>' | "new HashSet(['-PtestParam1=foo', '-PtestParam2=bar'])" | true
+        'String...'        | "'-PtestParam1=foo', '-PtestParam2=bar'"                | false
+        'String'           | "'-PtestParam1=foo', '-PtestParam2=bar'"                | false
+
+        method = (useSetter) ? "setBuildArguments" : "buildArguments"
+    }
+
+    @Unroll
+    def "can set tasks with #method(#type)"() {
+        given: "build script with exernal execution task"
+        buildFile << """
+            task("externalGradle", type:wooga.gradle.build.unity.tasks.GradleBuild) {
+                dir "${escapedPath(externalDir.path)}"
+                $method($value)
+            }
+        """.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully('externalGradle')
+
+        then:
+        result.standardOutput.contains("foo executed")
+        result.standardOutput.contains("bar executed")
+
+        where:
+        type               | value                         | useSetter
+        'List<String>'     | "['foo', 'bar']"              | false
+        'List<String>'     | "['foo', 'bar']"              | true
+        'Iterable<String>' | "new HashSet(['foo', 'bar'])" | false
+        'Iterable<String>' | "new HashSet(['foo', 'bar'])" | true
+        'String...'        | "'foo', 'bar'"                | false
+        'String'           | "'foo', 'bar'"                | false
+
+        method = (useSetter) ? "setTasks" : "tasks"
     }
 }

--- a/src/main/groovy/wooga/gradle/build/unity/tasks/GradleBuild.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/tasks/GradleBuild.groovy
@@ -51,18 +51,9 @@ class GradleBuild extends DefaultTask {
         this.tasks
     }
 
-    void setTasks(List<String> tasks) {
-        this.tasks.clear()
-        this.tasks.addAll(tasks)
-    }
-
     void setTasks(Iterable<String> tasks) {
-        setTasks(tasks.toList())
-    }
-
-    GradleBuild tasks(List<String> tasks) {
-        setTasks(tasks)
-        this
+        this.tasks.clear()
+        this.tasks.addAll(tasks.toList())
     }
 
     GradleBuild tasks(Iterable<String> tasks) {


### PR DESCRIPTION
## Description

Some properties had no full test spec setup. So I added some more test cases for `buildArguments` and `tasks` properties. While add it I added more standart API variants and added tests as well.

I also found an issue with the passed down log levels. If the `buildArguments` would contain a log level switch like `--info` it would be overriden. So I added some tests for this case and check if `buildArguments` already contain a log switch flag.

Also changed the output stream for `stderr` to `stderr`

## Changes

![IMPROVE] `GradleBuild` task interface
![FIX] edgecase with loglevel flag in `buildArguments`
![FIX] send `stderr` to `stderr` stream

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
