### PR TITLE
Fix version to string conversion crash

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/build/IntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/IntegrationSpec.groovy
@@ -36,4 +36,31 @@ class IntegrationSpec extends nebula.test.IntegrationSpec{
             fork = true
         }
     }
+
+    def wrapValueBasedOnType(Object rawValue, String type) {
+        def value
+        switch (type) {
+            case "Closure":
+                value = "{'$rawValue'}"
+                break
+            case "Callable":
+                value = "new java.util.concurrent.Callable<String>() {@Override String call() throws Exception { '$rawValue' }}"
+                break
+            case "Object":
+                value = "new Object() {@Override String toString() { '$rawValue' }}"
+                break
+            case "String":
+                value = "'$rawValue'"
+                break
+            case "File":
+                value = "new File('$rawValue')"
+                break
+            case "List<String>":
+                value = "['$rawValue']"
+                break
+            default:
+                value = $rawValue
+        }
+        value
+    }
 }

--- a/src/integrationTest/groovy/wooga/gradle/build/UnityBuildPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/UnityBuildPluginIntegrationSpec.groovy
@@ -241,4 +241,29 @@ class UnityBuildPluginIntegrationSpec extends UnityIntegrationSpec {
         "publish"  | "environment" | "extension"   | 'staging' | 'AndroidStaging'
         "publish"  | "environment" | "extension"   | 'staging' | 'AndroidStaging'
     }
+
+    @Unroll
+    def "default version is converted to String from #type"() {
+        given: "A custom project.version property"
+        buildFile << """
+            version = $value
+        """.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully("exportAndroidCi")
+
+        then:
+        //the batchmode task will be called with version
+        result.standardOutput.contains("version=$expectedValue;")
+
+        where:
+        rawValue | type           | expectedValue
+        "1.0.0"  | "String"       | "1.0.0"
+        "1.1.0"  | "Closure"      | "1.1.0"
+        "1.1.1"  | "Callable"     | "1.1.1"
+        "2.0.0"  | "Object"       | "2.0.0"
+        "2.0.0"  | "List<String>" | "[2.0.0]"
+
+        value = wrapValueBasedOnType(rawValue, type)
+    }
 }

--- a/src/integrationTest/groovy/wooga/gradle/build/unity/tasks/UnityBuildPlayerTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/unity/tasks/UnityBuildPlayerTaskIntegrationSpec.groovy
@@ -287,30 +287,6 @@ class UnityBuildPlayerTaskIntegrationSpec extends UnityIntegrationSpec {
         methodName = (useGetter) ? "setInputFiles" : "inputFiles"
     }
 
-    def wrapValueBasedOnType(Object rawValue, String type) {
-        def value
-        switch (type) {
-            case "Closure":
-                value = "{'$rawValue'}"
-                break
-            case "Callable":
-                value = "new java.util.concurrent.Callable<String>() {@Override String call() throws Exception { '$rawValue' }}"
-                break
-            case "Object":
-                value = "new Object() {@Override String toString() { '$rawValue' }}"
-                break
-            case "String":
-                value = "'$rawValue'"
-                break
-            case "File":
-                value = "new File('$rawValue')"
-                break
-            default:
-                value = rawValue
-        }
-        value
-    }
-
     Tuple prepareMockedProject(File projectDir, Iterable<File> files, File testFile) {
         files = files.collect { new File(projectDir, it.path) }
         testFile = new File(projectDir, testFile.path)

--- a/src/main/groovy/wooga/gradle/build/unity/UnityBuildPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/UnityBuildPlugin.groovy
@@ -27,6 +27,7 @@ import org.gradle.api.plugins.BasePlugin
 import org.gradle.api.publish.plugins.PublishingPlugin
 import org.gradle.api.specs.Spec
 import org.gradle.language.base.plugins.LifecycleBasePlugin
+import wooga.gradle.build.unity.ios.internal.utils.PropertyUtils
 import wooga.gradle.unity.UnityPlugin
 import wooga.gradle.build.unity.internal.DefaultUnityBuildPluginExtension
 import wooga.gradle.build.unity.tasks.GradleBuild
@@ -54,12 +55,12 @@ class UnityBuildPlugin implements Plugin<Project> {
             @Override
             void execute(UnityBuildPlayerTask task) {
                 def conventionMapping = task.getConventionMapping()
-                conventionMapping.map("version", {project.version})
                 conventionMapping.map("exportMethodName", {extension.getExportMethodName()})
                 conventionMapping.map("buildEnvironment", {extension.getDefaultEnvironment()})
                 conventionMapping.map("buildPlatform", {extension.getDefaultPlatform()})
                 conventionMapping.map("toolsVersion", {extension.getToolsVersion()})
                 conventionMapping.map("outputDirectoryBase", {extension.getOutputDirectoryBase()})
+                conventionMapping.map("version", { PropertyUtils.convertToString(project.version) })
                 conventionMapping.map("inputFiles", {
 
                     def assetsDir = new File(task.getProjectPath(), "Assets")

--- a/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPlugin.groovy
@@ -26,6 +26,7 @@ import org.gradle.api.plugins.BasePlugin
 import org.gradle.api.tasks.Sync
 import org.gradle.util.GUtil
 import wooga.gradle.build.unity.ios.internal.DefaultIOSBuildPluginExtension
+import wooga.gradle.build.unity.ios.internal.utils.PropertyUtils
 import wooga.gradle.build.unity.ios.tasks.ArchiveDsymTask
 import wooga.gradle.build.unity.ios.tasks.ImportProvisioningProfile
 import wooga.gradle.build.unity.ios.tasks.KeychainTask
@@ -56,7 +57,7 @@ class IOSBuildPlugin implements Plugin<Project> {
             @Override
             void execute(XCodeArchiveTask task) {
                 def conventionMapping = task.getConventionMapping()
-                conventionMapping.map("version", { project.version })
+                conventionMapping.map("version", { PropertyUtils.convertToString(project.version) })
                 conventionMapping.map("clean", { false })
                 conventionMapping.map("destinationDir", {
                     project.file("${project.buildDir}/archives")
@@ -72,12 +73,12 @@ class IOSBuildPlugin implements Plugin<Project> {
             @Override
             void execute(ArchiveDsymTask task) {
                 def conventionMapping = task.getConventionMapping()
-                conventionMapping.map("version", { project.version })
+                conventionMapping.map("version", { PropertyUtils.convertToString(project.version) })
                 conventionMapping.map("destinationDir", {
                     project.file("${project.buildDir}/symbols")
                 })
                 conventionMapping.map("baseName", { project.name })
-                conventionMapping.map("classifier", { "dSYM"})
+                conventionMapping.map("classifier", { "dSYM" })
                 conventionMapping.map("extension", { "zip" })
             }
         })
@@ -86,7 +87,7 @@ class IOSBuildPlugin implements Plugin<Project> {
             @Override
             void execute(XCodeExportTask task) {
                 def conventionMapping = task.getConventionMapping()
-                conventionMapping.map("version", { project.version })
+                conventionMapping.map("version", { PropertyUtils.convertToString(project.version) })
                 conventionMapping.map("destinationDir", {
                     project.file("${project.buildDir}/ipas")
                 })

--- a/src/main/groovy/wooga/gradle/build/unity/ios/internal/utils/PropertyUtils.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/internal/utils/PropertyUtils.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.build.unity.ios.internal.utils
+
+import java.util.concurrent.Callable
+
+class PropertyUtils {
+    static String convertToString(Object value) {
+        if (!value) {
+            return null
+        }
+
+        if (value instanceof Callable) {
+            value = ((Callable) value).call()
+        }
+
+        value.toString()
+    }
+}

--- a/src/main/groovy/wooga/gradle/build/unity/tasks/UnityBuildPlayerTask.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/tasks/UnityBuildPlayerTask.groovy
@@ -27,6 +27,7 @@ import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.OutputFiles
 import org.gradle.api.tasks.SkipWhenEmpty
+import wooga.gradle.build.unity.ios.internal.utils.PropertyUtils
 import wooga.gradle.unity.batchMode.BatchModeFlags
 import wooga.gradle.unity.batchMode.BatchModeSpec
 import wooga.gradle.unity.batchMode.BuildTarget
@@ -89,7 +90,7 @@ class UnityBuildPlayerTask extends AbstractUnityProjectTask {
 
     @Input
     String getBuildPlatform() {
-        def platform = convertToString(buildPlatform)
+        def platform = PropertyUtils.convertToString(buildPlatform)
         platform
     }
 
@@ -103,7 +104,7 @@ class UnityBuildPlayerTask extends AbstractUnityProjectTask {
 
     @Input
     String getBuildEnvironment() {
-        convertToString(buildEnvironment)
+        PropertyUtils.convertToString(buildEnvironment)
     }
 
     void setBuildEnvironment(Object environment) {
@@ -116,7 +117,7 @@ class UnityBuildPlayerTask extends AbstractUnityProjectTask {
 
     @Input
     String getExportMethodName() {
-        convertToString(exportMethodName)
+        PropertyUtils.convertToString(exportMethodName)
     }
 
     void setExportMethodName(Object method) {
@@ -130,7 +131,7 @@ class UnityBuildPlayerTask extends AbstractUnityProjectTask {
     @Optional
     @Input
     String getToolsVersion() {
-        convertToString(toolsVersion)
+        PropertyUtils.convertToString(toolsVersion)
     }
 
     void setToolsVersion(Object version) {
@@ -143,7 +144,7 @@ class UnityBuildPlayerTask extends AbstractUnityProjectTask {
 
     @Input
     String getVersion() {
-        convertToString(version)
+        PropertyUtils.convertToString(version)
     }
 
     void setVersion(Object value) {
@@ -180,7 +181,7 @@ class UnityBuildPlayerTask extends AbstractUnityProjectTask {
     BuildTarget convertBuildPlatformToBuildTarget(Object platform) {
         BuildTarget buildTarget
         try {
-            buildTarget = convertToString(platform).toLowerCase() as BuildTarget
+            buildTarget = PropertyUtils.convertToString(platform).toLowerCase() as BuildTarget
         }
         catch (IllegalArgumentException ignored) {
             logger.warn("build target ${platform} unknown")
@@ -188,18 +189,5 @@ class UnityBuildPlayerTask extends AbstractUnityProjectTask {
         }
 
         buildTarget
-    }
-
-    //TODO: move duplicate code
-    private static String convertToString(Object value) {
-        if (!value) {
-            return null
-        }
-
-        if (value instanceof Callable) {
-            value = ((Callable) value).call()
-        }
-
-        value.toString()
     }
 }


### PR DESCRIPTION
Description
===========

The `project.version` property is by default an `Object`. In most cases it will be a `String` value. I changed the way we set this `version` value from a direct assignment into a convention mapping (#9). What is important to note is that instead of the original `getter` the mapped `closure` will be executed instead. I added a lot of conversion methods to convert an object into a `String`. This wasn't done in the mapping. 

I added a very quick regression test in `UnityBuildPluginIntegrationSpec`. I wanted to do the same for the iOS plugin but this is impossible at the moment due to the untestable state of the plugin. I also moved some test/utility methods around to test/execute the logic without major code duplications

Changes
=======

![FIX] `project.version` toString conversion

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
