### PR TITLE
Update gradle support version to 4.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,35 @@ Development
 
 [Code of Conduct](docs/Code-of-conduct.md)
 
+Gradle and Java Compatibility
+=============================
+
+Built with Oracle JDK7
+Tested with Oracle JDK8
+
+| Gradle Version  | Works  |
+| :-------------: | :----: |
+| < 3.0           | ![no]  |
+| 3.0             | ![no]  |
+| 3.1             | ![no]  |
+| 3.2             | ![no]  |
+| 3.3             | ![no]  |
+| 3.4             | ![no]  |
+| 3.5             | ![yes] |
+| 3.5.1           | ![yes] |
+| 4.0             | ![yes] |
+| 4.1             | ![yes] |
+| 4.2             | ![yes] |
+| 4.3             | ![yes] |
+| 4.4             | ![yes] |
+| 4.5             | ![yes] |
+| 4.6             | ![yes] |
+| 4.6             | ![yes] |
+| 4.7             | ![yes] |
+| 4.8             | ![yes] |
+| 4.9             | ![yes] |
+| 4.10            | ![yes] |
+
 LICENSE
 =======
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-all.zip

--- a/gradle_check_versions.sh
+++ b/gradle_check_versions.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+versions=("3.0" "3.1" "3.2" "3.4" "3.4.1" "3.5" "3.5.1" "4.0" "4.1" "4.2" "4.3" "4.4" "4.5" "4.6" "4.7" "4.8" "4.9" "4.10")
+
+for i in "${versions[@]}"
+do
+    echo "test gradle version $i"
+    GRADLE_VERSION=$i ./gradlew integrationTest &> /dev/null
+    status=$?
+    mkdir -p "build/reports/$i"
+    mv build/reports/integrationTest "build/reports/$i"
+    if [ $status -ne 0 ]; then
+        echo "test error $i"
+    fi
+done

--- a/src/integrationTest/groovy/wooga/gradle/build/IntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/IntegrationSpec.groovy
@@ -17,6 +17,7 @@
 
 package wooga.gradle.build
 
+import nebula.test.functional.ExecutionResult
 import org.apache.commons.text.StringEscapeUtils
 
 class IntegrationSpec extends nebula.test.IntegrationSpec{
@@ -35,6 +36,10 @@ class IntegrationSpec extends nebula.test.IntegrationSpec{
             this.gradleVersion = gradleVersion
             fork = true
         }
+    }
+
+    Boolean outputContains(ExecutionResult result, String message) {
+        result.standardOutput.contains(message) || result.standardError.contains(message)
     }
 
     def wrapValueBasedOnType(Object rawValue, String type) {

--- a/src/integrationTest/groovy/wooga/gradle/build/unity/tasks/GradleBuildIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/unity/tasks/GradleBuildIntegrationSpec.groovy
@@ -104,7 +104,7 @@ class GradleBuildIntegrationSpec extends IntegrationSpec {
         def result = runTasksWithFailure('externalGradle')
 
         then:
-        result.standardError.contains("Task 'foo' not found")
+        outputContains(result,"Task 'foo' not found")
     }
 
     def "task fails when task is not part of external build"() {
@@ -120,7 +120,7 @@ class GradleBuildIntegrationSpec extends IntegrationSpec {
         def result = runTasksWithFailure('externalGradle')
 
         then:
-        result.standardError.contains("Task 'baz' not found")
+        outputContains(result,"Task 'baz' not found")
     }
 
     @Unroll

--- a/src/main/groovy/wooga/gradle/build/unity/UnityBuildPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/UnityBuildPlugin.groovy
@@ -72,7 +72,7 @@ class UnityBuildPlugin implements Plugin<Project> {
                     assetsFileTree.include(new Spec<FileTreeElement>() {
                         @Override
                         boolean isSatisfiedBy(FileTreeElement element) {
-                            def path = element.path.toLowerCase()
+                            def path = element.getRelativePath().getPathString().toLowerCase()
                             def name = element.name.toLowerCase()
                             def status = true
                             if (path.contains("plugins")

--- a/src/main/groovy/wooga/gradle/build/unity/ios/internal/DefaultIOSBuildPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/internal/DefaultIOSBuildPluginExtension.groovy
@@ -18,15 +18,12 @@
 package wooga.gradle.build.unity.ios.internal
 
 import org.gradle.api.Action
-import org.gradle.api.credentials.PasswordCredentials
-import org.gradle.api.internal.artifacts.repositories.DefaultPasswordCredentials
-
 import wooga.gradle.build.unity.ios.IOSBuildPluginExtension
 import static org.gradle.util.ConfigureUtil.configureUsing
 
 class DefaultIOSBuildPluginExtension implements IOSBuildPluginExtension {
 
-    private final PasswordCredentials fastlaneCredentials
+    private final org.gradle.api.credentials.PasswordCredentials fastlaneCredentials
     private String keychainPassword
     private String certificatePassphrase
     private String applicationIdentifier
@@ -35,12 +32,12 @@ class DefaultIOSBuildPluginExtension implements IOSBuildPluginExtension {
     private String configuration
 
     @Override
-    PasswordCredentials getFastlaneCredentials() {
+    org.gradle.api.credentials.PasswordCredentials getFastlaneCredentials() {
         fastlaneCredentials
     }
 
     @Override
-    void setFastlaneCredentials(PasswordCredentials cred) {
+    void setFastlaneCredentials(org.gradle.api.credentials.PasswordCredentials cred) {
         fastlaneCredentials.setUsername(cred.username)
         fastlaneCredentials.setPassword(cred.password)
         this
@@ -53,13 +50,13 @@ class DefaultIOSBuildPluginExtension implements IOSBuildPluginExtension {
     }
 
     @Override
-    IOSBuildPluginExtension fastlaneCredentials(Action<PasswordCredentials> action) {
+    IOSBuildPluginExtension fastlaneCredentials(Action<org.gradle.api.credentials.PasswordCredentials> action) {
         action.execute(fastlaneCredentials)
         this
     }
 
     @Override
-    IOSBuildPluginExtension fastlaneCredentials(PasswordCredentials cred) {
+    IOSBuildPluginExtension fastlaneCredentials(org.gradle.api.credentials.PasswordCredentials cred) {
         setFastlaneCredentials(cred)
         this
     }
@@ -161,6 +158,24 @@ class DefaultIOSBuildPluginExtension implements IOSBuildPluginExtension {
     }
 
     DefaultIOSBuildPluginExtension() {
-        fastlaneCredentials = new DefaultPasswordCredentials()
+        fastlaneCredentials = new PasswordCredentials()
+    }
+
+    class PasswordCredentials implements org.gradle.api.credentials.PasswordCredentials {
+
+        String username
+        String password
+
+        PasswordCredentials() {
+        }
+
+        PasswordCredentials(String username, String password) {
+            this.username = username
+            this.password = password
+        }
+
+        String toString() {
+            String.format("Credentials [username: %s]", this.username)
+        }
     }
 }

--- a/src/main/groovy/wooga/gradle/build/unity/ios/internal/DefaultIOSBuildPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/internal/DefaultIOSBuildPluginExtension.groovy
@@ -18,6 +18,7 @@
 package wooga.gradle.build.unity.ios.internal
 
 import org.gradle.api.Action
+import org.gradle.api.credentials.PasswordCredentials
 import wooga.gradle.build.unity.ios.IOSBuildPluginExtension
 import static org.gradle.util.ConfigureUtil.configureUsing
 
@@ -158,20 +159,15 @@ class DefaultIOSBuildPluginExtension implements IOSBuildPluginExtension {
     }
 
     DefaultIOSBuildPluginExtension() {
-        fastlaneCredentials = new PasswordCredentials()
+        fastlaneCredentials = new DefaultPasswordCredentials()
     }
 
-    class PasswordCredentials implements org.gradle.api.credentials.PasswordCredentials {
+    class DefaultPasswordCredentials implements PasswordCredentials {
 
         String username
         String password
 
-        PasswordCredentials() {
-        }
-
-        PasswordCredentials(String username, String password) {
-            this.username = username
-            this.password = password
+        DefaultPasswordCredentials() {
         }
 
         String toString() {


### PR DESCRIPTION
## Description

This patch updates the used gradle version for development to `4.10`. This concludes the support of the gradle `4.x` version range as `4.10` is the last version before `5.0`

see wooga/rfcs#2

## Needed adjustments

* Gradle >= `4.8` changed the output stream for errors
* Gradle 4.10 moved the internal class `DefaultPasswordCredentials`
* Gradle 4.10 changed internal `FileTreeElement` behavior

## Changes

![ADD] Optional property declaration in nested input model
![IMPROVE] integration specs by adding utility method to check both `stdout` and `stderr` for message
![ADD] custom `PasswordCredentials` implementation
![UPDATE] ![GRADLE] support version to `4.10`
![FIX] default unity export input files filter

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://atlas-resources.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:http://atlas-resources.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://atlas-resources.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://atlas-resources.wooga.com/icons/icon_break.svg "Break"
[REMOVE]:http://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://atlas-resources.wooga.com/icons/icon_webGL.svg "Web:GL"
[GRADLE]:http://atlas-resources.wooga.com/icons/icon_gradle.svg "Gradle"
[UNITY]:http://atlas-resources.wooga.com/icons/icon_unity.svg "Unity"
