### PR TITLE
Add ignoreFilesForExportUpToDateCheck property to exclude files for up-to-date check

### DIFF
--- a/src/main/groovy/wooga/gradle/build/unity/UnityBuildPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/UnityBuildPluginExtension.groovy
@@ -17,6 +17,7 @@
 
 package wooga.gradle.build.unity
 
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileCollection
 import org.gradle.api.provider.Property
@@ -30,4 +31,6 @@ interface UnityBuildPluginExtension<T extends UnityBuildPluginExtension> {
     Property<String> getDefaultAppConfigName()
 
     FileCollection getAppConfigs()
+
+    ConfigurableFileCollection getIgnoreFilesForExportUpToDateCheck()
 }

--- a/src/main/groovy/wooga/gradle/build/unity/internal/DefaultUnityBuildPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/internal/DefaultUnityBuildPluginExtension.groovy
@@ -18,10 +18,10 @@
 package wooga.gradle.build.unity.internal
 
 import org.gradle.api.Project
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileCollection
-import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import wooga.gradle.build.unity.UnityBuildPluginConsts
@@ -40,6 +40,7 @@ class DefaultUnityBuildPluginExtension implements UnityBuildPluginExtension {
     final Property<String> exportMethodName
     final Property<String> defaultAppConfigName
     final Provider<Directory> assetsDir
+    final ConfigurableFileCollection ignoreFilesForExportUpToDateCheck
 
     DefaultUnityBuildPluginExtension(final Project project) {
         this.project = project
@@ -50,6 +51,7 @@ class DefaultUnityBuildPluginExtension implements UnityBuildPluginExtension {
         exportMethodName = project.objects.property(String.class)
         defaultAppConfigName = project.objects.property(String.class)
         assetsDir = project.layout.directoryProperty()
+        ignoreFilesForExportUpToDateCheck = project.layout.configurableFiles()
 
         exportMethodName.set(project.provider(new Callable<String>() {
             @Override


### PR DESCRIPTION
## Description

This patch adds a new property `ignoreFilesForExportUpToDateCheck` to the `UnityBuildPluginExtension` extension. The files in this `ConfigurableFileCollection` will excluded from the default `inputFiles` collection for `UnityBuildPlayerTask`.

## Changes

![ADD] new property `ignoreFilesForExportUpToDateCheck` to `UnityBuildPluginExtension`
![IMPROVE] default `UnityBuildPlayerTask` `inputFiles` __include__/__exludue__ pattern

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
