### PR TITLE
Fix integration test build setup

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/build/IntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/IntegrationSpec.groovy
@@ -19,8 +19,13 @@ package wooga.gradle.build
 
 import nebula.test.functional.ExecutionResult
 import org.apache.commons.text.StringEscapeUtils
+import org.junit.Rule
+import org.junit.contrib.java.lang.system.ProvideSystemProperty
 
 class IntegrationSpec extends nebula.test.IntegrationSpec{
+
+    @Rule
+    ProvideSystemProperty properties = new ProvideSystemProperty("ignoreDeprecations", "true")
 
     def escapedPath(String path) {
         String osName = System.getProperty("os.name").toLowerCase()

--- a/src/integrationTest/groovy/wooga/gradle/build/UnityBuildPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/UnityBuildPluginIntegrationSpec.groovy
@@ -26,6 +26,7 @@ import spock.lang.IgnoreIf
 import spock.lang.Shared
 import spock.lang.Unroll
 import wooga.gradle.unity.batchMode.BatchModeFlags
+import wooga.gradle.unity.batchMode.BuildTarget
 
 class UnityBuildPluginIntegrationSpec extends UnityIntegrationSpec {
 
@@ -40,7 +41,7 @@ class UnityBuildPluginIntegrationSpec extends UnityIntegrationSpec {
 
         ['ios_ci', 'android_ci', 'webGL_ci'].collect { createFile("${it}.asset", appConfigsDir) }.each {
             Yaml yaml = new Yaml()
-            def buildTarget = it.name.split(/_/, 1).first()
+            def buildTarget = it.name.split(/_/, 2).first().toLowerCase()
             def appConfig = ['MonoBehaviour': ['bundleId': 'net.wooga.test', 'batchModeBuildTarget': buildTarget]]
             it << yaml.dump(appConfig)
         }
@@ -63,9 +64,9 @@ class UnityBuildPluginIntegrationSpec extends UnityIntegrationSpec {
 
         where:
         taskToRun         | expectedParameters
-        "exportAndroidCi" | "${BatchModeFlags.BUILD_TARGET} android"
-        "exportIosCi"     | "${BatchModeFlags.BUILD_TARGET} ios"
-        "exportWebGLCi"   | "${BatchModeFlags.BUILD_TARGET} webGL"
+        "exportAndroidCi" | "${BatchModeFlags.BUILD_TARGET} ${BuildTarget.android}"
+        "exportIosCi"     | "${BatchModeFlags.BUILD_TARGET} ${BuildTarget.ios}"
+        "exportWebGLCi"   | "${BatchModeFlags.BUILD_TARGET} ${BuildTarget.webgl}"
     }
 
     @Unroll
@@ -91,7 +92,7 @@ class UnityBuildPluginIntegrationSpec extends UnityIntegrationSpec {
 
 
     @Unroll
-    def "can override property #property in #location with #value"() {
+    def "can override property #property in #location"() {
         given: "execute on a default project"
         assert runTasksSuccessfully("exportAndroidCi").standardOutput.contains("-executeMethod Wooga.UnifiedBuildSystem.Build.Export")
 

--- a/src/integrationTest/groovy/wooga/gradle/build/unity/tasks/UnityBuildPlayerTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/unity/tasks/UnityBuildPlayerTaskIntegrationSpec.groovy
@@ -126,8 +126,8 @@ class UnityBuildPlayerTaskIntegrationSpec extends UnityIntegrationSpec {
 
         where:
         batchModeBuildTarget | valueType             | shouldContainBuildTargetFlag
-        'value'              | 'string'              | true
-        "'value'"            | 'quoted string'       | true
+        'ios'                | 'string'              | true
+        "'ios'"              | 'quoted string'       | true
         ''                   | 'empty'               | false
         "''"                 | 'quoted empty string' | false
         null                 | 'null'                | false
@@ -209,7 +209,7 @@ class UnityBuildPlayerTaskIntegrationSpec extends UnityIntegrationSpec {
     ]
 
     @Unroll
-    def "task #statusMessage up-to-date when file change at location #file with default inputFiles"() {
+    def "task #statusMessage up-to-date when #file changed with default inputFiles"() {
         given: "a mocked unity project"
         //need to convert the relative files to absolute files
         def (_, File testFile) = prepareMockedProject(projectDir, files as Iterable<File>, file as File)


### PR DESCRIPTION
## Description

This patch fixes some minor issues with the integration test setup. We need to disable the gradle 5 compatibility warnings as all tests fail because of it. There is also a setup bug for the provided build targets in the mock app configs. We should only test with valid build target values.

## Changes

![FIX] test values for build target in integration test
![IMPROVE] disable gradle 5 compatibility warnings

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
