### PR TITLE
Fix double buildTarget argument when exporting with default target set

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/build/unity/tasks/UnityBuildPlayerTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/unity/tasks/UnityBuildPlayerTaskIntegrationSpec.groovy
@@ -19,6 +19,7 @@ package wooga.gradle.build.unity.tasks
 
 import org.apache.commons.io.FilenameUtils
 import org.yaml.snakeyaml.Yaml
+import spock.lang.Issue
 import spock.lang.Shared
 import spock.lang.Unroll
 import wooga.gradle.build.UnityIntegrationSpec
@@ -55,6 +56,21 @@ class UnityBuildPlayerTaskIntegrationSpec extends UnityIntegrationSpec {
         result.standardOutput.contains("version=unspecified")
         result.standardOutput.contains("outputPath=${new File(projectDir, '/build/export/custom/project').path}")
         !result.standardOutput.contains("toolsVersion=")
+    }
+
+    @Issue("https://github.com/wooga/atlas-build-unity/issues/23")
+    def "clear buildTarget setting"() {
+        given: "a project setting default build target for all Unity tasks"
+        buildFile << """
+            unity.defaultBuildTarget = "ios"
+        """.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully("exportCustom")
+
+        then:
+        result.standardOutput.contains("-buildTarget android")
+        !result.standardOutput.contains("-buildTarget ios")
     }
 
     @Unroll

--- a/src/main/groovy/wooga/gradle/build/unity/tasks/UnityBuildPlayerTask.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/tasks/UnityBuildPlayerTask.groovy
@@ -117,7 +117,7 @@ class UnityBuildPlayerTask extends AbstractUnityProjectTask {
         customArgs += "version=${version.get()};"
 
         if (getBuildPlatform()) {
-            args BatchModeFlags.BUILD_TARGET, getBuildPlatform()
+            setBuildTarget(getBuildPlatform().toLowerCase() as BuildTarget)
         }
 
         if (toolsVersion.present) {


### PR DESCRIPTION
## Description

When using the `UnityBuildPlayerTask` within a gradle project that also configured the `defaultBuildTarget` value, then the `UnityBuildPlayerTask` might configure the `-buildTarget` flag for the batchmode invocation two times. It's undefined for me if the first or second value is used by Unity. This patch adds a test spec and the necessary patch to fix this issue.

## Changes

![FIX] double buildTarget argument when exporting with default target configured

resolves: #23 

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
