### PR TITLE
Improve inner task execution by providing gradle version to execute with

### DIFF
--- a/src/main/groovy/wooga/gradle/build/unity/tasks/GradleBuild.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/tasks/GradleBuild.groovy
@@ -21,8 +21,10 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 import org.gradle.tooling.GradleConnector
 import org.gradle.tooling.ProjectConnection
@@ -38,6 +40,9 @@ class GradleBuild extends DefaultTask {
 
     @Input
     final ListProperty<String> buildArguments = project.objects.listProperty(String.class)
+
+    @Input
+    final Property<String> gradleVersion = project.objects.property(String.class)
 
     @TaskAction
     protected exec() {
@@ -61,6 +66,7 @@ class GradleBuild extends DefaultTask {
 
         ProjectConnection connection = GradleConnector.newConnector()
                 .forProjectDirectory(dir.get().asFile)
+                .useGradleVersion(gradleVersion.get())
                 .connect()
 
         try {


### PR DESCRIPTION
## Description

For newer Unity version it is desired that the exported gradle project runs with a configured gradle version. At the moment, gradle uses the same version as the root project version to execute the build in the exported projects. This patch allows to set a custom gradle version in the `appConfig`. Gradle will fall back to the root gradle version if the property `gradleVersion` is not defined.

## Changes

![IMPROVE] configuration by providing gradle version for exported task runner

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
