### PR TITLE
Disable caching for ImportProvisioningProfile task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,9 +56,9 @@ dependencies {
     compile "org.gradle:gradle-tooling-api:+"
     compile 'gradle.plugin.net.wooga.gradle:atlas-unity:1.+'
     compile 'xmlwise:xmlwise:1.2.11'
-
     compile 'commons-codec:commons-codec:1.13'
     testCompile 'org.apache.commons:commons-text:1.8'
+    testCompile 'com.github.stefanbirkner:system-rules:1.18.0'
     testCompile('com.nagternal:spock-genesis:0.6.0') {
         exclude group: "org.codehaus.groovy", module: "groovy-all"
     }

--- a/src/integrationTest/groovy/wooga/gradle/build/IntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/IntegrationSpec.groovy
@@ -20,12 +20,16 @@ package wooga.gradle.build
 import nebula.test.functional.ExecutionResult
 import org.apache.commons.text.StringEscapeUtils
 import org.junit.Rule
+import org.junit.contrib.java.lang.system.EnvironmentVariables
 import org.junit.contrib.java.lang.system.ProvideSystemProperty
 
 class IntegrationSpec extends nebula.test.IntegrationSpec{
 
     @Rule
     ProvideSystemProperty properties = new ProvideSystemProperty("ignoreDeprecations", "true")
+
+    @Rule
+    public final EnvironmentVariables environmentVariables = new EnvironmentVariables()
 
     def escapedPath(String path) {
         String osName = System.getProperty("os.name").toLowerCase()

--- a/src/integrationTest/groovy/wooga/gradle/build/unity/ios/tasks/ImportProvisioningProfileSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/unity/ios/tasks/ImportProvisioningProfileSpec.groovy
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2019 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.build.unity.ios.tasks
+
+import org.gradle.internal.impldep.org.junit.Rule
+import org.junit.contrib.java.lang.system.EnvironmentVariables
+import spock.lang.Issue
+import spock.lang.Requires
+import wooga.gradle.build.IntegrationSpec
+
+@Requires({ os.macOs })
+class ImportProvisioningProfileSpec extends IntegrationSpec {
+
+    File fastlaneMock
+    File fastlaneMockPath
+
+    def setupFastlaneMock() {
+        fastlaneMockPath = File.createTempDir("fastlane","mock")
+
+        def path = System.getenv("PATH")
+        environmentVariables.clear("PATH")
+        String newPath = "${fastlaneMockPath}${File.pathSeparator}${path}"
+        environmentVariables.set("PATH", newPath)
+        assert System.getenv("PATH") == newPath
+
+
+        fastlaneMock = createFile("fastlane", fastlaneMockPath)
+        fastlaneMock.executable = true
+        String osName = System.getProperty("os.name").toLowerCase()
+        if (osName.contains("windows")) {
+            fastlaneMock << """
+                @echo off
+                echo %*
+            """.stripIndent()
+        }
+        else
+        {
+            fastlaneMock << """
+                #!/usr/bin/env bash
+                echo \$@
+            """.stripIndent()
+        }
+    }
+
+    def setup() {
+        buildFile << """
+            task customImportProfiles(type: wooga.gradle.build.unity.ios.tasks.ImportProvisioningProfile) {
+                appIdentifier = "com.test.testapp"
+                teamId = "fakeTeamId"
+                profileName = "signing.mobileprovisioning"
+                destinationDir = file("build")
+            }
+        """.stripIndent()
+
+        setupFastlaneMock()
+    }
+
+    @Issue("https://github.com/wooga/atlas-build-unity/issues/38")
+    def "task :#taskToRun is never up-to-date"() {
+        given: "call import tasks once"
+        def r = runTasks(taskToRun)
+
+        when: "no parameter changes"
+        def result = runTasksSuccessfully(taskToRun)
+
+        then:
+        !result.wasUpToDate(taskToRun)
+
+        where:
+        taskToRun = "customImportProfiles"
+    }
+}

--- a/src/main/groovy/wooga/gradle/build/unity/ios/tasks/ImportProvisioningProfile.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/tasks/ImportProvisioningProfile.groovy
@@ -152,14 +152,33 @@ class ImportProvisioningProfile extends ConventionTask {
                 return task.getTeamId() && task.getAppIdentifier()
             }
         })
+
+        outputs.upToDateWhen {false}
+    }
+
+    /**
+     * Finds path to executable in PATH.
+     *
+     * This function is aimed to make the whole task testable.
+     * The tests can override the PATH environment variable and
+     * point to a mock executable.
+     *
+     * @param executableName the name of the executable to find in PATH
+     * @return path to executable or executableName
+     */
+    private static String getExecutable(String executableName) {
+        def path = System.getenv("PATH").split(File.pathSeparator)
+                .collect {path -> new File(path, "fastlane")}
+                .find {path -> path.exists() && path.isFile() && path.canExecute()}
+        path? path.path : executableName
     }
 
     @TaskAction
     protected void importProfiles() {
+        def executablePath = getExecutable("fastlane")
         project.exec {
-            executable "fastlane"
+            executable executablePath
             args "sigh"
-
             def pw = getPassword()
 
             if (pw) {


### PR DESCRIPTION
## Description

The `ImportProvisioningProfile` task should never be `up-to-date`. A provisioning profile can change remotely without warning. Input caching can make this task to be marked `up-to-date`. This patch sets the output `upToDateWhen` spec to be always false. It would be possible to write a custom timeout handler but this is to much effort for a task that runs maximum of 15 seconds

### Test-ability changes

I had to adjust the source slightly to be able to test this new task caching behavior. I added a custom static getter `getExecutable` to the `ImportProvisioningProfile` class. This helper methods tries to find the path to the given executable in the environment `PATH`. The reason for this change is that I need a way to inject a mock `fastlane` executable. I can't override the path of the spawned gradle job so opted for the moment to find the executable at runtime.

## Changes

![FIX] caching for `ImportProvisioningProfile` task
![ADD] `getExecutable` helper method in `ImportProvisioningProfile`

resolves #38 

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
