### PR TITLE
Add provisioningName property to ImportProvisioningProfile

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/build/unity/ios/tasks/ImportProvisioningProfileSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/unity/ios/tasks/ImportProvisioningProfileSpec.groovy
@@ -17,12 +17,17 @@
 
 package wooga.gradle.build.unity.ios.tasks
 
-import org.gradle.internal.impldep.org.junit.Rule
-import org.junit.contrib.java.lang.system.EnvironmentVariables
 import spock.lang.Issue
 import spock.lang.Requires
+import spock.lang.Unroll
 import wooga.gradle.build.IntegrationSpec
 
+/**
+ * The test examples in this class are not 100% integration/functional tests.
+ *
+ * We can't run the real fastlane and connect to apple because there is no easy way to setup and maintain a test app and
+ * account with necessary credentials. We only test the invocation of fastlane and its parameters.
+ */
 @Requires({ os.macOs })
 class ImportProvisioningProfileSpec extends IntegrationSpec {
 
@@ -30,7 +35,7 @@ class ImportProvisioningProfileSpec extends IntegrationSpec {
     File fastlaneMockPath
 
     def setupFastlaneMock() {
-        fastlaneMockPath = File.createTempDir("fastlane","mock")
+        fastlaneMockPath = File.createTempDir("fastlane", "mock")
 
         def path = System.getenv("PATH")
         environmentVariables.clear("PATH")
@@ -41,25 +46,16 @@ class ImportProvisioningProfileSpec extends IntegrationSpec {
 
         fastlaneMock = createFile("fastlane", fastlaneMockPath)
         fastlaneMock.executable = true
-        String osName = System.getProperty("os.name").toLowerCase()
-        if (osName.contains("windows")) {
-            fastlaneMock << """
-                @echo off
-                echo %*
-            """.stripIndent()
-        }
-        else
-        {
-            fastlaneMock << """
-                #!/usr/bin/env bash
-                echo \$@
-            """.stripIndent()
-        }
+        fastlaneMock << """
+            #!/usr/bin/env bash
+            echo \$@
+            env
+        """.stripIndent()
     }
 
     def setup() {
         buildFile << """
-            task customImportProfiles(type: wooga.gradle.build.unity.ios.tasks.ImportProvisioningProfile) {
+            task importProfiles(type: wooga.gradle.build.unity.ios.tasks.ImportProvisioningProfile) {
                 appIdentifier = "com.test.testapp"
                 teamId = "fakeTeamId"
                 profileName = "signing.mobileprovisioning"
@@ -82,6 +78,84 @@ class ImportProvisioningProfileSpec extends IntegrationSpec {
         !result.wasUpToDate(taskToRun)
 
         where:
-        taskToRun = "customImportProfiles"
+        taskToRun = "importProfiles"
+    }
+
+    @Unroll
+    def "task :#taskToRun accepts input #parameter with #method and type #type"() {
+        given: "task with configured properties"
+        buildFile << """
+            ${taskToRun} {
+                ${method}(${value})
+            }
+        """.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully(taskToRun)
+
+        then:
+        result.standardOutput.contains(expectedCommandlineSwitch.replace("#{value_path}", new File(projectDir, rawValue).path))
+
+        where:
+        parameter           | rawValue                | type       | useSetter | expectedCommandlineSwitchRaw
+        "appIdentifier"     | "com.test.app2"         | 'String'   | true      | "--app_identifier #{value}"
+        "appIdentifier"     | "com.test.app3"         | 'String'   | false     | "--app_identifier #{value}"
+        "appIdentifier"     | "com.test.app4"         | 'Closure'  | true      | "--app_identifier #{value}"
+        "appIdentifier"     | "com.test.app5"         | 'Closure'  | false     | "--app_identifier #{value}"
+        "appIdentifier"     | "com.test.app6"         | 'Callable' | true      | "--app_identifier #{value}"
+        "appIdentifier"     | "com.test.app7"         | 'Callable' | false     | "--app_identifier #{value}"
+        "appIdentifier"     | "com.test.app8"         | 'Object'   | true      | "--app_identifier #{value}"
+        "appIdentifier"     | "com.test.app9"         | 'Object'   | false     | "--app_identifier #{value}"
+
+        "teamId"            | "1234561"               | 'String'   | true      | "--team_id #{value}"
+        "teamId"            | "1234562"               | 'String'   | false     | "--team_id #{value}"
+        "teamId"            | "1234563"               | 'Closure'  | true      | "--team_id #{value}"
+        "teamId"            | "1234564"               | 'Closure'  | false     | "--team_id #{value}"
+        "teamId"            | "1234565"               | 'Callable' | true      | "--team_id #{value}"
+        "teamId"            | "1234566"               | 'Callable' | false     | "--team_id #{value}"
+        "teamId"            | "1234567"               | 'Object'   | true      | "--team_id #{value}"
+        "teamId"            | "1234568"               | 'Object'   | false     | "--team_id #{value}"
+
+        "username"          | "tester1"               | 'String'   | true      | "--username #{value}"
+        "username"          | "tester2"               | 'String'   | false     | "--username #{value}"
+        "username"          | "tester3"               | 'Closure'  | true      | "--username #{value}"
+        "username"          | "tester4"               | 'Closure'  | false     | "--username #{value}"
+        "username"          | "tester5"               | 'Callable' | true      | "--username #{value}"
+        "username"          | "tester6"               | 'Callable' | false     | "--username #{value}"
+        "username"          | "tester7"               | 'Object'   | true      | "--username #{value}"
+        "username"          | "tester8"               | 'Object'   | false     | "--username #{value}"
+
+        "password"          | "pass1"                 | 'String'   | true      | "FASTLANE_PASSWORD=#{value}"
+        "password"          | "pass2"                 | 'String'   | false     | "FASTLANE_PASSWORD=#{value}"
+        "password"          | "pass3"                 | 'Closure'  | true      | "FASTLANE_PASSWORD=#{value}"
+        "password"          | "pass4"                 | 'Closure'  | false     | "FASTLANE_PASSWORD=#{value}"
+        "password"          | "pass5"                 | 'Callable' | true      | "FASTLANE_PASSWORD=#{value}"
+        "password"          | "pass6"                 | 'Callable' | false     | "FASTLANE_PASSWORD=#{value}"
+        "password"          | "pass7"                 | 'Object'   | true      | "FASTLANE_PASSWORD=#{value}"
+        "password"          | "pass8"                 | 'Object'   | false     | "FASTLANE_PASSWORD=#{value}"
+
+        "profileName"       | "sign1.mobileprovision" | 'String'   | true      | "--filename #{value}"
+        "profileName"       | "sign2.mobileprovision" | 'String'   | false     | "--filename #{value}"
+
+        "provisioningName" | "profile_1"             | 'String'   | true      | "--provisioning_name #{value}"
+        "provisioningName" | "profile_2"             | 'String'   | false     | "--provisioning_name #{value}"
+        "provisioningName" | "profile_3"             | 'Closure'  | true      | "--provisioning_name #{value}"
+        "provisioningName" | "profile_4"             | 'Closure'  | false     | "--provisioning_name #{value}"
+        "provisioningName" | "profile_5"             | 'Callable' | true      | "--provisioning_name #{value}"
+        "provisioningName" | "profile_6"             | 'Callable' | false     | "--provisioning_name #{value}"
+        "provisioningName" | "profile_7"             | 'Object'   | true      | "--provisioning_name #{value}"
+        "provisioningName" | "profile_8"             | 'Object'   | false     | "--provisioning_name #{value}"
+
+        "destinationDir"    | "build/out1"            | 'String'   | true      | "--output_path #{value_path}"
+        "destinationDir"    | "build/out2"            | 'String'   | false     | "--output_path #{value_path}"
+        "destinationDir"    | "build/out3"            | 'File'     | true      | "--output_path #{value_path}"
+        "destinationDir"    | "build/out4"            | 'File'     | false     | "--output_path #{value_path}"
+        "destinationDir"    | "build/out5"            | 'Closure'  | true      | "--output_path #{value_path}"
+        "destinationDir"    | "build/out6"            | 'Closure'  | false     | "--output_path #{value_path}"
+
+        taskToRun = "importProfiles"
+        value = wrapValueBasedOnType(rawValue, type)
+        method = (useSetter) ? "set${parameter.capitalize()}" : parameter
+        expectedCommandlineSwitch = expectedCommandlineSwitchRaw.replace("#{value}", rawValue)
     }
 }

--- a/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPlugin.groovy
@@ -119,6 +119,7 @@ class IOSBuildPlugin implements Plugin<Project> {
                 conventionMapping.map("teamId", { extension.getTeamId() })
                 conventionMapping.map("appIdentifier", { extension.getAppIdentifier() })
                 conventionMapping.map("destinationDir", { task.getTemporaryDir() })
+                conventionMapping.map("provisioningName", { extension.getProvisioningName() })
                 conventionMapping.map("profileName", { 'signing.mobileprovision' })
             }
         })

--- a/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginExtension.groovy
@@ -54,4 +54,8 @@ interface IOSBuildPluginExtension {
     void setConfiguration(String configuration)
     IOSBuildPluginExtension configuration(String configuration)
 
+    String getProvisioningName()
+    void setProvisioningName(String provisioningName)
+    IOSBuildPluginExtension provisioningName(String provisioningName)
+
 }

--- a/src/main/groovy/wooga/gradle/build/unity/ios/internal/DefaultIOSBuildPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/internal/DefaultIOSBuildPluginExtension.groovy
@@ -31,6 +31,7 @@ class DefaultIOSBuildPluginExtension implements IOSBuildPluginExtension {
     private String teamId
     private String scheme
     private String configuration
+    private String provisioningName
 
     @Override
     org.gradle.api.credentials.PasswordCredentials getFastlaneCredentials() {
@@ -155,6 +156,22 @@ class DefaultIOSBuildPluginExtension implements IOSBuildPluginExtension {
     @Override
     IOSBuildPluginExtension configuration(String configuration) {
         setConfiguration(configuration)
+        this
+    }
+
+    @Override
+    String getProvisioningName() {
+        this.provisioningName
+    }
+
+    @Override
+    void setProvisioningName(String provisioningName) {
+        this.provisioningName = provisioningName
+    }
+
+    @Override
+    IOSBuildPluginExtension provisioningName(String provisioningName) {
+        setProvisioningName(provisioningName)
         this
     }
 

--- a/src/main/groovy/wooga/gradle/build/unity/ios/tasks/ImportProvisioningProfile.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/tasks/ImportProvisioningProfile.groovy
@@ -114,6 +114,24 @@ class ImportProvisioningProfile extends ConventionTask {
         this
     }
 
+    private Object provisioningName
+
+    @Optional
+    @Input
+    String getProvisioningName() {
+        convertToString(provisioningName)
+    }
+
+    void setProvisioningName(Object value) {
+        provisioningName = value
+    }
+
+    ImportProvisioningProfile provisioningName(Object provisioningName) {
+        setProvisioningName(provisioningName)
+        this
+    }
+
+
     private Object destinationDir
 
     @Input
@@ -191,6 +209,12 @@ class ImportProvisioningProfile extends ConventionTask {
 
             args "--team_id", getTeamId()
             args "--app_identifier", getAppIdentifier()
+
+            def provisioningName = getProvisioningName()
+            if (provisioningName) {
+                args "--provisioning_name", provisioningName
+            }
+
             args "--filename", getProfileName()
             args "--output_path", getDestinationDir()
         }


### PR DESCRIPTION
## Description

Fastlane `sigh` tries to find a matching provisioning profile based on the `team_id` and `app_id` parameters. There could be multiple valid profiles matching these criteria and fastlane will by default download the first one it find. There is an option to download all matching profiles but I opted to not support this switch for now because this would mean the task has to generate multiple output files as well which would be a bigger change. There is another filter switch `--provisioning_name`. With this switch set, `sigh` tries to find a matching profile with exactly that name.

## Test-ability changes

The last patch added basic test setup for the `ImportProvisioningProfile` task class. This patch doubles down on it and provides a matrix test for all task input properties. It only checks the invocation of `fastlane`. So this is not a real integration test.

Changes
=======

![ADD] `provisioningName` property to `ImportProvisioningProfile`

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
