### PR TITLE
Add 'commitHash' property to UnityBuildPlayerTask

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/build/UnityBuildPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/UnityBuildPluginIntegrationSpec.groovy
@@ -127,6 +127,10 @@ class UnityBuildPluginIntegrationSpec extends UnityIntegrationSpec {
         "toolsVersion"        | "1.2.3"                                     | ""       | 'environment' | "toolsVersion="
         "toolsVersion"        | "3.2.1"                                     | ""       | 'properties'  | "toolsVersion="
         "toolsVersion"        | "2.1.3"                                     | "String" | 'extension'   | "toolsVersion="
+
+        "commitHash"          | "abcdefg"                                   | ""       | 'environment' | "commitHash="
+        "commitHash"          | "gfedcba"                                   | ""       | 'properties'  | "commitHash="
+        "commitHash"          | "1234567"                                   | "String" | 'extension'   | "commitHash="
         "outputDirectoryBase" | File.createTempDir("build", "export1").path | "File"   | 'extension'   | "outputPath="
 
         value = wrapValueBasedOnType(rawValue, type)
@@ -165,6 +169,8 @@ class UnityBuildPluginIntegrationSpec extends UnityIntegrationSpec {
         def extensionKey = 'unityBuild.defaultAppConfigName'
         def propertiesKey = 'unityBuild.defaultAppConfigName'
         def envKey = 'UNITY_BUILD_DEFAULT_APP_CONFIG_NAME'
+
+        envs.clear(envKey)
 
         if (location == "environment") {
             envs.set(envKey, value)

--- a/src/integrationTest/groovy/wooga/gradle/build/unity/tasks/UnityBuildPlayerTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/unity/tasks/UnityBuildPlayerTaskIntegrationSpec.groovy
@@ -91,6 +91,10 @@ class UnityBuildPlayerTaskIntegrationSpec extends UnityIntegrationSpec {
             result.standardOutput.contains("toolsVersion=${expectedToolsVersion}")
         }
 
+        if (expectedCommitHash) {
+            result.standardOutput.contains("commitHash=${expectedCommitHash}")
+        }
+
         result.standardOutput.contains("-executeMethod ${expectedExportMethod}")
         result.standardOutput.contains("version=${expectedVersion}")
         result.standardOutput.contains("outputPath=${new File(projectDir, expectedOutputPath).path}")
@@ -100,6 +104,7 @@ class UnityBuildPlayerTaskIntegrationSpec extends UnityIntegrationSpec {
         "exportMethodName"    | "method1"                         | 'String' | true
         "version"             | "1.0.0"                           | 'String' | true
         "toolsVersion"        | "1.0.0"                           | 'String' | true
+        "commitHash"          | "abcdef123456"                    | 'String' | true
         "outputDirectoryBase" | "build/customExport3"             | 'File'   | true
         "appConfigFile"       | "Assets/CustomConfigs/test.asset" | 'File'   | true
 
@@ -107,6 +112,7 @@ class UnityBuildPlayerTaskIntegrationSpec extends UnityIntegrationSpec {
 
         expectedVersion = (property == "version") ? rawValue : 'unspecified'
         expectedToolsVersion = (property == "toolsVersion") ? rawValue : null
+        expectedCommitHash = (property == "commitHash") ? rawValue : null
 
         expectedOutputDirectoryBase = (property == 'outputDirectoryBase') ? rawValue : "/build/export"
         expectedAppConfigFile = (property == 'appConfigFile') ? new File(rawValue) : new File("Assets/CustomConfigs/custom.asset")

--- a/src/main/groovy/wooga/gradle/build/unity/UnityBuildPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/UnityBuildPlugin.groovy
@@ -61,6 +61,7 @@ class UnityBuildPlugin implements Plugin<Project> {
             void execute(UnityBuildPlayerTask task) {
                 task.exportMethodName.set(extension.exportMethodName)
                 task.toolsVersion.set(extension.toolsVersion)
+                task.commitHash.set(extension.commitHash)
                 task.outputDirectoryBase.set(extension.outputDirectoryBase)
                 task.version.set(project.provider({PropertyUtils.convertToString(project.version)}))
                 task.inputFiles.from({

--- a/src/main/groovy/wooga/gradle/build/unity/UnityBuildPluginConsts.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/UnityBuildPluginConsts.groovy
@@ -76,6 +76,23 @@ class UnityBuildPluginConsts {
     static String BUILD_TOOLS_VERSION_ENV_VAR = "UNITY_BUILD_TOOLS_VERSION"
 
     /**
+     * Gradle property baseName to set the default value for {@code commitHash}.
+     *
+     * @value "unityBuild.commitHash"
+     * @see UnityBuildPluginExtension#getCommitHash()
+     */
+    static String BUILD_COMMIT_HASH_OPTION = "unityBuild.commitHash"
+
+    /**
+     * Environment variable to set the default value for {@code commitHash}.
+     *
+     * @value "unityBuild.commitHash"
+     * @see UnityBuildPluginExtension#getCommitHash()
+     */
+    static String BUILD_COMMIT_HASH_ENV_VAR = "UNITY_BUILD_COMMIT_HASH"
+
+
+    /**
      * Default name for the base export location.
      *
      * @value "export"

--- a/src/main/groovy/wooga/gradle/build/unity/UnityBuildPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/UnityBuildPluginExtension.groovy
@@ -27,6 +27,7 @@ interface UnityBuildPluginExtension<T extends UnityBuildPluginExtension> {
     DirectoryProperty getAppConfigsDirectory()
     DirectoryProperty getOutputDirectoryBase()
     Property<String> getToolsVersion()
+    Property<String> getCommitHash()
     Property<String> getExportMethodName()
     Property<String> getDefaultAppConfigName()
 

--- a/src/main/groovy/wooga/gradle/build/unity/internal/DefaultUnityBuildPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/internal/DefaultUnityBuildPluginExtension.groovy
@@ -37,6 +37,7 @@ class DefaultUnityBuildPluginExtension implements UnityBuildPluginExtension {
     final DirectoryProperty appConfigsDirectory
     final DirectoryProperty outputDirectoryBase
     final Property<String> toolsVersion
+    final Property<String> commitHash
     final Property<String> exportMethodName
     final Property<String> defaultAppConfigName
     final Provider<Directory> assetsDir
@@ -48,6 +49,7 @@ class DefaultUnityBuildPluginExtension implements UnityBuildPluginExtension {
         appConfigsDirectory = project.layout.directoryProperty()
         outputDirectoryBase = project.layout.directoryProperty()
         toolsVersion = project.objects.property(String.class)
+        commitHash = project.objects.property(String.class)
         exportMethodName = project.objects.property(String.class)
         defaultAppConfigName = project.objects.property(String.class)
         assetsDir = project.layout.directoryProperty()
@@ -66,6 +68,14 @@ class DefaultUnityBuildPluginExtension implements UnityBuildPluginExtension {
             String call() throws Exception {
                 System.getenv()[UnityBuildPluginConsts.DEFAULT_APP_CONFIG_NAME_ENV_VAR] ?:
                         project.properties.get(UnityBuildPluginConsts.DEFAULT_APP_CONFIG_NAME_OPTION)
+            }
+        }))
+
+        commitHash.set(project.provider(new Callable<String>() {
+            @Override
+            String call() throws Exception {
+                System.getenv().get(UnityBuildPluginConsts.BUILD_COMMIT_HASH_ENV_VAR) ?:
+                        project.properties.get(UnityBuildPluginConsts.BUILD_COMMIT_HASH_OPTION, null)
             }
         }))
 

--- a/src/main/groovy/wooga/gradle/build/unity/tasks/UnityBuildPlayerTask.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/tasks/UnityBuildPlayerTask.groovy
@@ -64,6 +64,10 @@ class UnityBuildPlayerTask extends AbstractUnityProjectTask {
     @Input
     final Property<String> toolsVersion
 
+    @Optional
+    @Input
+    final Property<String> commitHash
+
     @Input
     final Property<String> version
 
@@ -105,6 +109,7 @@ class UnityBuildPlayerTask extends AbstractUnityProjectTask {
 
         exportMethodName = project.objects.property(String.class)
         toolsVersion = project.objects.property(String.class)
+        commitHash = project.objects.property(String.class)
         version = project.objects.property(String.class)
     }
 
@@ -122,6 +127,10 @@ class UnityBuildPlayerTask extends AbstractUnityProjectTask {
 
         if (toolsVersion.present) {
             customArgs += "toolsVersion=${toolsVersion.get()}"
+        }
+
+        if (commitHash.present) {
+            customArgs += "commitHash=${commitHash.get()}"
         }
 
         args "-executeMethod", exportMethodName.get()


### PR DESCRIPTION
## Description

A long with the `toolsVersion` and gradle project version we want to know the current `commitHash` in Unity without quering git. This patch adds a new property `commitHash` to the
`UnityBuildPlayerTask` class. The property is configured similar as the `toolsVersion` property. There is a fallback to the `UNITY_BUILD_COMMIT_HASH` environment variable and `unityBuild.commitHash` gradle property

resolves: #43 

## Changes

* ![ADD] 'commitHash' property to `UnityBuildPlayerTask`


[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
