### PR TITLE
Improve iOS keychain task error messages

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/build/unity/ios/tasks/KeychainTaskSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/unity/ios/tasks/KeychainTaskSpec.groovy
@@ -97,4 +97,18 @@ class KeychainTaskSpec extends IntegrationSpec {
         then:
         result.wasUpToDate('buildKeychain')
     }
+
+    def "fails with security stderr printed to error log"() {
+        given: "wrong certificatePassphrase"
+        buildFile << """
+            iosBuild.certificatePassphrase = "randomPassphrase"
+        """.stripIndent()
+
+        when:
+        def result = runTasksWithFailure('buildKeychain')
+
+        then:
+        outputContains(result, "security: SecKeychainItemImport: MAC verification failed during PKCS12 import (wrong password?)")
+
+    }
 }

--- a/src/main/groovy/wooga/gradle/build/unity/ios/tasks/KeychainTask.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/tasks/KeychainTask.groovy
@@ -17,9 +17,11 @@
 
 package wooga.gradle.build.unity.ios.tasks
 
+import org.gradle.api.GradleScriptException
 import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.ConventionTask
 import org.gradle.api.tasks.*
+import org.gradle.process.internal.ExecException
 
 import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
@@ -162,10 +164,22 @@ class KeychainTask extends ConventionTask {
         logger.info("Run scurity tasks:")
         logger.info(commands.join("\n"))
 
-        project.exec {
+        def stdout = new ByteArrayOutputStream()
+        def stderr = new ByteArrayOutputStream()
+
+        def execResult = project.exec {
             executable "security"
             args "-i"
             standardInput = new ByteArrayInputStream(commands.join("\n").getBytes(StandardCharsets.UTF_8))
+            ignoreExitValue = true
+            standardOutput = stdout
+            errorOutput = stderr
+        }
+
+        logger.info(stdout.toString())
+        if (execResult.exitValue != 0) {
+            logger.error(stderr.toString())
+            throw new ExecException(stderr.toString())
         }
 
         def extension = getExtension()


### PR DESCRIPTION
## Description

The `buildKeychain` task for iOS projects uses the `security` commandline tool to setup a new keychain and import optional certificates. This operation is handled in the _interactive_ mode to
spawn only one `security` process. In case of an error we only show a message that `security` failed but not exactly what failed. I changed the task to register both `stderr` and `stdout` and print both to the gradle logger. In additon to this I also handle the exit value and throw a `ExecException` with the `stderr` string as message. This should result in a clearer error message. 

As an example. If the user provides a wrong certificate (.p12) passphrase the gradle process would end like:

```
FAILURE: Build failed with an exception.
* What went wrong:
Execution failed for task ':buildKeychain'.
> security: SecKeychainItemImport: MAC verification failed during PKCS12 import (wrong password?)
  import: returned 1
```

## Changes

* ![IMPROVE] ![IOS] keychain task error messages

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
