### PR TITLE
Add iOS adhoc support

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/build/IntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/IntegrationSpec.groovy
@@ -53,18 +53,20 @@ class IntegrationSpec extends nebula.test.IntegrationSpec{
 
     String wrapValueBasedOnType(Object rawValue, String type) {
         def value
+        def rawValueEscaped = String.isInstance(rawValue) ? "'${rawValue}'" : rawValue
+
         switch (type) {
             case "Closure":
-                value = "{'$rawValue'}"
+                value = "{$rawValueEscaped}"
                 break
             case "Callable":
-                value = "new java.util.concurrent.Callable<String>() {@Override String call() throws Exception { '$rawValue' }}"
+                value = "new java.util.concurrent.Callable<${rawValue.class.typeName}>() {@Override ${rawValue.class.typeName} call() throws Exception { $rawValueEscaped }}"
                 break
             case "Object":
-                value = "new Object() {@Override String toString() { '$rawValue' }}"
+                value = "new Object() {@Override String toString() { ${rawValueEscaped}.toString() }}"
                 break
             case "String":
-                value = "'$rawValue'"
+                value = "$rawValueEscaped"
                 break
             case "File":
                 value = "new File('${escapedPath(rawValue.toString())}')"

--- a/src/integrationTest/groovy/wooga/gradle/build/unity/ios/tasks/ImportProvisioningProfileSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/unity/ios/tasks/ImportProvisioningProfileSpec.groovy
@@ -17,6 +17,7 @@
 
 package wooga.gradle.build.unity.ios.tasks
 
+import spock.lang.Ignore
 import spock.lang.Issue
 import spock.lang.Requires
 import spock.lang.Unroll
@@ -81,6 +82,25 @@ class ImportProvisioningProfileSpec extends IntegrationSpec {
         taskToRun = "importProfiles"
     }
 
+    // Test fails with current implementation.
+    // When we switch to gradle provider API we can fix this usecase.
+    @Ignore()
+    def "task :#taskToRun accepts input #parameter is unset when not configured"() {
+        given: "task adhoc property is not configured"
+
+        when:
+        def result = runTasksSuccessfully(taskToRun)
+
+        then:
+        !outputContains(result, commandlineFlag)
+
+        where:
+        parameter | commandlineFlag
+        "adhoc"   | "--adhoc"
+
+        taskToRun = "importProfiles"
+    }
+
     @Unroll
     def "task :#taskToRun accepts input #parameter with #method and type #type"() {
         given: "task with configured properties"
@@ -94,7 +114,7 @@ class ImportProvisioningProfileSpec extends IntegrationSpec {
         def result = runTasksSuccessfully(taskToRun)
 
         then:
-        result.standardOutput.contains(expectedCommandlineSwitch.replace("#{value_path}", new File(projectDir, rawValue).path))
+        result.standardOutput.contains(expectedCommandlineSwitch.replace("#{value_path}", new File(projectDir, rawValue.toString()).path))
 
         where:
         parameter           | rawValue                | type       | useSetter | expectedCommandlineSwitchRaw
@@ -146,16 +166,29 @@ class ImportProvisioningProfileSpec extends IntegrationSpec {
         "provisioningName" | "profile_7"             | 'Object'   | true      | "--provisioning_name #{value}"
         "provisioningName" | "profile_8"             | 'Object'   | false     | "--provisioning_name #{value}"
 
-        "destinationDir"    | "build/out1"            | 'String'   | true      | "--output_path #{value_path}"
-        "destinationDir"    | "build/out2"            | 'String'   | false     | "--output_path #{value_path}"
-        "destinationDir"    | "build/out3"            | 'File'     | true      | "--output_path #{value_path}"
-        "destinationDir"    | "build/out4"            | 'File'     | false     | "--output_path #{value_path}"
-        "destinationDir"    | "build/out5"            | 'Closure'  | true      | "--output_path #{value_path}"
-        "destinationDir"    | "build/out6"            | 'Closure'  | false     | "--output_path #{value_path}"
+        "adhoc"            | true                    | 'Boolean'  | true      | "--adhoc true"
+        "adhoc"            | true                    | 'Boolean'  | false     | "--adhoc true"
+        "adhoc"            | true                    | 'Closure'  | true      | "--adhoc true"
+        "adhoc"            | true                    | 'Closure'  | false     | "--adhoc true"
+        "adhoc"            | true                    | 'Callable' | true      | "--adhoc true"
+        "adhoc"            | true                    | 'Callable' | false     | "--adhoc true"
+        "adhoc"            | false                   | 'Boolean'  | true      | "--adhoc false"
+        "adhoc"            | false                   | 'Boolean'  | false     | "--adhoc false"
+        "adhoc"            | false                   | 'Closure'  | true      | "--adhoc false"
+        "adhoc"            | false                   | 'Closure'  | false     | "--adhoc false"
+        "adhoc"            | false                   | 'Callable' | true      | "--adhoc false"
+        "adhoc"            | false                   | 'Callable' | false     | "--adhoc false"
+
+        "destinationDir"   | "build/out1"            | 'String'   | true      | "--output_path #{value_path}"
+        "destinationDir"   | "build/out2"            | 'String'   | false     | "--output_path #{value_path}"
+        "destinationDir"   | "build/out3"            | 'File'     | true      | "--output_path #{value_path}"
+        "destinationDir"   | "build/out4"            | 'File'     | false     | "--output_path #{value_path}"
+        "destinationDir"   | "build/out5"            | 'Closure'  | true      | "--output_path #{value_path}"
+        "destinationDir"   | "build/out6"            | 'Closure'  | false     | "--output_path #{value_path}"
 
         taskToRun = "importProfiles"
         value = wrapValueBasedOnType(rawValue, type)
         method = (useSetter) ? "set${parameter.capitalize()}" : parameter
-        expectedCommandlineSwitch = expectedCommandlineSwitchRaw.replace("#{value}", rawValue)
+        expectedCommandlineSwitch = expectedCommandlineSwitchRaw.replace("#{value}", rawValue.toString())
     }
 }

--- a/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPlugin.groovy
@@ -120,6 +120,7 @@ class IOSBuildPlugin implements Plugin<Project> {
                 conventionMapping.map("appIdentifier", { extension.getAppIdentifier() })
                 conventionMapping.map("destinationDir", { task.getTemporaryDir() })
                 conventionMapping.map("provisioningName", { extension.getProvisioningName() })
+                conventionMapping.map("adhoc", { extension.getAdhoc() })
                 conventionMapping.map("profileName", { 'signing.mobileprovision' })
             }
         })

--- a/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginExtension.groovy
@@ -58,4 +58,8 @@ interface IOSBuildPluginExtension {
     void setProvisioningName(String provisioningName)
     IOSBuildPluginExtension provisioningName(String provisioningName)
 
+    Boolean getAdhoc()
+    void setAdhoc(Boolean value)
+    IOSBuildPluginExtension adhoc(Boolean value)
+
 }

--- a/src/main/groovy/wooga/gradle/build/unity/ios/internal/DefaultIOSBuildPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/internal/DefaultIOSBuildPluginExtension.groovy
@@ -32,6 +32,7 @@ class DefaultIOSBuildPluginExtension implements IOSBuildPluginExtension {
     private String scheme
     private String configuration
     private String provisioningName
+    private Boolean adhoc
 
     @Override
     org.gradle.api.credentials.PasswordCredentials getFastlaneCredentials() {
@@ -173,6 +174,22 @@ class DefaultIOSBuildPluginExtension implements IOSBuildPluginExtension {
     IOSBuildPluginExtension provisioningName(String provisioningName) {
         setProvisioningName(provisioningName)
         this
+    }
+
+    @Override
+    Boolean getAdhoc() {
+        return adhoc
+    }
+
+    @Override
+    void setAdhoc(Boolean value) {
+        adhoc = value
+    }
+
+    @Override
+    IOSBuildPluginExtension adhoc(Boolean value) {
+        setAdhoc(value)
+        return this
     }
 
     DefaultIOSBuildPluginExtension() {

--- a/src/main/groovy/wooga/gradle/build/unity/ios/tasks/ImportProvisioningProfile.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/tasks/ImportProvisioningProfile.groovy
@@ -131,6 +131,23 @@ class ImportProvisioningProfile extends ConventionTask {
         this
     }
 
+    private Object adhoc
+
+    @Optional
+    @Input
+    Boolean getAdhoc() {
+        convertToBoolean(adhoc)
+    }
+
+    void setAdhoc(Object value) {
+        adhoc = value
+    }
+
+    ImportProvisioningProfile adhoc(Object value) {
+        setAdhoc(value)
+        this
+    }
+
 
     private Object destinationDir
 
@@ -215,9 +232,22 @@ class ImportProvisioningProfile extends ConventionTask {
                 args "--provisioning_name", provisioningName
             }
 
+            args "--adhoc", getAdhoc().toString()
             args "--filename", getProfileName()
             args "--output_path", getDestinationDir()
         }
+    }
+
+    private static Boolean convertToBoolean(Object value) {
+        if (!value) {
+            return false
+        }
+
+        if (value instanceof Callable) {
+            value = ((Callable) value).call()
+        }
+
+        value
     }
 
     private static String convertToString(Object value) {


### PR DESCRIPTION
## Description

To import _adhoc_ provisioning profiles with `fastlane` correctly in case of _adhoc_ builds we need to tell fastlane that we want an _adhoc_ profile. Fastlane will fail and try to generate a _store_ or _enterprise_ profile instead.

This patch adds a new property `adhoc` to `ImportProvisioningProfile` and `IOSBuildPluginExtension` which will pass this information over to fastlane. It would had been possible to set `SIGH_AD_HOC` to make this clearer in both useage and output.

## Be aware!

Because of the nature of boolean values (true/false there is no notion of not set) this new logic will always set the `--adhoc` field. When we swich to the gradle provider API this issue will be fixed since a gradle property has the information of `present` or not. This also means that the environment variable `SIGH_AD_HOC` will have no effect anymore.

## Changes

* ![ADD] ![IOS] `adhoc` support

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
