### PR TITLE
Refactor external build cache setup and configuration

### DIFF
--- a/docs/api/index-all.html
+++ b/docs/api/index-all.html
@@ -135,6 +135,12 @@ if (location.href.indexOf('is-external=true') == -1) {
 </dt><dd> <div class="block"></div></dd>
 <dt><span class="strong"><a href="wooga/gradle/build/unity/ios/internal/utils/SecurityUtil.html#addKeychains(Iterable<File>)" title="Method in SecurityUtil">addKeychains(Iterable&lt;File&gt;)</a></span> - Method in <a href="wooga/gradle/build/unity/ios/internal/utils/SecurityUtil.html">SecurityUtil</a>
 </dt><dd> <div class="block"></div></dd>
+<dt><span class="strong"><a href="wooga/gradle/build/unity/ios/internal/DefaultIOSBuildPluginExtension.html#adhoc(java.lang.Boolean)" title="Method in DefaultIOSBuildPluginExtension">adhoc(Boolean)</a></span> - Method in <a href="wooga/gradle/build/unity/ios/internal/DefaultIOSBuildPluginExtension.html">DefaultIOSBuildPluginExtension</a>
+</dt><dd> <div class="block"></div></dd>
+<dt><span class="strong"><a href="wooga/gradle/build/unity/ios/tasks/ImportProvisioningProfile.html#adhoc(java.lang.Object)" title="Method in ImportProvisioningProfile">adhoc(Object)</a></span> - Method in <a href="wooga/gradle/build/unity/ios/tasks/ImportProvisioningProfile.html">ImportProvisioningProfile</a>
+</dt><dd> <div class="block"></div></dd>
+<dt><span class="strong"><a href="wooga/gradle/build/unity/ios/IOSBuildPluginExtension.html#adhoc(java.lang.Boolean)" title="Method in IOSBuildPluginExtension">adhoc(Boolean)</a></span> - Method in <a href="wooga/gradle/build/unity/ios/IOSBuildPluginExtension.html">IOSBuildPluginExtension</a>
+</dt><dd> <div class="block"></div></dd>
 <dt><span class="strong"><a href="wooga/gradle/build/unity/ios/internal/utils/SecurityUtil.html#allKeychainsAdded(Iterable<File>)" title="Method in SecurityUtil">allKeychainsAdded(Iterable&lt;File&gt;)</a></span> - Method in <a href="wooga/gradle/build/unity/ios/internal/utils/SecurityUtil.html">SecurityUtil</a>
 </dt><dd> <div class="block"></div></dd>
 <dt><span class="strong"><a href="wooga/gradle/build/unity/ios/tasks/XCodeArchiveTask.html#appendix(java.lang.String)" title="Method in XCodeArchiveTask">appendix(String)</a></span> - Method in <a href="wooga/gradle/build/unity/ios/tasks/XCodeArchiveTask.html">XCodeArchiveTask</a>
@@ -275,6 +281,12 @@ if (location.href.indexOf('is-external=true') == -1) {
 </dt><dd> <div class="block"></div></dd>
 <dt><span class="strong"><a href="wooga/gradle/build/unity/ios/tasks/LockKeychainTask.html#getAction()" title="Method in LockKeychainTask">getAction()</a></span> - Method in <a href="wooga/gradle/build/unity/ios/tasks/LockKeychainTask.html">LockKeychainTask</a>
 </dt><dd> <div class="block"></div></dd>
+<dt><span class="strong"><a href="wooga/gradle/build/unity/ios/internal/DefaultIOSBuildPluginExtension.html#getAdhoc()" title="Method in DefaultIOSBuildPluginExtension">getAdhoc()</a></span> - Method in <a href="wooga/gradle/build/unity/ios/internal/DefaultIOSBuildPluginExtension.html">DefaultIOSBuildPluginExtension</a>
+</dt><dd> <div class="block"></div></dd>
+<dt><span class="strong"><a href="wooga/gradle/build/unity/ios/tasks/ImportProvisioningProfile.html#getAdhoc()" title="Method in ImportProvisioningProfile">getAdhoc()</a></span> - Method in <a href="wooga/gradle/build/unity/ios/tasks/ImportProvisioningProfile.html">ImportProvisioningProfile</a>
+</dt><dd> <div class="block"></div></dd>
+<dt><span class="strong"><a href="wooga/gradle/build/unity/ios/IOSBuildPluginExtension.html#getAdhoc()" title="Method in IOSBuildPluginExtension">getAdhoc()</a></span> - Method in <a href="wooga/gradle/build/unity/ios/IOSBuildPluginExtension.html">IOSBuildPluginExtension</a>
+</dt><dd> <div class="block"></div></dd>
 <dt><span class="strong"><a href="wooga/gradle/build/unity/tasks/UnityBuildPlayerTask.html#getAppConfig()" title="Method in UnityBuildPlayerTask">getAppConfig()</a></span> - Method in <a href="wooga/gradle/build/unity/tasks/UnityBuildPlayerTask.html">UnityBuildPlayerTask</a>
 </dt><dd> <div class="block"></div></dd>
 <dt><span class="strong"><a href="wooga/gradle/build/unity/internal/DefaultUnityBuildPluginExtension.html#getAppConfigs()" title="Method in DefaultUnityBuildPluginExtension">getAppConfigs()</a></span> - Method in <a href="wooga/gradle/build/unity/internal/DefaultUnityBuildPluginExtension.html">DefaultUnityBuildPluginExtension</a>
@@ -315,6 +327,10 @@ if (location.href.indexOf('is-external=true') == -1) {
 </dt><dd> <div class="block"></div></dd>
 <dt><span class="strong"><a href="wooga/gradle/build/unity/ios/tasks/XCodeArchiveTask.html#getClean()" title="Method in XCodeArchiveTask">getClean()</a></span> - Method in <a href="wooga/gradle/build/unity/ios/tasks/XCodeArchiveTask.html">XCodeArchiveTask</a>
 </dt><dd> <div class="block"></div></dd>
+<dt><span class="strong"><a href="wooga/gradle/build/unity/UnityBuildPluginExtension.html#getCleanBuildDirBeforeBuild()" title="Method in UnityBuildPluginExtension">getCleanBuildDirBeforeBuild()</a></span> - Method in <a href="wooga/gradle/build/unity/UnityBuildPluginExtension.html">UnityBuildPluginExtension</a>
+</dt><dd> <div class="block"></div></dd>
+<dt><span class="strong"><a href="wooga/gradle/build/unity/UnityBuildPluginExtension.html#getCommitHash()" title="Method in UnityBuildPluginExtension">getCommitHash()</a></span> - Method in <a href="wooga/gradle/build/unity/UnityBuildPluginExtension.html">UnityBuildPluginExtension</a>
+</dt><dd> <div class="block"></div></dd>
 <dt><span class="strong"><a href="wooga/gradle/build/unity/ios/internal/DefaultIOSBuildPluginExtension.html#getConfiguration()" title="Method in DefaultIOSBuildPluginExtension">getConfiguration()</a></span> - Method in <a href="wooga/gradle/build/unity/ios/internal/DefaultIOSBuildPluginExtension.html">DefaultIOSBuildPluginExtension</a>
 </dt><dd> <div class="block"></div></dd>
 <dt><span class="strong"><a href="wooga/gradle/build/unity/ios/IOSBuildPluginExtension.html#getConfiguration()" title="Method in IOSBuildPluginExtension">getConfiguration()</a></span> - Method in <a href="wooga/gradle/build/unity/ios/IOSBuildPluginExtension.html">IOSBuildPluginExtension</a>
@@ -328,6 +344,10 @@ if (location.href.indexOf('is-external=true') == -1) {
 <dt><span class="strong"><a href="wooga/gradle/build/unity/ios/tasks/KeychainTask.html#getDestinationDir()" title="Method in KeychainTask">getDestinationDir()</a></span> - Method in <a href="wooga/gradle/build/unity/ios/tasks/KeychainTask.html">KeychainTask</a>
 </dt><dd> <div class="block"></div></dd>
 <dt><span class="strong"><a href="wooga/gradle/build/unity/ios/tasks/XCodeArchiveTask.html#getDestinationDir()" title="Method in XCodeArchiveTask">getDestinationDir()</a></span> - Method in <a href="wooga/gradle/build/unity/ios/tasks/XCodeArchiveTask.html">XCodeArchiveTask</a>
+</dt><dd> <div class="block"></div></dd>
+<dt><span class="strong"><a href="wooga/gradle/build/unity/UnityBuildPluginExtension.html#getExportBuildDirBase()" title="Method in UnityBuildPluginExtension">getExportBuildDirBase()</a></span> - Method in <a href="wooga/gradle/build/unity/UnityBuildPluginExtension.html">UnityBuildPluginExtension</a>
+</dt><dd> <div class="block"></div></dd>
+<dt><span class="strong"><a href="wooga/gradle/build/unity/UnityBuildPluginExtension.html#getExportInitScript()" title="Method in UnityBuildPluginExtension">getExportInitScript()</a></span> - Method in <a href="wooga/gradle/build/unity/UnityBuildPluginExtension.html">UnityBuildPluginExtension</a>
 </dt><dd> <div class="block"></div></dd>
 <dt><span class="strong"><a href="wooga/gradle/build/unity/UnityBuildPluginExtension.html#getExportMethodName()" title="Method in UnityBuildPluginExtension">getExportMethodName()</a></span> - Method in <a href="wooga/gradle/build/unity/UnityBuildPluginExtension.html">UnityBuildPluginExtension</a>
 </dt><dd> <div class="block"></div></dd>
@@ -379,6 +399,12 @@ if (location.href.indexOf('is-external=true') == -1) {
 </dt><dd> <div class="block"></div></dd>
 <dt><span class="strong"><a href="wooga/gradle/build/unity/ios/tasks/XCodeArchiveTask.html#getProjectPath()" title="Method in XCodeArchiveTask">getProjectPath()</a></span> - Method in <a href="wooga/gradle/build/unity/ios/tasks/XCodeArchiveTask.html">XCodeArchiveTask</a>
 </dt><dd> <div class="block"></div></dd>
+<dt><span class="strong"><a href="wooga/gradle/build/unity/ios/internal/DefaultIOSBuildPluginExtension.html#getProvisioningName()" title="Method in DefaultIOSBuildPluginExtension">getProvisioningName()</a></span> - Method in <a href="wooga/gradle/build/unity/ios/internal/DefaultIOSBuildPluginExtension.html">DefaultIOSBuildPluginExtension</a>
+</dt><dd> <div class="block"></div></dd>
+<dt><span class="strong"><a href="wooga/gradle/build/unity/ios/tasks/ImportProvisioningProfile.html#getProvisioningName()" title="Method in ImportProvisioningProfile">getProvisioningName()</a></span> - Method in <a href="wooga/gradle/build/unity/ios/tasks/ImportProvisioningProfile.html">ImportProvisioningProfile</a>
+</dt><dd> <div class="block"></div></dd>
+<dt><span class="strong"><a href="wooga/gradle/build/unity/ios/IOSBuildPluginExtension.html#getProvisioningName()" title="Method in IOSBuildPluginExtension">getProvisioningName()</a></span> - Method in <a href="wooga/gradle/build/unity/ios/IOSBuildPluginExtension.html">IOSBuildPluginExtension</a>
+</dt><dd> <div class="block"></div></dd>
 <dt><span class="strong"><a href="wooga/gradle/build/unity/ios/tasks/XCodeArchiveTask.html#getProvisioningProfile()" title="Method in XCodeArchiveTask">getProvisioningProfile()</a></span> - Method in <a href="wooga/gradle/build/unity/ios/tasks/XCodeArchiveTask.html">XCodeArchiveTask</a>
 </dt><dd> <div class="block"></div></dd>
 <dt><span class="strong"><a href="wooga/gradle/build/unity/ios/internal/DefaultIOSBuildPluginExtension.html#getScheme()" title="Method in DefaultIOSBuildPluginExtension">getScheme()</a></span> - Method in <a href="wooga/gradle/build/unity/ios/internal/DefaultIOSBuildPluginExtension.html">DefaultIOSBuildPluginExtension</a>
@@ -407,6 +433,8 @@ if (location.href.indexOf('is-external=true') == -1) {
 </dt><dd> <div class="block"></div></dd>
 <dt><span class="strong"><a href="wooga/gradle/build/unity/tasks/GradleBuild.html" title="Class in wooga.gradle.build.unity.tasks">GradleBuild</a></span> - Class in <a href="./wooga/gradle/build/unity/tasks/package-summary.html">wooga.gradle.build.unity.tasks</a>
 </dt><dd><div class="block"></div></dd>
+<dt><span class="strong"><a href="wooga/gradle/build/unity/tasks/GradleBuild.html#GradleBuild()" title="Constructor in GradleBuild">GradleBuild()</a></span> - Constructor in <a href="wooga/gradle/build/unity/tasks/GradleBuild.html">GradleBuild</a>
+</dt><dd> <div class="block"></div></dd>
 </dl>
 
     
@@ -540,6 +568,12 @@ if (location.href.indexOf('is-external=true') == -1) {
 </dt><dd> <div class="block"></div></dd>
 <dt><span class="strong"><a href="wooga/gradle/build/unity/ios/internal/utils/PropertyUtils.html" title="Class in wooga.gradle.build.unity.ios.internal.utils">PropertyUtils</a></span> - Class in <a href="./wooga/gradle/build/unity/ios/internal/utils/package-summary.html">wooga.gradle.build.unity.ios.internal.utils</a>
 </dt><dd><div class="block"></div></dd>
+<dt><span class="strong"><a href="wooga/gradle/build/unity/ios/internal/DefaultIOSBuildPluginExtension.html#provisioningName(java.lang.String)" title="Method in DefaultIOSBuildPluginExtension">provisioningName(String)</a></span> - Method in <a href="wooga/gradle/build/unity/ios/internal/DefaultIOSBuildPluginExtension.html">DefaultIOSBuildPluginExtension</a>
+</dt><dd> <div class="block"></div></dd>
+<dt><span class="strong"><a href="wooga/gradle/build/unity/ios/tasks/ImportProvisioningProfile.html#provisioningName(java.lang.Object)" title="Method in ImportProvisioningProfile">provisioningName(Object)</a></span> - Method in <a href="wooga/gradle/build/unity/ios/tasks/ImportProvisioningProfile.html">ImportProvisioningProfile</a>
+</dt><dd> <div class="block"></div></dd>
+<dt><span class="strong"><a href="wooga/gradle/build/unity/ios/IOSBuildPluginExtension.html#provisioningName(java.lang.String)" title="Method in IOSBuildPluginExtension">provisioningName(String)</a></span> - Method in <a href="wooga/gradle/build/unity/ios/IOSBuildPluginExtension.html">IOSBuildPluginExtension</a>
+</dt><dd> <div class="block"></div></dd>
 <dt><span class="strong"><a href="wooga/gradle/build/unity/ios/tasks/XCodeArchiveTask.html#provisioningProfile(java.lang.Object)" title="Method in XCodeArchiveTask">provisioningProfile(Object)</a></span> - Method in <a href="wooga/gradle/build/unity/ios/tasks/XCodeArchiveTask.html">XCodeArchiveTask</a>
 </dt><dd> <div class="block"></div></dd>
 </dl>
@@ -584,6 +618,12 @@ if (location.href.indexOf('is-external=true') == -1) {
 <dt><span class="strong"><a href="wooga/gradle/build/unity/ios/KeychainLookupList.html#set(int, java.io.File)" title="Method in KeychainLookupList">set(int, File)</a></span> - Method in <a href="wooga/gradle/build/unity/ios/KeychainLookupList.html">KeychainLookupList</a>
 </dt><dd> <div class="block"></div></dd>
 <dt><span class="strong"><a href="wooga/gradle/build/unity/ios/tasks/ListKeychainTask.html#setAction(java.lang.Object)" title="Method in ListKeychainTask">setAction(Object)</a></span> - Method in <a href="wooga/gradle/build/unity/ios/tasks/ListKeychainTask.html">ListKeychainTask</a>
+</dt><dd> <div class="block"></div></dd>
+<dt><span class="strong"><a href="wooga/gradle/build/unity/ios/internal/DefaultIOSBuildPluginExtension.html#setAdhoc(java.lang.Boolean)" title="Method in DefaultIOSBuildPluginExtension">setAdhoc(Boolean)</a></span> - Method in <a href="wooga/gradle/build/unity/ios/internal/DefaultIOSBuildPluginExtension.html">DefaultIOSBuildPluginExtension</a>
+</dt><dd> <div class="block"></div></dd>
+<dt><span class="strong"><a href="wooga/gradle/build/unity/ios/tasks/ImportProvisioningProfile.html#setAdhoc(java.lang.Object)" title="Method in ImportProvisioningProfile">setAdhoc(Object)</a></span> - Method in <a href="wooga/gradle/build/unity/ios/tasks/ImportProvisioningProfile.html">ImportProvisioningProfile</a>
+</dt><dd> <div class="block"></div></dd>
+<dt><span class="strong"><a href="wooga/gradle/build/unity/ios/IOSBuildPluginExtension.html#setAdhoc(java.lang.Boolean)" title="Method in IOSBuildPluginExtension">setAdhoc(Boolean)</a></span> - Method in <a href="wooga/gradle/build/unity/ios/IOSBuildPluginExtension.html">IOSBuildPluginExtension</a>
 </dt><dd> <div class="block"></div></dd>
 <dt><span class="strong"><a href="wooga/gradle/build/unity/ios/tasks/XCodeArchiveTask.html#setAppendix(java.lang.String)" title="Method in XCodeArchiveTask">setAppendix(String)</a></span> - Method in <a href="wooga/gradle/build/unity/ios/tasks/XCodeArchiveTask.html">XCodeArchiveTask</a>
 </dt><dd> <div class="block"></div></dd>
@@ -650,6 +690,12 @@ if (location.href.indexOf('is-external=true') == -1) {
 <dt><span class="strong"><a href="wooga/gradle/build/unity/ios/tasks/ImportProvisioningProfile.html#setProfileName(java.lang.String)" title="Method in ImportProvisioningProfile">setProfileName(String)</a></span> - Method in <a href="wooga/gradle/build/unity/ios/tasks/ImportProvisioningProfile.html">ImportProvisioningProfile</a>
 </dt><dd> <div class="block"></div></dd>
 <dt><span class="strong"><a href="wooga/gradle/build/unity/ios/tasks/XCodeArchiveTask.html#setProjectPath(java.lang.Object)" title="Method in XCodeArchiveTask">setProjectPath(Object)</a></span> - Method in <a href="wooga/gradle/build/unity/ios/tasks/XCodeArchiveTask.html">XCodeArchiveTask</a>
+</dt><dd> <div class="block"></div></dd>
+<dt><span class="strong"><a href="wooga/gradle/build/unity/ios/internal/DefaultIOSBuildPluginExtension.html#setProvisioningName(java.lang.String)" title="Method in DefaultIOSBuildPluginExtension">setProvisioningName(String)</a></span> - Method in <a href="wooga/gradle/build/unity/ios/internal/DefaultIOSBuildPluginExtension.html">DefaultIOSBuildPluginExtension</a>
+</dt><dd> <div class="block"></div></dd>
+<dt><span class="strong"><a href="wooga/gradle/build/unity/ios/tasks/ImportProvisioningProfile.html#setProvisioningName(java.lang.Object)" title="Method in ImportProvisioningProfile">setProvisioningName(Object)</a></span> - Method in <a href="wooga/gradle/build/unity/ios/tasks/ImportProvisioningProfile.html">ImportProvisioningProfile</a>
+</dt><dd> <div class="block"></div></dd>
+<dt><span class="strong"><a href="wooga/gradle/build/unity/ios/IOSBuildPluginExtension.html#setProvisioningName(java.lang.String)" title="Method in IOSBuildPluginExtension">setProvisioningName(String)</a></span> - Method in <a href="wooga/gradle/build/unity/ios/IOSBuildPluginExtension.html">IOSBuildPluginExtension</a>
 </dt><dd> <div class="block"></div></dd>
 <dt><span class="strong"><a href="wooga/gradle/build/unity/ios/tasks/XCodeArchiveTask.html#setProvisioningProfile(java.lang.Object)" title="Method in XCodeArchiveTask">setProvisioningProfile(Object)</a></span> - Method in <a href="wooga/gradle/build/unity/ios/tasks/XCodeArchiveTask.html">XCodeArchiveTask</a>
 </dt><dd> <div class="block"></div></dd>

--- a/src/main/groovy/wooga/gradle/build/unity/UnityBuildPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/UnityBuildPlugin.groovy
@@ -152,6 +152,7 @@ class UnityBuildPlugin implements Plugin<Project> {
                         t.dir.set(exportTask.outputDirectory)
                         t.initScript.set(extension.exportInitScript)
                         t.buildDirBase.set(extension.exportBuildDirBase)
+                        t.cleanBuildDirBeforeBuild.set(extension.cleanBuildDirBeforeBuild)
                         t.tasks.add(taskName)
                         t.gradleVersion.set(project.provider({
                             if (!config.isValid()) {

--- a/src/main/groovy/wooga/gradle/build/unity/UnityBuildPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/UnityBuildPlugin.groovy
@@ -144,23 +144,14 @@ class UnityBuildPlugin implements Plugin<Project> {
                     t.appConfigFile.set(appConfig)
                 } as UnityBuildPlayerTask
 
-                FileCollection exportInitScripts = project.fileTree(project.projectDir) {
-                    it.include('exportInit.gradle')
-                }
-                List<String> args = []
-                args << "-Pexport.buildDirBase=../buildCache" << "--project-cache-dir=../buildCache/.gradle"
-
-                if (exportInitScripts.size() > 0) {
-                    args << "--init-script=${exportInitScripts.files.first().path}".toString()
-                }
-
                 [baseLifecycleTaskNames, baseLifecycleTaskGroups].transpose().each { String taskName, String groupName ->
                     def gradleBuild = project.tasks.create("${taskName}${baseName.capitalize()}", GradleBuild) { GradleBuild t ->
                         t.dependsOn exportTask
                         t.group = groupName
                         t.description = "executes :${taskName} task on exported project for app config ${appConfigName}"
                         t.dir.set(exportTask.outputDirectory)
-                        t.buildArguments.set(args)
+                        t.initScript.set(extension.exportInitScript)
+                        t.buildDirBase.set(extension.exportBuildDirBase)
                         t.tasks.add(taskName)
                         t.gradleVersion.set(project.provider({
                             if (!config.isValid()) {

--- a/src/main/groovy/wooga/gradle/build/unity/UnityBuildPluginConsts.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/UnityBuildPluginConsts.groovy
@@ -86,10 +86,58 @@ class UnityBuildPluginConsts {
     /**
      * Environment variable to set the default value for {@code commitHash}.
      *
-     * @value "unityBuild.commitHash"
+     * @value "UNITY_BUILD_COMMIT_HASH"
      * @see UnityBuildPluginExtension#getCommitHash()
      */
     static String BUILD_COMMIT_HASH_ENV_VAR = "UNITY_BUILD_COMMIT_HASH"
+
+    /**
+     * Environment variable to set the default value for {@code exportBuildDirBase}.
+     *
+     * @value "UNITY_BUILD_EXPORT_BUILD_DIR_BASE"
+     * @see UnityBuildPluginExtension#getExportBuildDirBase()
+     */
+    static String EXPORT_BUILD_DIR_BASE_ENV_VAR = "UNITY_BUILD_EXPORT_BUILD_DIR_BASE"
+
+    /**
+     * Gradle property baseName to set the default value for {@code exportBuildDirBase}.
+     *
+     * @value "unityBuild.exportBuildDirBase"
+     * @see UnityBuildPluginExtension#getExportBuildDirBase()
+     */
+    static String EXPORT_BUILD_DIR_BASE_OPTION = "unityBuild.exportBuildDirBase"
+
+    /**
+     * Gradle property baseName to set the default value for {@code exportInitScript}.
+     *
+     * @value "unityBuild.exportInitScript"
+     * @see UnityBuildPluginExtension#getExportInitScript()
+     */
+    static String EXPORT_INIT_SCRIPT_OPTION = "unityBuild.exportInitScript"
+
+    /**
+     * Environment variable to set the default value for {@code exportInitScript}.
+     *
+     * @value "UNITY_BUILD_EXPORT_INIT_SCRIPT"
+     * @see UnityBuildPluginExtension#getExportInitScript()
+     */
+    static String EXPORT_INIT_SCRIPT_ENV_VAR = "UNITY_BUILD_EXPORT_INIT_SCRIPT"
+
+    /**
+     * Gradle property baseName to set the default value for {@code cleanBuildDirBeforeBuild}.
+     *
+     * @value "unityBuild.cleanBuildDirBeforeBuild"
+     * @see UnityBuildPluginExtension#getCleanBuildDirBeforeBuild()
+     */
+    static String CLEAN_BUILD_DIR_BEFORE_BUILD_OPTION = "unityBuild.cleanBuildDirBeforeBuild"
+
+    /**
+     * Environment variable to set the default value for {@code cleanBuildDirBeforeBuild}.
+     *
+     * @value "UNITY_BUILD_CLEAN_BUILD_DIR_BEFORE_BUILD"
+     * @see UnityBuildPluginExtension#getCleanBuildDirBeforeBuild()
+     */
+    static String CLEAN_BUILD_DIR_BEFORE_BUILD_ENV_VAR = "UNITY_BUILD_CLEAN_BUILD_DIR_BEFORE_BUILD"
 
 
     /**

--- a/src/main/groovy/wooga/gradle/build/unity/UnityBuildPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/UnityBuildPluginExtension.groovy
@@ -20,6 +20,7 @@ package wooga.gradle.build.unity
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileCollection
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 
 interface UnityBuildPluginExtension<T extends UnityBuildPluginExtension> {
@@ -30,7 +31,9 @@ interface UnityBuildPluginExtension<T extends UnityBuildPluginExtension> {
     Property<String> getCommitHash()
     Property<String> getExportMethodName()
     Property<String> getDefaultAppConfigName()
-
+    RegularFileProperty getExportInitScript()
+    DirectoryProperty getExportBuildDirBase()
+    Property<Boolean> getCleanBuildDirBeforeBuild()
     FileCollection getAppConfigs()
 
     ConfigurableFileCollection getIgnoreFilesForExportUpToDateCheck()

--- a/src/main/groovy/wooga/gradle/build/unity/UnityBuildPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/UnityBuildPluginExtension.groovy
@@ -32,7 +32,7 @@ interface UnityBuildPluginExtension<T extends UnityBuildPluginExtension> {
     Property<String> getExportMethodName()
     Property<String> getDefaultAppConfigName()
     RegularFileProperty getExportInitScript()
-    DirectoryProperty getExportBuildDirBase()
+    Property<File> getExportBuildDirBase()
     Property<Boolean> getCleanBuildDirBeforeBuild()
     FileCollection getAppConfigs()
 

--- a/src/main/groovy/wooga/gradle/build/unity/internal/DefaultUnityBuildPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/internal/DefaultUnityBuildPluginExtension.groovy
@@ -45,7 +45,7 @@ class DefaultUnityBuildPluginExtension implements UnityBuildPluginExtension {
     final Provider<Directory> assetsDir
     final ConfigurableFileCollection ignoreFilesForExportUpToDateCheck
     final RegularFileProperty exportInitScript
-    final DirectoryProperty exportBuildDirBase
+    final Property<File> exportBuildDirBase
     final Property<Boolean> cleanBuildDirBeforeBuild
 
     DefaultUnityBuildPluginExtension(final Project project) {
@@ -60,7 +60,7 @@ class DefaultUnityBuildPluginExtension implements UnityBuildPluginExtension {
         assetsDir = project.layout.directoryProperty()
         ignoreFilesForExportUpToDateCheck = project.layout.configurableFiles()
         exportInitScript = project.layout.fileProperty()
-        exportBuildDirBase = project.layout.directoryProperty()
+        exportBuildDirBase = project.objects.property(File)
         cleanBuildDirBeforeBuild = project.objects.property(Boolean)
 
         exportMethodName.set(project.provider(new Callable<String>() {

--- a/src/main/groovy/wooga/gradle/build/unity/internal/DefaultUnityBuildPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/internal/DefaultUnityBuildPluginExtension.groovy
@@ -22,6 +22,8 @@ import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileCollection
+import org.gradle.api.file.RegularFile
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import wooga.gradle.build.unity.UnityBuildPluginConsts
@@ -42,6 +44,9 @@ class DefaultUnityBuildPluginExtension implements UnityBuildPluginExtension {
     final Property<String> defaultAppConfigName
     final Provider<Directory> assetsDir
     final ConfigurableFileCollection ignoreFilesForExportUpToDateCheck
+    final RegularFileProperty exportInitScript
+    final DirectoryProperty exportBuildDirBase
+    final Property<Boolean> cleanBuildDirBeforeBuild
 
     DefaultUnityBuildPluginExtension(final Project project) {
         this.project = project
@@ -54,6 +59,9 @@ class DefaultUnityBuildPluginExtension implements UnityBuildPluginExtension {
         defaultAppConfigName = project.objects.property(String.class)
         assetsDir = project.layout.directoryProperty()
         ignoreFilesForExportUpToDateCheck = project.layout.configurableFiles()
+        exportInitScript = project.layout.fileProperty()
+        exportBuildDirBase = project.layout.directoryProperty()
+        cleanBuildDirBeforeBuild = project.objects.property(Boolean)
 
         exportMethodName.set(project.provider(new Callable<String>() {
             @Override
@@ -97,6 +105,52 @@ class DefaultUnityBuildPluginExtension implements UnityBuildPluginExtension {
                 def assetDir = project.layout.directoryProperty()
                 assetDir.set(project.file(unity.assetsDir))
                 assetDir.get()
+            }
+        }))
+
+        exportInitScript.set(project.provider(new Callable<RegularFile>() {
+            @Override
+            RegularFile call() throws Exception {
+                String exportInitScriptPath = System.getenv().get(UnityBuildPluginConsts.EXPORT_INIT_SCRIPT_ENV_VAR) ?:
+                        project.properties.get(UnityBuildPluginConsts.EXPORT_INIT_SCRIPT_OPTION, null)
+
+                if (exportInitScriptPath) {
+                    def property = project.layout.fileProperty()
+                    property.set(new File(exportInitScriptPath))
+                    return property.get()
+                }
+                return null
+            }
+        }))
+
+        exportBuildDirBase.set(project.provider(new Callable<Directory>() {
+            @Override
+            Directory call() throws Exception {
+                String exportBuildDirBasePath = System.getenv().get(UnityBuildPluginConsts.EXPORT_BUILD_DIR_BASE_ENV_VAR) ?:
+                        project.properties.get(UnityBuildPluginConsts.EXPORT_BUILD_DIR_BASE_OPTION, null)
+
+                if (exportBuildDirBasePath) {
+                    def property = project.layout.directoryProperty()
+                    property.set(new File(exportBuildDirBasePath))
+                    return property.get()
+                }
+                return null
+            }
+        }))
+
+        cleanBuildDirBeforeBuild.set(project.provider(new Callable<Boolean>() {
+            @Override
+            Boolean call() throws Exception {
+                String rawValue = System.getenv().get(UnityBuildPluginConsts.CLEAN_BUILD_DIR_BEFORE_BUILD_ENV_VAR) ?:
+                        project.properties.get(UnityBuildPluginConsts.CLEAN_BUILD_DIR_BEFORE_BUILD_OPTION, null)
+
+                if(rawValue) {
+                    rawValue = rawValue.toString().toLowerCase()
+                    rawValue = (rawValue == "1" || rawValue == "yes") ? "true" : false
+                    return rawValue
+                }
+
+                return false
             }
         }))
     }

--- a/src/main/groovy/wooga/gradle/build/unity/tasks/GradleBuild.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/tasks/GradleBuild.groovy
@@ -80,9 +80,13 @@ class GradleBuild extends DefaultTask {
             def tempInitScript = new File(getTemporaryDir(), 'initScript.groovy')
             tempInitScript.text = ""
 
-            if (buildDirBase.isPresent() || cleanBuildDirBeforeBuild) {
+            if(initScript.isPresent()) {
+                tempInitScript << initScript.get().getAsFile().text
+            } else {
                 tempInitScript << getClass().getResource('/buildUnityExportInit.gradle').text
+            }
 
+            if (buildDirBase.isPresent() || cleanBuildDirBeforeBuild) {
                 if (buildDirBase.isPresent()) {
                     def buildBase = buildDirBase.get()
                     def projectCacheDir = projectCacheDir.get()
@@ -104,11 +108,6 @@ class GradleBuild extends DefaultTask {
                 if(cleanBuildDirBeforeBuild) {
                     args << "-Pexport.deleteBuildDirBeforeBuild=1"
                 }
-            }
-
-            if (initScript.isPresent()) {
-                tempInitScript << getClass().getResource('/exportMarker.gradle').text
-                tempInitScript << initScript.get().getAsFile().text
             }
 
             args << "--init-script=${tempInitScript.getPath()}".toString()

--- a/src/main/resources/buildUnityExportInit.gradle
+++ b/src/main/resources/buildUnityExportInit.gradle
@@ -1,0 +1,21 @@
+println "------------------------------------------------------------"
+println "               BUILD UNITY EXPORT INIT SCRIPT               "
+println "------------------------------------------------------------"
+
+projectsLoaded {
+    def buildDirBase = rootProject.file(rootProject.properties.get("export.buildDirBase", rootProject.projectDir))
+    Boolean cleanBuildDirBeforeBuild = rootProject.properties.get("export.deleteBuildDirBeforeBuild", "0") == "1"
+
+    allprojects(new Action<Project>() {
+        @Override
+        void execute(Project project) {
+            def newBuildPath = new File(buildDirBase, "${project.path.replace(':','/')}/build")
+            println("set buildDir for project ${project.name} to $newBuildPath")
+            project.buildDir = newBuildPath
+            if(cleanBuildDirBeforeBuild) {
+                println("Delete buildDir: ${project.buildDir.path}")
+                project.buildDir.deleteDir()
+            }
+        }
+    })
+}

--- a/src/main/resources/exportMarker.gradle
+++ b/src/main/resources/exportMarker.gradle
@@ -1,0 +1,6 @@
+
+println "------------------------------------------------------------"
+println "               BUILD UNITY EXPORT INIT SCRIPT               "
+println "                                                            "
+println "                   START PROVIDED SCRIPT                    "
+println "------------------------------------------------------------"

--- a/src/main/resources/exportMarker.gradle
+++ b/src/main/resources/exportMarker.gradle
@@ -1,6 +1,0 @@
-
-println "------------------------------------------------------------"
-println "               BUILD UNITY EXPORT INIT SCRIPT               "
-println "                                                            "
-println "                   START PROVIDED SCRIPT                    "
-println "------------------------------------------------------------"


### PR DESCRIPTION
## Description

Exporting and building an exported gradle project from unity will at the moment move the `build` directory of all projects of the exported project to a custom location. As an example:

_a project exported to `build/export/ios/project`_ will have its gradle cache dir and build dir set to `build/export/ios/buildCache`.

This was achieved by loading a gradle init script from the current project directory named `exportInit.gradle`. This script needed the following content and was *not* part of this plugin:

```groovy
println "------------------------------------------------------------"
println "                        INIT                                "
println "------------------------------------------------------------"

projectsLoaded {
    def buildDirBase = rootProject.file(rootProject.properties.get("export.buildDirBase", rootProject.projectDir))

    allprojects(new Action<Project>() {
        @Override
        void execute(Project project) {
            def newBuildPath = new File(buildDirBase, "${project.path.replace(':','/')}/build")
            println("set buildDir for project ${project.name} to $newBuildPath")
            project.buildDir = newBuildPath
        }
    })
}
```

The main purpose of this script is to set the `buildDir` folder for all projects of a gradle multiproject build. This all worked well but was rather unintuitive and the fact that the main part, the init script itself, wasn't a part of the plugin, makes the setup difficult.

This patch changes the implementation and streamlines the process. The `GradleBuild` task and the `UnityBuildPluginExtension` have some new properties:

- `exportInitScript` / `initScript`
- `cleanBuildDirBeforeBuild`
- `exportBuildDirBase` / `buildDirBase`

There is no need for a custom `exportInit.gradle` in the project. The plugin contains this script and will use it based on the values of the new properties. It's possible now to provide an additional init script and a way to let gradle clean the build dir before building.

_build.gradle_

```groovy

plugins {
   id 'net.wooga.build-unity' version 'x.x.x'
}

unityBuild {
   cleanBuildDirBeforeBuild = true
   exportBuildDirBase = new File("../buildCache")
}

```

## Changes

* ![IMPROVE] external build cache setup and configuration

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
