### PR TITLE
Fix adhoc property default value in extension

### DIFF
--- a/src/main/groovy/wooga/gradle/build/unity/ios/internal/DefaultIOSBuildPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/internal/DefaultIOSBuildPluginExtension.groovy
@@ -32,7 +32,7 @@ class DefaultIOSBuildPluginExtension implements IOSBuildPluginExtension {
     private String scheme
     private String configuration
     private String provisioningName
-    private Boolean adhoc
+    private Boolean adhoc = false
 
     @Override
     org.gradle.api.credentials.PasswordCredentials getFastlaneCredentials() {

--- a/src/test/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginSpec.groovy
@@ -1,0 +1,47 @@
+package wooga.gradle.build.unity.ios
+
+import nebula.test.ProjectSpec
+import spock.lang.Requires
+import spock.lang.Unroll
+import wooga.gradle.build.unity.ios.internal.DefaultIOSBuildPluginExtension
+
+@Requires({os.macOs})
+class IOSBuildPluginSpec extends ProjectSpec {
+    public static final String PLUGIN_NAME = 'net.wooga.build-unity-ios'
+
+    def 'Creates the [iosBuild] extension'() {
+        given:
+        assert !project.plugins.hasPlugin(PLUGIN_NAME)
+        assert !project.extensions.findByName(IOSBuildPlugin.EXTENSION_NAME)
+
+        when:
+        project.plugins.apply(PLUGIN_NAME)
+
+        then:
+        def extension = project.extensions.findByName(IOSBuildPlugin.EXTENSION_NAME)
+        extension instanceof DefaultIOSBuildPluginExtension
+    }
+
+    @Unroll
+    def 'extension returns #defaultValue value for property #property'() {
+        given:
+        project.plugins.apply(PLUGIN_NAME)
+
+        and: "the extension"
+        DefaultIOSBuildPluginExtension extension = project.extensions.findByName(IOSBuildPlugin.EXTENSION_NAME) as DefaultIOSBuildPluginExtension
+
+        expect:
+        extension.getProperty(property) == defaultValue
+
+        where:
+        property                | defaultValue
+        "keychainPassword"      | null
+        "certificatePassphrase" | null
+        "appIdentifier"         | null
+        "teamId"                | null
+        "scheme"                | null
+        "configuration"         | null
+        "provisioningName"      | null
+        "adhoc"                 | false
+    }
+}


### PR DESCRIPTION
## Description

The `Boolean` type initializes with the value `null` instead of `false`. This patch simply sets a default value to `false`. I also added missing tests to verify it.

## Changes

* ![FIX] ![IOS] `adhoc` property default value in extension


[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
