### PR TITLE
Improve iOS ArchiveTask provide optional team id

### DIFF
--- a/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPlugin.groovy
@@ -66,6 +66,7 @@ class IOSBuildPlugin implements Plugin<Project> {
                 conventionMapping.map("extension", { "xcarchive" })
                 conventionMapping.map("scheme", { extension.getScheme() })
                 conventionMapping.map("configuration", { extension.getConfiguration() })
+                conventionMapping.map("teamId", { extension.getTeamId() })
             }
         })
 

--- a/src/main/groovy/wooga/gradle/build/unity/ios/tasks/XCodeArchiveTask.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/tasks/XCodeArchiveTask.groovy
@@ -23,6 +23,8 @@ import org.gradle.api.tasks.*
 import org.gradle.util.GUtil
 import wooga.gradle.build.unity.ios.XCAction
 
+import java.util.concurrent.Callable
+
 class XCodeArchiveTask extends ConventionTask {
 
     private Object projectPath
@@ -149,6 +151,23 @@ class XCodeArchiveTask extends ConventionTask {
 
     XCodeArchiveTask configuration(String configuration) {
         setConfiguration(configuration)
+        this
+    }
+
+    private Object teamId
+
+    @Optional
+    @Input
+    String getTeamId() {
+        convertToString(teamId)
+    }
+
+    void setTeamId(Object value) {
+        teamId = value
+    }
+
+    ImportProvisioningProfile teamId(Object teamId) {
+        setTeamId(teamId)
         this
     }
 
@@ -299,6 +318,10 @@ class XCodeArchiveTask extends ConventionTask {
             arguments << "OTHER_CODE_SIGN_FLAGS=--keychain ${getBuildKeychain()}"
         }
 
+        if (getTeamId()) {
+            arguments << "DEVELOPMENT_TEAM=${getTeamId()}"
+        }
+
         arguments << "-archivePath" << getArchivePath().getPath()
 
         def derivedDataPath = new File(project.buildDir, "derivedData")
@@ -310,5 +333,17 @@ class XCodeArchiveTask extends ConventionTask {
             executable "/usr/bin/xcrun"
             args = arguments
         }
+    }
+
+    private static String convertToString(Object value) {
+        if (!value) {
+            return null
+        }
+
+        if (value instanceof Callable) {
+            value = ((Callable) value).call()
+        }
+
+        value.toString()
     }
 }


### PR DESCRIPTION
## Description

During archive and the resulting code sign, it can happen that Xcode has issues with ambigious certificate names. It is possible to provide a `DEVELOPMENT_TEAM` flag during invocation and providing the teamId for code sign.

This patch adds a new optional task input variable `teamId` to the `Archive` task and sets the `DEVELOPMENT_TEAM` option during execution if the property is set. The plugin will provide a default value from the plugin extension.

Changes
=======

* ![IMPROVE] ![IOS] `ArchiveTask` provide optional team id

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
