### PR TITLE
Add versionCode property

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/build/UnityBuildPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/UnityBuildPluginIntegrationSpec.groovy
@@ -128,6 +128,14 @@ class UnityBuildPluginIntegrationSpec extends UnityIntegrationSpec {
         "toolsVersion"        | "3.2.1"                                     | ""       | 'properties'  | "toolsVersion="
         "toolsVersion"        | "2.1.3"                                     | "String" | 'extension'   | "toolsVersion="
 
+        "version"             | "1.2.3"                                     | ""       | 'environment' | "version="
+        "version"             | "3.2.1"                                     | ""       | 'properties'  | "version="
+        "version"             | "2.1.3"                                     | "String" | 'extension'   | "version="
+
+        "versionCode"         | "10203"                                     | ""       | 'environment' | "versionCode="
+        "versionCode"         | "30201"                                     | ""       | 'properties'  | "versionCode="
+        "versionCode"         | "20103"                                     | "String" | 'extension'   | "versionCode="
+
         "commitHash"          | "abcdefg"                                   | ""       | 'environment' | "commitHash="
         "commitHash"          | "gfedcba"                                   | ""       | 'properties'  | "commitHash="
         "commitHash"          | "1234567"                                   | "String" | 'extension'   | "commitHash="

--- a/src/integrationTest/groovy/wooga/gradle/build/unity/tasks/UnityBuildPlayerTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/unity/tasks/UnityBuildPlayerTaskIntegrationSpec.groovy
@@ -95,14 +95,20 @@ class UnityBuildPlayerTaskIntegrationSpec extends UnityIntegrationSpec {
             result.standardOutput.contains("commitHash=${expectedCommitHash}")
         }
 
+        if (expectedVersionCode) {
+            result.standardOutput.contains("versionCode=${expectedVersionCode}")
+        }
+
         result.standardOutput.contains("-executeMethod ${expectedExportMethod}")
         result.standardOutput.contains("version=${expectedVersion}")
+
         result.standardOutput.contains("outputPath=${new File(projectDir, expectedOutputPath).path}")
 
         where:
         property              | rawValue                          | type     | useSetter
         "exportMethodName"    | "method1"                         | 'String' | true
         "version"             | "1.0.0"                           | 'String' | true
+        "versionCode"         | "100000"                          | 'String' | true
         "toolsVersion"        | "1.0.0"                           | 'String' | true
         "commitHash"          | "abcdef123456"                    | 'String' | true
         "outputDirectoryBase" | "build/customExport3"             | 'File'   | true
@@ -112,6 +118,7 @@ class UnityBuildPlayerTaskIntegrationSpec extends UnityIntegrationSpec {
 
         expectedVersion = (property == "version") ? rawValue : 'unspecified'
         expectedToolsVersion = (property == "toolsVersion") ? rawValue : null
+        expectedVersionCode = (property == "versionCode") ? rawValue : null
         expectedCommitHash = (property == "commitHash") ? rawValue : null
 
         expectedOutputDirectoryBase = (property == 'outputDirectoryBase') ? rawValue : "/build/export"
@@ -119,7 +126,7 @@ class UnityBuildPlayerTaskIntegrationSpec extends UnityIntegrationSpec {
 
         expectedOutputPath = "$expectedOutputDirectoryBase/${FilenameUtils.removeExtension(expectedAppConfigFile.name)}/project"
 
-        methodIsOptional = (property == "toolsVersion") ? 'optional' : ''
+        methodIsOptional = (property == "toolsVersion" || property == "versionCode") ? 'optional' : ''
         value = wrapValueBasedOnType(rawValue, type)
     }
 
@@ -178,6 +185,7 @@ class UnityBuildPlayerTaskIntegrationSpec extends UnityIntegrationSpec {
         "exportMethodName" | "'method1'"
         "appConfigFile"    | "file('Assets/CustomConfigs/test.asset')"
         "version"          | "'1.0.1'"
+        "versionCode"      | "'100100'"
     }
 
     def "task skips with no-source when input files are empty"() {

--- a/src/main/groovy/wooga/gradle/build/unity/UnityBuildPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/UnityBuildPlugin.groovy
@@ -63,7 +63,8 @@ class UnityBuildPlugin implements Plugin<Project> {
                 task.toolsVersion.set(extension.toolsVersion)
                 task.commitHash.set(extension.commitHash)
                 task.outputDirectoryBase.set(extension.outputDirectoryBase)
-                task.version.set(project.provider({PropertyUtils.convertToString(project.version)}))
+                task.version.set(extension.version)
+                task.versionCode.set(extension.versionCode)
                 task.inputFiles.from({
 
                     def assetsDir = new File(task.getProjectPath(), "Assets")

--- a/src/main/groovy/wooga/gradle/build/unity/UnityBuildPluginConsts.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/UnityBuildPluginConsts.groovy
@@ -58,6 +58,37 @@ class UnityBuildPluginConsts {
      */
     static String DEFAULT_APP_CONFIG_NAME_ENV_VAR = "UNITY_BUILD_DEFAULT_APP_CONFIG_NAME"
 
+    /**
+     * Gradle property baseName to set the default value for {@code version}.
+     *
+     * @value "unityBuild.version"
+     * @see UnityBuildPluginExtension#getVersion()
+     */
+    static String BUILD_VERSION_OPTION = "unityBuild.version"
+
+    /**
+     * Environment variable to set the default value for {@code version}.
+     *
+     * @value "UNITY_BUILD_VERSION"
+     * @see UnityBuildPluginExtension#getVersion()
+     */
+    static String BUILD_VERSION_ENV_VAR = "UNITY_BUILD_VERSION"
+
+    /**
+     * Gradle property baseName to set the default value for {@code versionCode}.
+     *
+     * @value "unityBuild.versionCode"
+     * @see UnityBuildPluginExtension#getVersionCode()
+     */
+    static String BUILD_VERSION_CODE_OPTION = "unityBuild.versionCode"
+
+    /**
+     * Environment variable to set the default value for {@code versionCode}.
+     *
+     * @value "UNITY_BUILD_VERSION_CODE"
+     * @see UnityBuildPluginExtension#getVersionCode()
+     */
+    static String BUILD_VERSION_CODE_ENV_VAR = "UNITY_BUILD_VERSION_CODE"
 
     /**
      * Gradle property baseName to set the default value for {@code toolsVersion}.
@@ -70,7 +101,7 @@ class UnityBuildPluginConsts {
     /**
      * Environment variable to set the default value for {@code toolsVersion}.
      *
-     * @value "unityBuild.toolsVersion"
+     * @value "UNITY_BUILD_TOOLS_VERSION"
      * @see UnityBuildPluginExtension#getToolsVersion()
      */
     static String BUILD_TOOLS_VERSION_ENV_VAR = "UNITY_BUILD_TOOLS_VERSION"

--- a/src/main/groovy/wooga/gradle/build/unity/UnityBuildPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/UnityBuildPluginExtension.groovy
@@ -22,12 +22,15 @@ import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 
 interface UnityBuildPluginExtension<T extends UnityBuildPluginExtension> {
 
     DirectoryProperty getAppConfigsDirectory()
     DirectoryProperty getOutputDirectoryBase()
     Property<String> getToolsVersion()
+    Property<String> getVersion()
+    Property<String> getVersionCode()
     Property<String> getCommitHash()
     Property<String> getExportMethodName()
     Property<String> getDefaultAppConfigName()

--- a/src/main/groovy/wooga/gradle/build/unity/internal/DefaultUnityBuildPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/internal/DefaultUnityBuildPluginExtension.groovy
@@ -28,6 +28,7 @@ import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import wooga.gradle.build.unity.UnityBuildPluginConsts
 import wooga.gradle.build.unity.UnityBuildPluginExtension
+import wooga.gradle.build.unity.ios.internal.utils.PropertyUtils
 import wooga.gradle.unity.UnityPluginExtension
 
 import java.util.concurrent.Callable
@@ -39,6 +40,8 @@ class DefaultUnityBuildPluginExtension implements UnityBuildPluginExtension {
     final DirectoryProperty appConfigsDirectory
     final DirectoryProperty outputDirectoryBase
     final Property<String> toolsVersion
+    final Property<String> version
+    final Property<String> versionCode
     final Property<String> commitHash
     final Property<String> exportMethodName
     final Property<String> defaultAppConfigName
@@ -54,6 +57,8 @@ class DefaultUnityBuildPluginExtension implements UnityBuildPluginExtension {
         appConfigsDirectory = project.layout.directoryProperty()
         outputDirectoryBase = project.layout.directoryProperty()
         toolsVersion = project.objects.property(String.class)
+        version = project.objects.property(String.class)
+        versionCode = project.objects.property(String.class)
         commitHash = project.objects.property(String.class)
         exportMethodName = project.objects.property(String.class)
         defaultAppConfigName = project.objects.property(String.class)
@@ -92,6 +97,26 @@ class DefaultUnityBuildPluginExtension implements UnityBuildPluginExtension {
             String call() throws Exception {
                 System.getenv().get(UnityBuildPluginConsts.BUILD_TOOLS_VERSION_ENV_VAR) ?:
                         project.properties.get(UnityBuildPluginConsts.BUILD_TOOLS_VERSION_OPTION, null)
+            }
+        }))
+
+        version.set(project.provider(new Callable<String>() {
+            @Override
+            String call() throws Exception {
+                def version = PropertyUtils.convertToString(project.version)
+                if(!version || version == "unspecified") {
+                    return System.getenv().get(UnityBuildPluginConsts.BUILD_VERSION_ENV_VAR) ?:
+                            project.properties.get(UnityBuildPluginConsts.BUILD_VERSION_OPTION, version) as String
+                }
+                version
+            }
+        }))
+
+        versionCode.set(project.provider(new Callable<String>() {
+            @Override
+            String call() throws Exception {
+                System.getenv().get(UnityBuildPluginConsts.BUILD_VERSION_CODE_ENV_VAR) ?:
+                        project.properties.get(UnityBuildPluginConsts.BUILD_VERSION_CODE_OPTION, null) as String
             }
         }))
 

--- a/src/main/groovy/wooga/gradle/build/unity/tasks/UnityBuildPlayerTask.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/tasks/UnityBuildPlayerTask.groovy
@@ -71,6 +71,10 @@ class UnityBuildPlayerTask extends AbstractUnityProjectTask {
     @Input
     final Property<String> version
 
+    @Optional
+    @Input
+    final Property<String> versionCode
+
     @Internal("loaded app config asset")
     protected GenericUnityAsset getAppConfig() {
         if(!appConfig) {
@@ -111,6 +115,7 @@ class UnityBuildPlayerTask extends AbstractUnityProjectTask {
         toolsVersion = project.objects.property(String.class)
         commitHash = project.objects.property(String.class)
         version = project.objects.property(String.class)
+        versionCode = project.objects.property(String.class)
     }
 
     @Override
@@ -125,12 +130,16 @@ class UnityBuildPlayerTask extends AbstractUnityProjectTask {
             setBuildTarget(getBuildPlatform().toLowerCase() as BuildTarget)
         }
 
+        if (versionCode.present) {
+            customArgs += "versionCode=${versionCode.get()};"
+        }
+
         if (toolsVersion.present) {
-            customArgs += "toolsVersion=${toolsVersion.get()}"
+            customArgs += "toolsVersion=${toolsVersion.get()};"
         }
 
         if (commitHash.present) {
-            customArgs += "commitHash=${commitHash.get()}"
+            customArgs += "commitHash=${commitHash.get()};"
         }
 
         args "-executeMethod", exportMethodName.get()


### PR DESCRIPTION
## Description

This patch adds main support for a second version specifier the `versionCode`. The `versionCode` is a `String` property even though android uses an integer.

1. To pass it down to unity it has to be converted to `String` anyways
2. iOS has different rules for the [`CFBundleVersion`] which is a `String`

The default value is `null` and won't be send to Unity. The property can be set on the `UnityBuildPlayerTask` or in the `buildUnity` extension. In the later case all tasks of type `UnityBuildPlayerTask` will have the same value set. It is also possible to set the value via environmen or gradle properties. I also made the `version` property of the extension overrideable via environment or gradle properties. The main fallback is still the project version. Only if this value for project.version is `unspecified` will the extension check the environment/gradle properties.

| property              | gradle property name      | environment variable      |
| --------------------- | ------------------------- | ------------------------- |
| version               | `unityBuild.version`      | `UNITY_BUILD_VERSION`     |
| versionCode           | `unityBuild.versionCode`  | `UNITY_BUILD_VERSION_CODE |

## Changes

* ![ADD] `versionCode` property

[CFBundleVersion]: https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleversion

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
