### PR TITLE
Add secrets resolver base setup

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/build/UnityIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/UnityIntegrationSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Wooga GmbH
+ * Copyright 2018-2020 Wooga GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,36 @@ import wooga.gradle.build.unity.UnityBuildPlugin
 abstract class UnityIntegrationSpec extends IntegrationSpec {
 
     File unityTestLocation
+    File unityFailTestLocation
     File unityMainDirectory
+
+    File createFakeUnity(File unityTestLocation, exitCode = 0) {
+        String osName = System.getProperty("os.name").toLowerCase()
+        unityTestLocation.createNewFile()
+        unityTestLocation.executable = true
+        if (osName.contains("windows")) {
+            unityTestLocation << """
+                @echo off
+                echo %*
+                echo environment
+                set
+                exit ${exitCode}
+            """.stripIndent()
+        }
+        else
+        {
+            unityTestLocation << """
+                #!/usr/bin/env bash
+                echo arguments
+                echo \$@
+                echo environment
+                env
+                exit ${exitCode}
+            """.stripIndent()
+        }
+
+        unityTestLocation
+    }
 
     def setup() {
         String osName = System.getProperty("os.name").toLowerCase()
@@ -31,21 +60,8 @@ abstract class UnityIntegrationSpec extends IntegrationSpec {
             unityMainDirectory = new File(projectDir, "Unity/SomeLevel/SecondLevel")
             unityMainDirectory.mkdirs()
         }
-        unityTestLocation = createFile("fakeUnity.bat", unityMainDirectory)
-        unityTestLocation.executable = true
-        if (osName.contains("windows")) {
-            unityTestLocation << """
-                @echo off
-                echo %*
-            """.stripIndent()
-        }
-        else
-        {
-            unityTestLocation << """
-                #!/usr/bin/env bash
-                echo \$@
-            """.stripIndent()
-        }
+        unityTestLocation = createFakeUnity(new File(unityMainDirectory,"fakeUnity.bat"))
+        unityFailTestLocation = createFakeUnity(new File(unityMainDirectory,"fakeUnityFailing.bat"), 1)
 
         buildFile << """
             group = 'test'

--- a/src/integrationTest/groovy/wooga/gradle/build/unity/UnityBuildPluginSecretHandlingIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/unity/UnityBuildPluginSecretHandlingIntegrationSpec.groovy
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.build.unity
+
+import org.junit.Rule
+import org.junit.contrib.java.lang.system.EnvironmentVariables
+import org.yaml.snakeyaml.Yaml
+import spock.lang.Shared
+import spock.lang.Unroll
+import wooga.gradle.build.UnityIntegrationSpec
+
+class UnityBuildPluginSecretHandlingIntegrationSpec extends UnityIntegrationSpec {
+
+    @Rule
+    public final EnvironmentVariables environmentVariables = new EnvironmentVariables()
+
+    @Shared
+    File appConfigsDir
+
+    @Shared
+    File externalDir
+
+    @Shared
+    File externalGradle
+
+    @Shared
+    List<String> secretIds = [
+            'net_wooga_secretText_test1',
+            'net_wooga_secretText_test2',
+            'net_wooga_secretText_test3',
+            'net_wooga_secretText_test4',
+            'net_wooga_secretFile_test1',
+            'net_wooga_secretFile_test2',
+    ]
+
+    def setup() {
+        //create the default location for app configs
+        def assets = new File(projectDir, "Assets")
+        appConfigsDir = new File(assets, "UnifiedBuildSystem-Assets/AppConfigs")
+        appConfigsDir.mkdirs()
+
+        ['ios_ci', 'android_ci', 'webGL_ci'].collect { createFile("${it}.asset", appConfigsDir) }.each {
+            Yaml yaml = new Yaml()
+            def buildTarget = it.name.split(/_/, 2).first().toLowerCase()
+            def appConfig = ['MonoBehaviour': ['bundleId': 'net.wooga.test', 'batchModeBuildTarget': buildTarget, secrets: secretIds]]
+            it << yaml.dump(appConfig)
+        }
+
+        Yaml yaml = new Yaml()
+        createFile("custom.asset", appConfigsDir) << yaml.dump(['MonoBehaviour': ['bundleId': 'net.wooga.test']])
+
+        buildFile << """
+            import wooga.gradle.build.unity.secrets.SecretResolver
+            import wooga.gradle.build.unity.secrets.Secret
+            import wooga.gradle.build.unity.secrets.internal.SecretText
+            import wooga.gradle.build.unity.secrets.internal.SecretFile
+            
+            class CustomResolver implements SecretResolver {
+                Secret<?> resolve(String secretId) {
+                    if(secretId.startsWith("net_wooga_secretFile")) {
+                        return new SecretFile(secretId.toUpperCase().bytes)
+                    } else {
+                        return new SecretText(secretId.toUpperCase())
+                    }
+                }
+            }
+
+            unityBuild.secretResolver = new CustomResolver()
+        """.stripIndent()
+
+        //to make sure our fake unity export works we need to mock a fake exported project
+
+        externalDir = new File(projectDir, "extern/project")
+        externalDir.mkdirs()
+
+        externalGradle = createFile("build.gradle", externalDir)
+        externalGradle << """
+            plugins {
+                id 'base'
+            }
+
+            task(printEnv) {
+                doLast {
+                    def outputFile = new File(project.buildDir, 'env.txt')
+                    outputFile.parentFile.mkdirs()
+                    outputFile.text = System.getenv().collect({key,value -> key + "=" + value}).join("\\n")
+                }
+            }
+
+            assemble.dependsOn printEnv
+
+        """.stripIndent()
+        def externalSettings = createFile("settings.gradle", externalDir)
+        externalSettings << """
+            rootProject.name = 'test'
+        """.stripIndent()
+
+        buildFile << """
+            import wooga.gradle.build.unity.tasks.UnityBuildPlayerTask
+            project.tasks.withType(UnityBuildPlayerTask) { task ->
+                task.doLast {
+                    project.copy {
+                        from(project.file('${escapedPath(externalDir.path)}'))
+                        into(task.outputDirectory)
+                    }
+                }
+            }
+        """.stripIndent()
+    }
+
+    def "task :taskToRun executes matching #expectedFetchSecretTask task"() {
+        when:
+        def result = runTasksSuccessfully(taskToRun)
+
+        then:
+        result.wasExecuted(expectedFetchSecretTask)
+
+        where:
+        taskToRun           | expectedFetchSecretTask
+        "assembleAndroidCi" | "fetchSecretsAndroidCi"
+    }
+
+    def "task :#taskToRun sends secret texts as environment variables"() {
+        given: "future printEnvOutput"
+        def envOutput = new File(projectDir,"build/export/android_ci/project/build/env.txt")
+        assert !envOutput.exists()
+
+        when:
+        def result = runTasksSuccessfully(taskToRun)
+
+        then:
+        secretIds.every { secretId ->
+            def match = result.standardOutput =~ /.*${secretId.toUpperCase()}=(.*)?.*/
+            if (match) {
+                String value = match.group(1)
+                if (secretId.startsWith("net_wooga_secretFile")) {
+                    return true
+                }
+                return value == secretId.toUpperCase()
+            }
+            false
+        }
+
+        envOutput.exists()
+        def envOutputText = envOutput.text
+        secretIds.every { secretId ->
+            def match = envOutputText =~ /.*${secretId.toUpperCase()}=(.*)?.*/
+            if (match) {
+                String value = match.group(1)
+                if (secretId.startsWith("net_wooga_secretFile")) {
+                    return true
+                }
+                return value == secretId.toUpperCase()
+            }
+            false
+        }
+
+        where:
+        taskToRun           | _
+        "assembleAndroidCi" | _
+
+    }
+
+    @Unroll
+    def "task :#taskToRun deletes secret files after invocation when #message"() {
+        given:
+        if (!taskSucceeds) {
+            buildFile << """
+                unity.unityPath(file("${escapedPath(unityFailTestLocation.path)}"))
+            """.stripIndent()
+        }
+        when:
+        def result = runTasks(taskToRun)
+
+        then:
+        result.success == taskSucceeds
+
+        secretIds.every { secretId ->
+            def match = result.standardOutput =~ /.*${secretId.toUpperCase()}=(.*)?.*/
+            if (match) {
+                String value = match.group(1)
+                if (secretId.startsWith("net_wooga_secretFile")) {
+                    File secretFile = new File(value)
+                    return !secretFile.exists()
+                }
+                return true
+            }
+            false
+        }
+
+        where:
+        taskToRun           | taskSucceeds
+        "assembleAndroidCi" | true
+        "assembleAndroidCi" | false
+        message = taskSucceeds ? "task succeeds" : "task fails"
+    }
+}

--- a/src/integrationTest/groovy/wooga/gradle/build/unity/tasks/FetchSecretsTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/unity/tasks/FetchSecretsTaskIntegrationSpec.groovy
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.build.unity.tasks
+
+import org.yaml.snakeyaml.Yaml
+import wooga.gradle.build.IntegrationSpec
+import wooga.gradle.build.unity.UnityBuildPlugin
+import wooga.gradle.build.unity.secrets.internal.EncryptionSpecHelper
+
+class FetchSecretsTaskIntegrationSpec extends IntegrationSpec {
+    def setup() {
+        def assets = new File(projectDir, "Assets")
+        def appConfigsDir = new File(assets, "CustomConfigs")
+        appConfigsDir.mkdirs()
+
+        def appConfig = ['MonoBehaviour': ['bundleId': 'net.wooga.test', 'batchModeBuildTarget': 'android']]
+        def appConfigWithSecrets = ['MonoBehaviour': ['bundleId': 'net.wooga.test', 'batchModeBuildTarget': 'android', 'secrets': [
+                'net_wooga_testCredential',
+                'net_wooga_testCredential2',
+                'net_wooga_testCredential3',
+                'net_wooga_testCredential4'
+        ]]]
+        def appConfigWithEmptySecrets = ['MonoBehaviour': ['bundleId': 'net.wooga.test', 'batchModeBuildTarget': 'android', 'secrets': []]]
+
+        ["legacyConfig": appConfig, "withSecrets": appConfigWithSecrets, "emptySecrets": appConfigWithEmptySecrets]
+                .each { name, config ->
+                    Yaml yaml = new Yaml()
+                    def f = createFile("${name}.asset", appConfigsDir)
+                    f << yaml.dump(config)
+                }
+
+        buildFile << """
+            ${applyPlugin(UnityBuildPlugin)}
+
+            import wooga.gradle.build.unity.secrets.internal.Resolver
+            import wooga.gradle.build.unity.secrets.internal.DefaultSecret
+            import wooga.gradle.build.unity.secrets.SecretResolver
+            import wooga.gradle.build.unity.secrets.Secret
+
+            task("fetchSecretsCustom", type: wooga.gradle.build.unity.tasks.FetchSecrets) {
+                appConfigFile = file('Assets/CustomConfigs/withSecrets.asset')
+            }
+        """.stripIndent()
+    }
+
+    def "task is Up-To-Date when secret key is cached"() {
+        given: "a secret key"
+        def key = EncryptionSpecHelper.createSecretKey(this.class.name)
+        def keyFile = createFile("secrets.key", projectDir)
+        keyFile.bytes = key.encoded
+
+        and: "the key configured"
+        buildFile << """
+            fetchSecretsCustom.secretsKey = "${escapedPath(keyFile.path)}"
+        """
+
+        and: "a fake resolver"
+        buildFile << """
+            fetchSecretsCustom.resolver = Resolver.withClosure {
+                if(it == "net_wooga_testCredential2") {
+                    return it.toUpperCase().bytes
+                } else {
+                    return it.toUpperCase()
+                } 
+            }
+        """.stripIndent()
+
+        and: "a future secrets file"
+        def secretsFile = new File(projectDir, "build/secret/fetchSecretsCustom/secrets.yml")
+        assert !secretsFile.exists()
+
+        when:
+        def result = runTasksSuccessfully("fetchSecretsCustom")
+
+        then:
+        !result.wasUpToDate("fetchSecretsCustom")
+
+        when:
+        result = runTasksSuccessfully("fetchSecretsCustom")
+
+        then:
+        result.wasUpToDate("fetchSecretsCustom")
+        secretsFile.exists()
+
+        when:
+        secretsFile.delete()
+        result = runTasksSuccessfully("fetchSecretsCustom")
+
+        then:
+        !result.wasUpToDate("fetchSecretsCustom")
+    }
+
+    def "task is not Up-To-Date when resolver changes"() {
+        given: "a secret key"
+        def key = EncryptionSpecHelper.createSecretKey(this.class.name)
+        def keyFile = createFile("secrets.key", projectDir)
+        keyFile.bytes = key.encoded
+
+        and: "the key configured"
+        buildFile << """
+            fetchSecretsCustom.secretsKey = "${escapedPath(keyFile.path)}"
+        """
+
+        and: "a fake resolver"
+        buildFile << """
+            class Resolver1 implements SecretResolver {
+                @Override
+                Secret<?> resolve(String secretId) {
+                    if(secretId == "net_wooga_testCredential2") {
+                        return new DefaultSecret(secretId.toUpperCase().bytes)
+                    } else {
+                        return new DefaultSecret(secretId.toUpperCase())
+                    } 
+                }            
+            }
+            
+            class Resolver2 implements SecretResolver {
+                @Override
+                Secret<?> resolve(String secretId) {
+                    if(secretId == "net_wooga_testCredential3") {
+                        return new DefaultSecret(secretId.toUpperCase().bytes)
+                    } else {
+                        return new DefaultSecret(secretId.toUpperCase())
+                    } 
+                }            
+            }
+            
+            fetchSecretsCustom.resolver = new Resolver1()
+        """.stripIndent()
+
+        and: "a future secrets file"
+        def secretsFile = new File(projectDir, "build/secret/fetchSecretsCustom/secrets.yml")
+        assert !secretsFile.exists()
+
+        when: "first run"
+        def result = runTasksSuccessfully("fetchSecretsCustom")
+
+        then:
+        !result.wasUpToDate("fetchSecretsCustom")
+        secretsFile.exists()
+
+        when: "second run"
+        result = runTasksSuccessfully("fetchSecretsCustom")
+
+        then:
+        result.wasUpToDate("fetchSecretsCustom")
+        secretsFile.exists()
+
+        when: "changing the resolver"
+        buildFile << """
+            fetchSecretsCustom.resolver = new Resolver2()
+        """.stripIndent()
+        result = runTasksSuccessfully("fetchSecretsCustom")
+
+        then:
+        !result.wasUpToDate("fetchSecretsCustom")
+    }
+
+
+    def "Second task can depend on secret output file"() {
+        given: "a fake resolver"
+        buildFile << """
+            fetchSecretsCustom.resolver = Resolver.withClosure {
+                if(it == "net_wooga_testCredential2") {
+                    return it.toUpperCase().bytes
+                } else {
+                    return it.toUpperCase()
+                } 
+            }
+        """.stripIndent()
+
+        and: "a task to use the secrets"
+        buildFile << """
+            class Consumer extends DefaultTask {
+                @InputFile
+                final RegularFileProperty inputFile = newInputFile()
+            
+                @TaskAction
+                void consume() {
+                    def input = inputFile.get().asFile
+                    def message = input.text
+                }
+            }
+            
+            task secretConsumer(type: Consumer) {
+                inputFile = fetchSecretsCustom.secretsFile
+            }
+        """.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully("secretConsumer")
+
+        then:
+        result.wasExecuted("fetchSecretsCustom")
+    }
+}

--- a/src/integrationTest/groovy/wooga/gradle/build/unity/tasks/SecretSpecIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/unity/tasks/SecretSpecIntegrationSpec.groovy
@@ -1,0 +1,102 @@
+package wooga.gradle.build.unity.tasks
+
+import org.gradle.api.Task
+import spock.lang.Unroll
+import wooga.gradle.build.UnityIntegrationSpec
+import wooga.gradle.build.unity.internal.DefaultUnityBuildPluginExtension
+import wooga.gradle.build.unity.secrets.internal.EncryptionSpecHelper
+
+class SecretSpecIntegrationSpec extends UnityIntegrationSpec {
+
+    @Unroll("#containerTypeName of type #containerType.name can set secrets key with #method(#type)")
+    def "can set secrets key"() {
+        given: "secret key saved to disc"
+        def key = EncryptionSpecHelper.createSecretKey("a random key")
+        def keyFile = File.createTempFile("secret", "key")
+        def outputKeyFile = File.createTempFile("secretOut", "key")
+        def keyPath = escapedPath(keyFile.path)
+        keyFile.bytes = key.encoded
+
+        and: "the value to set"
+        def value = ""
+        if (type == "key") {
+            value = "new javax.crypto.spec.SecretKeySpec(project.file('${keyPath}').bytes, 'AES')"
+        } else if (type == "keyFile") {
+            value = "project.file('${keyPath}')"
+        } else if (type == "keyPath") {
+            value = "'${keyPath}'"
+        }
+
+        and: "the key configured"
+        if (Task.isAssignableFrom(containerType)) {
+            buildFile << """
+                task("temp", type: ${containerType.name}) {
+                    ${method}(${value})
+                }
+            """.stripIndent()
+        } else {
+            buildFile << """
+                extensions.create('temp', ${containerType.name}, project)
+                temp.${method}(${value})
+            """.stripIndent()
+        }
+
+        and: "a task to write out the key"
+        buildFile << """
+            task("writeKey") {
+                doLast {
+                    def output = new File("${escapedPath(outputKeyFile.path)}")
+                    output.bytes = temp.secretsKey.get().encoded
+                }
+            }
+        """
+
+        when:
+        runTasksSuccessfully("writeKey")
+
+        then:
+        outputKeyFile.exists()
+        outputKeyFile.bytes == keyFile.bytes
+
+        cleanup:
+        keyFile.delete()
+        outputKeyFile.delete()
+
+        where:
+        containerType                    | property         | type      | useSetter
+        GradleBuild                      | "secretsKey"     | "key"     | false
+        GradleBuild                      | "secretsKey"     | "key"     | true
+        GradleBuild                      | "secretsKey.set" | "key"     | false
+        GradleBuild                      | "secretsKey"     | "keyFile" | false
+        GradleBuild                      | "secretsKey"     | "keyFile" | true
+        GradleBuild                      | "secretsKey"     | "keyPath" | false
+        GradleBuild                      | "secretsKey"     | "keyPath" | true
+
+        FetchSecrets                     | "secretsKey"     | "key"     | false
+        FetchSecrets                     | "secretsKey"     | "key"     | true
+        FetchSecrets                     | "secretsKey.set" | "key"     | false
+        FetchSecrets                     | "secretsKey"     | "keyFile" | false
+        FetchSecrets                     | "secretsKey"     | "keyFile" | true
+        FetchSecrets                     | "secretsKey"     | "keyPath" | false
+        FetchSecrets                     | "secretsKey"     | "keyPath" | true
+
+        UnityBuildPlayerTask             | "secretsKey"     | "key"     | false
+        UnityBuildPlayerTask             | "secretsKey"     | "key"     | true
+        UnityBuildPlayerTask             | "secretsKey.set" | "key"     | false
+        UnityBuildPlayerTask             | "secretsKey"     | "keyFile" | false
+        UnityBuildPlayerTask             | "secretsKey"     | "keyFile" | true
+        UnityBuildPlayerTask             | "secretsKey"     | "keyPath" | false
+        UnityBuildPlayerTask             | "secretsKey"     | "keyPath" | true
+
+        DefaultUnityBuildPluginExtension | "secretsKey"     | "key"     | false
+        DefaultUnityBuildPluginExtension | "secretsKey"     | "key"     | true
+        DefaultUnityBuildPluginExtension | "secretsKey.set" | "key"     | false
+        DefaultUnityBuildPluginExtension | "secretsKey"     | "keyFile" | false
+        DefaultUnityBuildPluginExtension | "secretsKey"     | "keyFile" | true
+        DefaultUnityBuildPluginExtension | "secretsKey"     | "keyPath" | false
+        DefaultUnityBuildPluginExtension | "secretsKey"     | "keyPath" | true
+
+        method = (useSetter) ? "set${property.capitalize()}" : property
+        containerTypeName = Task.isAssignableFrom(containerType) ? "task" : "extension"
+    }
+}

--- a/src/main/groovy/wooga/gradle/build/unity/SecretSpec.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/SecretSpec.groovy
@@ -1,0 +1,18 @@
+package wooga.gradle.build.unity
+
+import org.gradle.api.provider.Property
+
+import javax.crypto.spec.SecretKeySpec
+
+interface SecretSpec<T extends SecretSpec> {
+
+    Property<SecretKeySpec> getSecretsKey()
+    void setSecretsKey(SecretKeySpec key)
+    T setSecretsKey(String keyFile)
+    T setSecretsKey(File keyFile)
+
+    T secretsKey(SecretKeySpec key)
+    T secretsKey(String keyFile)
+    T secretsKey(File keyFile)
+
+}

--- a/src/main/groovy/wooga/gradle/build/unity/UnityBuildPluginConsts.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/UnityBuildPluginConsts.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Wooga GmbH
+ * Copyright 2018-2020 Wooga GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -170,6 +170,11 @@ class UnityBuildPluginConsts {
      */
     static String CLEAN_BUILD_DIR_BEFORE_BUILD_ENV_VAR = "UNITY_BUILD_CLEAN_BUILD_DIR_BEFORE_BUILD"
 
+    static Integer SECRETS_KEY_ITERATION = 65536
+    static Integer SECRETS_KEY_LENGTH = 256
+
+    static String SECRETS_KEY_OPTION = "unityBuild.secretsKey"
+    static String SECRETS_KEY_ENV_VAR = "UNITY_BUILD_SECRETS_KEY"
 
     /**
      * Default name for the base export location.

--- a/src/main/groovy/wooga/gradle/build/unity/UnityBuildPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/UnityBuildPluginExtension.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Wooga GmbH
+ * Copyright 2018-2020 Wooga GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,9 +22,9 @@ import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
-import org.gradle.api.provider.Provider
+import wooga.gradle.build.unity.secrets.SecretResolver
 
-interface UnityBuildPluginExtension<T extends UnityBuildPluginExtension> {
+interface UnityBuildPluginExtension<T extends UnityBuildPluginExtension> extends SecretSpec {
 
     DirectoryProperty getAppConfigsDirectory()
     DirectoryProperty getOutputDirectoryBase()
@@ -40,4 +40,6 @@ interface UnityBuildPluginExtension<T extends UnityBuildPluginExtension> {
     FileCollection getAppConfigs()
 
     ConfigurableFileCollection getIgnoreFilesForExportUpToDateCheck()
+
+    Property<SecretResolver> getSecretResolver()
 }

--- a/src/main/groovy/wooga/gradle/build/unity/internal/MemoisationProvider.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/internal/MemoisationProvider.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.build.unity.internal
+
+import org.gradle.api.internal.provider.AbstractProvider
+import org.gradle.api.provider.Provider
+
+class MemoisationProvider<T> extends AbstractProvider<T> implements Provider<T> {
+
+    private T inferredValue
+    private final Provider<T> inner
+
+    MemoisationProvider(Provider<T> provider) {
+        this.inner = provider
+    }
+
+    @Override
+    Class<T> getType() {
+        null
+    }
+
+    @Override
+    T getOrNull() {
+        if(!inferredValue) {
+            inferredValue = inner.getOrNull()
+        }
+        inferredValue
+    }
+}

--- a/src/main/groovy/wooga/gradle/build/unity/tasks/FetchSecrets.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/tasks/FetchSecrets.groovy
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.build.unity.tasks
+
+import org.apache.commons.io.FilenameUtils
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.*
+import wooga.gradle.build.unity.SecretSpec
+import wooga.gradle.build.unity.secrets.Secret
+import wooga.gradle.build.unity.secrets.SecretResolver
+import wooga.gradle.build.unity.secrets.SecretResolverException
+import wooga.gradle.build.unity.secrets.internal.Resolver
+import wooga.gradle.build.unity.secrets.internal.Secrets
+import wooga.gradle.unity.utils.GenericUnityAsset
+
+import javax.crypto.spec.SecretKeySpec
+
+class FetchSecrets extends DefaultTask implements SecretSpec {
+    static String SECRETS_KEY = "secrets"
+    private GenericUnityAsset appConfig
+
+    @Input
+    final Property<SecretKeySpec> secretsKey
+
+    void setSecretsKey(SecretKeySpec key) {
+        secretsKey.set(key)
+    }
+
+    FetchSecrets setSecretsKey(String keyFile) {
+        setSecretsKey(project.file(keyFile))
+    }
+
+    FetchSecrets setSecretsKey(File keyFile) {
+        setSecretsKey(new SecretKeySpec(keyFile.bytes, "AES"))
+    }
+
+    @Override
+    FetchSecrets secretsKey(SecretKeySpec key) {
+        setSecretsKey(key)
+    }
+
+    @Override
+    FetchSecrets secretsKey(String keyFile) {
+        return setSecretsKey(keyFile)
+    }
+
+    @Override
+    FetchSecrets secretsKey(File keyFile) {
+        return setSecretsKey(keyFile)
+    }
+
+    @Optional
+    @Input
+    protected Class<Resolver> getResolverType() {
+        if(resolver.present) {
+            resolver.get().class as Class<Resolver>
+        }
+    }
+
+    @Internal
+    final Property<SecretResolver> resolver
+
+    void setResolver(SecretResolver value) {
+        resolver.set(value)
+    }
+
+    void resolver(SecretResolver value) {
+        setResolver(value)
+    }
+
+    @InputFile
+    final RegularFileProperty appConfigFile
+
+    @OutputFile
+    final RegularFileProperty secretsFile
+
+    @Internal
+    final Provider<String> appConfigName
+
+    @Internal("loaded app config asset")
+    protected GenericUnityAsset getAppConfig() {
+        if(!appConfig) {
+            appConfig = new GenericUnityAsset(appConfigFile.get().asFile)
+            if(!appConfig.isValid()) {
+                throw new StopExecutionException('provided appConfig is invalid')
+            }
+        }
+
+        appConfig
+    }
+
+    @Internal("read from appConfig file")
+    List<String> getSecretIds() {
+        def appConfig = getAppConfig()
+        if(appConfig.containsKey(SECRETS_KEY)) {
+            return appConfig[SECRETS_KEY] as List<String>
+        }
+        []
+    }
+
+    FetchSecrets() {
+        appConfigFile = newInputFile()
+        secretsFile = newOutputFile()
+        appConfigName = appConfigFile.map { FilenameUtils.removeExtension(it.asFile.name) }
+        resolver = project.objects.property(SecretResolver)
+        secretsKey = project.objects.property(SecretKeySpec)
+    }
+
+    @TaskAction
+    protected void fetchSecrets() {
+        logger.info("Fetch secrets for appConfig: ${appConfigName.get()}")
+        Secrets secrets = new Secrets()
+        def resolver = resolver.getOrNull()
+        def key = secretsKey.get()
+
+        if(resolver) {
+            for(String secretId in getSecretIds()) {
+                logger.info("Fetch secret: ${secretId}")
+                try {
+                    Secret secret = resolver.resolve(secretId)
+                    secrets.putSecret(secretId, secret, key)
+                } catch(SecretResolverException e){
+                    throw new ScriptException("unable to fetch secret ${secretId}", e)
+                }
+            }
+        }
+        this.secretsFile.get().asFile.text = secrets.encode()
+    }
+}

--- a/src/test/groovy/wooga/gradle/build/unity/internal/MemoisationProviderSpec.groovy
+++ b/src/test/groovy/wooga/gradle/build/unity/internal/MemoisationProviderSpec.groovy
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package wooga.gradle.build.unity.internal
+
+import nebula.test.ProjectSpec
+import spock.lang.Unroll
+
+class MemoisationProviderSpec extends ProjectSpec {
+    def "provider caches value"() {
+        given: "a random number generator"
+        def random = new Random()
+        and: "a normal provider"
+        def baseProvider = project.provider({ random.nextInt() })
+
+        and: "a memoisation provider"
+        def subject = new MemoisationProvider(baseProvider)
+
+        expect:
+        subject.get() == subject.get()
+        subject.get() == subject.get()
+        subject.get() == subject.get()
+        baseProvider.get() != baseProvider.get()
+        baseProvider.get() != baseProvider.get()
+        baseProvider.get() != baseProvider.get()
+    }
+
+    @Unroll
+    def "getOrNull returns value or null"() {
+        given: "a memoisation provider"
+        def baseProvider = project.provider({ innerValue })
+        def subject = new MemoisationProvider(baseProvider)
+
+        when:
+        def value = subject.getOrNull()
+
+        then:
+        value == innerValue
+        noExceptionThrown()
+
+        where:
+        innerValue << [1, null]
+    }
+
+    @Unroll
+    def "get throws error when value is null"() {
+        given: "a memoisation provider"
+        def baseProvider = project.provider({ null })
+        def subject = new MemoisationProvider(baseProvider)
+
+        when:
+        subject.get()
+
+        then:
+        thrown(IllegalStateException)
+    }
+
+    @Unroll
+    def "present returns #expectedValue when value is #message"() {
+        given: "a memoisation provider"
+        def baseProvider = project.provider({ innerValue })
+        def subject = new MemoisationProvider(baseProvider)
+
+        when:
+        def value = subject.isPresent()
+
+        then:
+        value == expectedValue
+
+        where:
+        innerValue | expectedValue
+        1          | true
+        null       | false
+        message = innerValue == null ? "not set" : "set"
+    }
+}


### PR DESCRIPTION
## Description

depends on #59 
see wooga/wdk-unity-UnifiedBuildSystem#94

This is a pretty huge patch and implements the basic tools needed to fetch and pass secrets to Unity. The patch [#105] is introducing a new configuration field called `secrets` to the `AppConfig`. The fields intention is to declare all secretIds needed byt the `AppConfig`. This patch implements the basic workflow to read the secretsIds, fetch the secrets through a `SecretResolver` and pass them to Unity via environment variables (this is the plan for the first implementation).

### FetchSecrets

I added a new task type `FetchSecrets` and configured tasks for all found `AppConfig` files in the `AppConfig` lookup directory. This means every `UnityBuildPlayerTask` generated from the plugin will have a corresponding `FetchSecrets` task as a direct dependency. (I might change this setup so any task of `UnityBuildPlayerTask` gets a fetch secret task assigned)

The `FetchSecrets` task will read the list of configured secrets in the `AppConfig` and pass them to a configured resolver of type `SecretResolver`. There is no default implementation available at the moment. Only the integration tests provide some mock resolvers. If no resolver is set or no secret ids are configured the task will create an empty output.

The output of the `FetchSecrets` file is a serialized yaml version of an object the new helper class type `Secrets`. This class handles unencrypted secrets and encrypts them before serializing to disk.

e.g.

```yml
!secrets
secrets:
  net.wooga.testCredential: !encryptedSecretText
    secretValue: xllADGqYIK5h3go11IMfx8Iv0eH6UHhukv9sH6VrO4bggTXU+54HUhjR/29Bojvq
  net.wooga.testCredential2: !encryptedSecretText
    secretValue: AZ5nk3W6sogqFz/w82iZkA4pcGHKEmZpWbM7Cvgd+xsJCtEL6sTP+UGtUDaDh0dt
  net.wooga.testCredential3: !encryptedSecretFile
    secretValue: !!binary |-
      o+nF/o+R7jTy9q5aLfUsJ0WjXVl5hwVuykjr/G9zJVtweA7e+c/1HEjkR4f3988x
  net.wooga.testCredential4: !encryptedSecretText
    secretValue: 11TjUVMnoVHF3v2G2H1l1jDLo7AvpoNbvvqy6Ck3Nbt/Yvk3gXKFKfBeHIN/MPF7
```

Both `Secrets` and `SecretResolver` build on top of other helper types to describe resolved secrets (`Secret`, `EncryptedSecret`, and more)

### UnityBuildPlayerTask

Before execution of the Unity batchmode task the build task will decrypt the secrets from disk and format them in a way suitable to be passed as environment variables.

SecretStrings are passed as is. Secret files are passend in memory as byte arrays and are saved to a random temp file before execution. The temp files will be delted after the Unity job is finished (successfull or not).

### SecretKey

To encrypt and decrypt the logic uses a `AES` key. This key is by default generated at runtime. This means that cached secret files are unreadable after the gradle build is done. For local machines it is possible to configure a static key outside of the project. This part of the implementation is not yet final. The patch already includes a setter for the key but no way to generate a key or save it securely on the host computer.

What is needed next are a real `SecretResolver` implementation which can
fetch secret strings and files from a secure vault.

## Changes

* ![ADD] Secret resolver base setup

[#105]:		https://github.com/wooga/wdk-unity-UnifiedBuildSystem/pull/105


[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
