### PR TITLE
Add secret handling base types

### DIFF
--- a/src/main/groovy/wooga/gradle/build/unity/secrets/EncryptedSecret.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/secrets/EncryptedSecret.groovy
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.build.unity.secrets
+
+import javax.crypto.spec.SecretKeySpec
+
+interface EncryptedSecret<T> extends Secret<T> {
+    T decryptedSecretValue(SecretKeySpec key)
+    Secret<T> decryptSecret(SecretKeySpec key)
+}

--- a/src/main/groovy/wooga/gradle/build/unity/secrets/Secret.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/secrets/Secret.groovy
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.build.unity.secrets
+
+interface Secret<T> {
+    T getSecretValue()
+}

--- a/src/main/groovy/wooga/gradle/build/unity/secrets/SecretResolver.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/secrets/SecretResolver.groovy
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.build.unity.secrets
+
+interface SecretResolver<T> {
+    Secret<T> resolve(String secretId)
+}
+

--- a/src/main/groovy/wooga/gradle/build/unity/secrets/SecretResolverException.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/secrets/SecretResolverException.groovy
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.build.unity.secrets
+
+import groovy.transform.InheritConstructors
+
+@InheritConstructors
+class SecretResolverException extends Exception {
+
+}

--- a/src/main/groovy/wooga/gradle/build/unity/secrets/internal/AbstractEncryptedSecret.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/secrets/internal/AbstractEncryptedSecret.groovy
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.build.unity.secrets.internal
+
+import groovy.transform.InheritConstructors
+import wooga.gradle.build.unity.secrets.EncryptedSecret
+import wooga.gradle.build.unity.secrets.Secret
+
+import javax.crypto.Cipher
+import javax.crypto.spec.IvParameterSpec
+import javax.crypto.spec.SecretKeySpec
+import java.security.AlgorithmParameters
+import java.security.GeneralSecurityException
+
+@InheritConstructors
+abstract class AbstractEncryptedSecret<T> extends DefaultSecret<T> implements EncryptedSecret<T> {
+    AbstractEncryptedSecret(Secret<T> secret, SecretKeySpec key) {
+        secretValue = encryptSecretValue(secret.secretValue, key)
+    }
+
+    protected static byte[] encrypt(byte[] property, SecretKeySpec key) throws GeneralSecurityException, UnsupportedEncodingException {
+        Cipher pbeCipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
+        pbeCipher.init(Cipher.ENCRYPT_MODE, key)
+        AlgorithmParameters parameters = pbeCipher.getParameters()
+        IvParameterSpec ivParameterSpec = parameters.getParameterSpec(IvParameterSpec.class)
+        byte[] cryptoText = pbeCipher.doFinal(property)
+        byte[] iv = ivParameterSpec.getIV()
+        byte[] combined = new byte[iv.length + cryptoText.length]
+        System.arraycopy(iv, 0, combined, 0, iv.length)
+        System.arraycopy(cryptoText, 0, combined, iv.length, cryptoText.length)
+
+        combined
+    }
+
+    protected static String base64Encode(byte[] bytes) {
+        return Base64.getEncoder().encodeToString(bytes);
+    }
+
+    protected static byte[] decrypt(byte[] value, SecretKeySpec key) throws GeneralSecurityException, IOException {
+        byte[] iv = Arrays.copyOfRange(value, 0, 16)
+        byte[] property = Arrays.copyOfRange(value, 16, value.length)
+        Cipher pbeCipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
+        pbeCipher.init(Cipher.DECRYPT_MODE, key, new IvParameterSpec(iv))
+        pbeCipher.doFinal(property)
+    }
+
+    protected static byte[] base64Decode(String property) throws IOException {
+        return Base64.getDecoder().decode(property);
+    }
+
+    @Override
+    Secret<T> decryptSecret(SecretKeySpec key) {
+        new DefaultSecret<T>(decryptedSecretValue(key))
+    }
+
+    abstract T decryptedSecretValue(SecretKeySpec key)
+    abstract protected T encryptSecretValue(T secret, SecretKeySpec key)
+}

--- a/src/main/groovy/wooga/gradle/build/unity/secrets/internal/DefaultResolver.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/secrets/internal/DefaultResolver.groovy
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.build.unity.secrets.internal
+
+import wooga.gradle.build.unity.secrets.Secret
+import wooga.gradle.build.unity.secrets.SecretResolver
+
+class DefaultResolver implements SecretResolver {
+    final Closure<String> resolver
+
+    DefaultResolver(Closure<String> resolver) {
+        this.resolver = resolver
+    }
+
+    @Override
+    Secret<?> resolve(String secretId) {
+        def secret = resolver.call(secretId)
+        if(String.isInstance(secret)) {
+            return new SecretText(secret as String)
+        } else {
+            return new SecretFile(secret as byte[])
+        }
+    }
+}

--- a/src/main/groovy/wooga/gradle/build/unity/secrets/internal/DefaultSecret.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/secrets/internal/DefaultSecret.groovy
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.build.unity.secrets.internal
+
+import wooga.gradle.build.unity.secrets.Secret
+
+class DefaultSecret<T> implements Secret<T> {
+    protected T secretValue
+
+    @Override
+    T getSecretValue() {
+        secretValue
+    }
+
+    void setSecretValue(T value) {
+        secretValue = value
+    }
+
+    DefaultSecret() {
+    }
+
+    DefaultSecret(T secret) {
+        this.secretValue = secret
+    }
+}

--- a/src/main/groovy/wooga/gradle/build/unity/secrets/internal/EncryptedSecretFile.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/secrets/internal/EncryptedSecretFile.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.build.unity.secrets.internal
+
+import groovy.transform.InheritConstructors
+
+import javax.crypto.spec.SecretKeySpec
+
+@InheritConstructors
+class EncryptedSecretFile extends AbstractEncryptedSecret<byte[]> {
+
+    @Override
+    byte[] decryptedSecretValue(SecretKeySpec key) {
+        decrypt(secretValue, key)
+    }
+
+    @Override
+    protected byte[] encryptSecretValue(byte[] secret, SecretKeySpec key) {
+        encrypt(secret, key)
+    }
+}

--- a/src/main/groovy/wooga/gradle/build/unity/secrets/internal/EncryptedSecretText.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/secrets/internal/EncryptedSecretText.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.build.unity.secrets.internal
+
+import groovy.transform.InheritConstructors
+
+import javax.crypto.spec.SecretKeySpec
+
+@InheritConstructors
+class EncryptedSecretText extends AbstractEncryptedSecret<String> {
+    @Override
+    String decryptedSecretValue(SecretKeySpec key) {
+        new String(decrypt(base64Decode(secretValue), key), "UTF8")
+    }
+
+    @Override
+    protected String encryptSecretValue(String secret, SecretKeySpec key) {
+        base64Encode(encrypt(secret.bytes, key))
+    }
+}

--- a/src/main/groovy/wooga/gradle/build/unity/secrets/internal/Resolver.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/secrets/internal/Resolver.groovy
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.build.unity.secrets.internal
+
+import wooga.gradle.build.unity.secrets.Secret
+import wooga.gradle.build.unity.secrets.SecretResolver
+
+class Resolver {
+    static SecretResolver withClosure(Closure<String> resolver) {
+        new SecretResolver() {
+            @Override
+            Secret<?> resolve(String secretId) {
+                def secret = resolver.call(secretId)
+                if(String.isInstance(secret)) {
+                    return new SecretText(secret as String)
+                } else {
+                    return new SecretFile(secret as byte[])
+                }
+            }
+        }
+    }
+}

--- a/src/main/groovy/wooga/gradle/build/unity/secrets/internal/SecretFile.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/secrets/internal/SecretFile.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.build.unity.secrets.internal
+
+import groovy.transform.InheritConstructors
+
+@InheritConstructors
+class SecretFile extends DefaultSecret<byte[]> {
+}

--- a/src/main/groovy/wooga/gradle/build/unity/secrets/internal/SecretText.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/secrets/internal/SecretText.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.build.unity.secrets.internal
+
+import groovy.transform.InheritConstructors
+
+@InheritConstructors
+class SecretText extends DefaultSecret<String> {
+}

--- a/src/main/groovy/wooga/gradle/build/unity/secrets/internal/Secrets.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/secrets/internal/Secrets.groovy
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.build.unity.secrets.internal
+
+import org.apache.commons.lang3.RandomStringUtils
+import org.yaml.snakeyaml.DumperOptions
+import org.yaml.snakeyaml.TypeDescription
+import org.yaml.snakeyaml.Yaml
+import org.yaml.snakeyaml.constructor.Constructor
+import org.yaml.snakeyaml.introspector.BeanAccess
+import org.yaml.snakeyaml.nodes.Tag
+import org.yaml.snakeyaml.representer.Representer
+import wooga.gradle.build.unity.secrets.EncryptedSecret
+import wooga.gradle.build.unity.secrets.Secret
+
+import javax.crypto.spec.SecretKeySpec
+
+class Secrets implements Map<String, EncryptedSecret<?>> {
+
+    @Delegate
+    Map<String, EncryptedSecret<?>> secrets = [:]
+
+    Secrets() {
+    }
+
+    static Secrets decode(String input) {
+        Constructor constructor = new Constructor()
+        constructor.addTypeDescription(new TypeDescription(Secrets.class, "!secrets"))
+        constructor.addTypeDescription(new TypeDescription(EncryptedSecretText.class, "!secretText"))
+        constructor.addTypeDescription(new TypeDescription(EncryptedSecretFile.class, "!secretFile"))
+        constructor.propertyUtils.beanAccess = BeanAccess.FIELD
+        Yaml yaml = new Yaml(constructor)
+        yaml.loadAs(input, Secrets.class)
+    }
+
+    String encode() {
+        Representer representer = new Representer()
+        representer.propertyUtils.beanAccess = BeanAccess.FIELD
+        representer.defaultFlowStyle = DumperOptions.FlowStyle.BLOCK
+        representer.addClassTag(Secrets.class, new Tag("!secrets"))
+        representer.addClassTag(EncryptedSecretText.class, new Tag("!secretText"))
+        representer.addClassTag(EncryptedSecretFile.class, new Tag("!secretFile"))
+        Yaml yaml = new Yaml(representer)
+
+        yaml.dump(this)
+    }
+
+    class EnvironmentSecrets implements Map<String, Object> {
+        @Delegate
+        private final Map<String,Object> environment = [:]
+
+        void clear() {
+            environment.each { _,secret ->
+                if (File.isInstance(secret)) {
+                    ((File) secret).delete()
+                }
+            }
+            environment.clear()
+        }
+    }
+
+    EnvironmentSecrets encodeEnvironment(SecretKeySpec secretsKey) {
+        EnvironmentSecrets env = new EnvironmentSecrets()
+        secrets.each {secretId, secret ->
+            def decodedSecret = secret.decryptedSecretValue(secretsKey)
+            if(String.isInstance(decodedSecret)) {
+                env.put(secretId.toUpperCase(), decodedSecret as String)
+            } else if(byte[].isInstance(decodedSecret)) {
+                File tempFile = File.createTempFile(RandomStringUtils.random(10, true, true), RandomStringUtils.random(10, true, true))
+                tempFile.deleteOnExit()
+                tempFile.bytes = decodedSecret as byte[]
+                env.put(secretId.toUpperCase(), tempFile)
+            } else {
+                throw new ScriptException("Unsupported secret type ${secret.secretValue.class} of ${secretId}")
+            }
+        }
+        env
+    }
+
+    void putSecret(String secretId, Secret<?> secret, SecretKeySpec secretsKey) {
+        def encryptedSecret
+
+        if(String.isInstance(secret.secretValue)) {
+            encryptedSecret = new EncryptedSecretText(secret as Secret<String>, secretsKey)
+        } else if(byte[].isInstance(secret.secretValue)) {
+            encryptedSecret = new EncryptedSecretFile(secret as Secret<byte[]>, secretsKey)
+        } else {
+            throw new IllegalArgumentException("Unsupported secret type ${secret.secretValue.class} of ${secretId}")
+        }
+        secrets.put(secretId, encryptedSecret)
+    }
+
+    Secret<?> getSecret(String secretId, SecretKeySpec secretsKey) {
+        if(secrets.containsKey(secretId)) {
+            EncryptedSecret<?> secret = secrets.get(secretId)
+            return secret.decryptSecret(secretsKey)
+        }
+        return null
+    }
+
+    Collection<Secret<?>> secretValues(SecretKeySpec secretsKey) {
+        secrets.values().collect {it.decryptSecret(secretsKey)}
+    }
+}

--- a/src/test/groovy/wooga/gradle/build/unity/secrets/internal/EncryptedSecretFileSpec.groovy
+++ b/src/test/groovy/wooga/gradle/build/unity/secrets/internal/EncryptedSecretFileSpec.groovy
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.build.unity.secrets.internal
+
+
+import wooga.gradle.build.unity.secrets.Secret
+
+import javax.crypto.spec.SecretKeySpec
+import java.security.SecureRandom
+
+class EncryptedSecretFileSpec extends EncryptedSecretSpec<byte[], EncryptedSecretFile, SecretFile> {
+
+    @Override
+    byte[] getTestValue() {
+        SecureRandom random = new SecureRandom()
+        byte[] test = new byte[2048]
+        random.nextBytes(test)
+        test
+    }
+
+    @Override
+    SecretFile createSecret(byte[] value) {
+        new SecretFile(value)
+    }
+
+    @Override
+    EncryptedSecretFile createEncryptedSecret(Secret<byte[]> secret, SecretKeySpec secretKey) {
+        new EncryptedSecretFile(secret, secretKey)
+    }
+}

--- a/src/test/groovy/wooga/gradle/build/unity/secrets/internal/EncryptedSecretSpec.groovy
+++ b/src/test/groovy/wooga/gradle/build/unity/secrets/internal/EncryptedSecretSpec.groovy
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.build.unity.secrets.internal
+
+
+import wooga.gradle.build.unity.secrets.EncryptedSecret
+import wooga.gradle.build.unity.secrets.Secret
+
+import javax.crypto.BadPaddingException
+import javax.crypto.spec.SecretKeySpec
+
+abstract class EncryptedSecretSpec<T, E extends EncryptedSecret<T>, S extends Secret<T>> extends SecretSpec<T, S> {
+    SecretKeySpec secretKey
+
+    abstract E createEncryptedSecret(Secret<T> secret, SecretKeySpec key)
+
+    def setup() {
+        secretKey = EncryptionSpecHelper.createSecretKey("some_secret_passphrase")
+    }
+
+    def "can encrypt secret"() {
+        given: "a secret"
+        def secret = createSecret(testValue)
+
+        when:
+        def encrypted = createEncryptedSecret(secret, secretKey)
+
+        then:
+        encrypted.secretValue != secret.secretValue
+    }
+
+    def "can decrypt secret"() {
+        given: "an encrypted secret"
+        def secret = createSecret(testValue)
+        def encrypted = createEncryptedSecret(secret, secretKey)
+
+        expect:
+        encrypted.decryptedSecretValue(secretKey) == secret.secretValue
+    }
+
+    def "can used saved key"() {
+        given: "an encrypted secret"
+        def secret = createSecret(testValue)
+        def encrypted = createEncryptedSecret(secret, secretKey)
+
+        and: "a key saved to disk"
+        def testKey = File.createTempFile("test","secretKey")
+        testKey.bytes = secretKey.encoded
+
+        and: "a second key created from file"
+        def keyFromFile = new SecretKeySpec(testKey.bytes, "AES")
+
+        expect:
+        encrypted.decryptedSecretValue(keyFromFile) == secret.secretValue
+    }
+
+    def "decrypt with different key fails"() {
+        given: "an encrypted secret"
+        def secret = createSecret(testValue)
+        def encrypted = createEncryptedSecret(secret, secretKey)
+
+        and: "a second encrypted value with a different key"
+        def secondKey = EncryptionSpecHelper.createSecretKey("some_other_secret_passphrase")
+
+        when:
+        encrypted.decryptedSecretValue(secondKey)
+
+        then:
+        thrown(BadPaddingException)
+    }
+}

--- a/src/test/groovy/wooga/gradle/build/unity/secrets/internal/EncryptedSecretTextSpec.groovy
+++ b/src/test/groovy/wooga/gradle/build/unity/secrets/internal/EncryptedSecretTextSpec.groovy
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.build.unity.secrets.internal
+
+import wooga.gradle.build.unity.secrets.Secret
+
+import javax.crypto.spec.SecretKeySpec
+
+class EncryptedSecretTextSpec extends EncryptedSecretSpec<String, EncryptedSecretText, SecretText> {
+
+    String testValue = "Secret123456789Secret"
+
+    @Override
+    SecretText createSecret(String value) {
+        new SecretText(value)
+    }
+
+    @Override
+    EncryptedSecretText createEncryptedSecret(Secret<String> secret, SecretKeySpec secretKey) {
+        new EncryptedSecretText(secret, secretKey)
+    }
+}

--- a/src/test/groovy/wooga/gradle/build/unity/secrets/internal/EncryptionSpecHelper.groovy
+++ b/src/test/groovy/wooga/gradle/build/unity/secrets/internal/EncryptionSpecHelper.groovy
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.build.unity.secrets.internal
+
+import javax.crypto.SecretKeyFactory
+import javax.crypto.spec.PBEKeySpec
+import javax.crypto.spec.SecretKeySpec
+import java.security.SecureRandom
+import java.security.spec.KeySpec
+
+class EncryptionSpecHelper {
+    static SecretKeySpec createSecretKey(String passphrase) {
+        SecureRandom random = new SecureRandom()
+        byte[] salt = new byte[16]
+        random.nextBytes(salt)
+
+        KeySpec spec = new PBEKeySpec(passphrase.chars, salt, 65536, 256)
+        SecretKeyFactory f = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA1");
+        byte[] key = f.generateSecret(spec).getEncoded();
+        new SecretKeySpec(key, "AES");
+    }
+}

--- a/src/test/groovy/wooga/gradle/build/unity/secrets/internal/SecretSpec.groovy
+++ b/src/test/groovy/wooga/gradle/build/unity/secrets/internal/SecretSpec.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.build.unity.secrets.internal
+
+import spock.lang.Specification
+import wooga.gradle.build.unity.secrets.Secret
+
+abstract class SecretSpec<T, S extends Secret<T>> extends Specification {
+    abstract T getTestValue()
+    abstract S createSecret(T value)
+
+    def "can fetch secret value"() {
+        given: "a secret"
+        def secret = createSecret(testValue)
+
+        expect:
+        secret.secretValue != null
+    }
+
+
+}

--- a/src/test/groovy/wooga/gradle/build/unity/secrets/internal/SecretsSpec.groovy
+++ b/src/test/groovy/wooga/gradle/build/unity/secrets/internal/SecretsSpec.groovy
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.build.unity.secrets.internal
+
+
+import spock.lang.Specification
+import spock.lang.Unroll
+import wooga.gradle.build.unity.secrets.EncryptedSecret
+
+import javax.crypto.spec.SecretKeySpec
+
+class SecretsSpec extends Specification {
+
+    SecretKeySpec key
+    Secrets secrets
+
+    def setup() {
+        key = EncryptionSpecHelper.createSecretKey("secret_pass_phrase")
+        secrets = new Secrets()
+    }
+
+    @Unroll
+    def "can put unencrypted secret<#type>"() {
+        when:
+        secrets.putSecret(secretId, new DefaultSecret(value), key)
+
+        then:
+        noExceptionThrown()
+        secrets.containsKey(secretId)
+        secrets.get(secretId) != null
+        EncryptedSecret.isInstance(secrets.get(secretId))
+
+        where:
+        type     | value            | supported
+        "String" | "a secret"       | true
+        "byte[]" | "a secret".bytes | true
+        secretId = "someId"
+    }
+
+    def "can get unencrypted secret<#type>"() {
+        given: "a secret"
+        def secret = new DefaultSecret(value)
+        secrets.putSecret(secretId, secret, key)
+
+        when:
+        def result = secrets.getSecret(secretId, key)
+
+        then:
+        noExceptionThrown()
+        result != null
+        result.secretValue == secret.secretValue
+        result != secret
+
+        where:
+        type     | value            | supported
+        "String" | "a secret"       | true
+        "byte[]" | "a secret".bytes | true
+        secretId = "someId"
+    }
+
+    def "can list secretId"() {
+        given: "a few secrets"
+        secretIds.each {
+            secrets.putSecret(it, new DefaultSecret(it.toUpperCase()), key)
+        }
+
+        expect:
+        secrets.keySet() == secretIds.toSet()
+
+        where:
+        secretIds = ["secret1", "secret2", "secret3", "secret4"]
+    }
+
+    def "can list encrypted secret values"() {
+        given: "a few secrets"
+        secretIds.each {
+            secrets.putSecret(it, new DefaultSecret(testValue), key)
+        }
+
+        expect:
+        secrets.values().size() == secretIds.size()
+        secrets.values().every { it.secretValue != testValue}
+        secrets.values().every { it.decryptedSecretValue(key) == testValue}
+
+        where:
+        secretIds = ["secret1", "secret2", "secret3", "secret4"]
+        testValue = "testValue"
+    }
+
+    def "can list decrypted secret values"() {
+        given: "a few secrets"
+        secretIds.each {
+            secrets.putSecret(it, new DefaultSecret(testValue), key)
+        }
+
+        expect:
+        secrets.secretValues(key) != secrets.values()
+        secrets.secretValues(key).size() == secretIds.size()
+        secrets.secretValues(key).every { it.secretValue == testValue}
+
+        where:
+        secretIds = ["secret1", "secret2", "secret3", "secret4"]
+        testValue = "testValue"
+    }
+
+    @Unroll
+    def "add secret fails when type is not supported (#type)"() {
+        when:
+        secrets.putSecret("someId", new DefaultSecret(value), key)
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message.startsWith("Unsupported secret type")
+
+        where:
+        type    | value
+        "bool"  | true
+        "int"   | 123456
+        "float" | 1.6
+    }
+
+    def "can dump encrypted secrets to yml"() {
+        given: "some secret texts"
+        secrets.putSecret("test1", new SecretText("testValue1"), key)
+        secrets.putSecret("test2", new SecretText("testValue2"), key)
+
+        and: "some secret files"
+        secrets.putSecret("test3", new SecretFile("testValue1".bytes), key)
+        secrets.putSecret("test4", new SecretFile("testValue2".bytes), key)
+
+        secrets.values()
+
+        when:
+        String ymlDump = secrets.encode()
+
+        then:
+        noExceptionThrown()
+        ymlDump != null
+        def loadedSecrets = Secrets.decode(ymlDump)
+        loadedSecrets.encode() == ymlDump
+        loadedSecrets.getSecret("test3", key).secretValue == "testValue1".bytes
+    }
+
+    def "can encode for environment"() {
+        given: "some secret texts"
+        secrets.putSecret("test1", new SecretText("testValue1"), key)
+        secrets.putSecret("test2", new SecretText("testValue2"), key)
+
+        and: "some secret files"
+        secrets.putSecret("test3", new SecretFile("testValue1".bytes), key)
+        secrets.putSecret("test4", new SecretFile("testValue2".bytes), key)
+
+        when:
+        def env = secrets.encodeEnvironment(key)
+
+        then:
+        noExceptionThrown()
+        env != null
+        env["TEST1"] == "testValue1"
+        env["TEST2"] == "testValue2"
+        ((File)(env["TEST3"])).bytes == "testValue1".bytes
+        ((File)(env["TEST4"])).bytes == "testValue2".bytes
+
+        cleanup:
+        env.each { _, value ->
+            if (File.isInstance(value)) {
+                ((File) value).delete()
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

see wooga/wdk-unity-UnifiedBuildSystem#94
This patch brings in base type for future secret handling. These types are planned as a base API for further detailed implementation in future patches / plugin extensions.

We have three basic sets of types

* _secrets_ - a wrapper type that holds a secret value
* _resolver_ - a basic object that can resolve a secret
* _secrets_ a map like structure to hold secrets in memory

### Secrets

The exposed type is an interface with a pretty simple API

```groovy
interface Secret<T> {
    T getSecretValue()
}
```

There is one base implementation available (`DefaultSecret`) and two concrete implementations for secret file (`byte[]`) and secret text (`String`). The concrete classes are only added for completion and are used in some unit tests.

A second extended form of secret is the `EncryptedSecret`.

```groovy
interface EncryptedSecret<T> extends Secret<T> {
    T decryptedSecretValue(SecretKeySpec key)
    Secret<T> decryptSecret(SecretKeySpec key)
}
```

Objects of type `EncryptedSecret` should encrypt the secret value on creation. The type contains a two API's to either convert this type back to an unencrypted secret or to return the enclosed secret value directly. To make implementation easier, this patch also adds an `abstract` base class for `EncryptedSecret` objects calles `AbstractEncryptedSecret`. This class contains helper methods to encode and decode the secret value with a passed `AES` key. The implementor needs to provide two implementations:

```groovy
abstract T decryptedSecretValue(SecretKeySpec key)
abstract protected T encryptSecretValue(T secret, SecretKeySpec key)
```

Two concrete types are also provided for the `EncryptedSecret` called
`EncryptedSecretFile` and `EncryptedSecretText`.

### Resolver

The `SecretResolver` interface contains only one small API

```groovy
interface SecretResolver<T> {
    Secret<T> resolve(String secretId)
}
```
This patch provides a default implemetation which is not type bound. It also uses a `Closure` as the inner resolver. It only supports two secrets types: (`byte[]` and `String`)

```groovy
@Override
Secret<?> resolve(String secretId) {
    def secret = resolver.call(secretId)
    if(String.isInstance(secret)) {
        return new SecretText(secret as String)
    } else {
        return new SecretFile(secret as byte[])
    }
}
```

This type should not be used for production.

### Secrtes

This is a `Map<String, EncryptedSecret<?>>` like structure. It's main purpose is to keep multiple secrets in memory and serialize them secure on disk.

Next to the `Map<String, EncryptedSecret<?>>` API, some concrete API's are provided to store unencrypted secrets and fetch them.

```groovy
void putSecret(String secretId, Secret<?> secret, SecretKeySpec secretsKey)
Secret<?> getSecret(String secretId, SecretKeySpec secretsKey)
Collection<Secret<?>> secretValues(SecretKeySpec secretsKey)
```

The whole object can be encoded into two forms:

* yaml encoded (encrypted)
* environment map (unencrypted)

The yaml encoding returns the map in yaml serialized form. All secrets are encrypted and the correct key is needed to deserialize the object back.

The environment map is a `Map<String, Object>` like structure. All `SecretFile` secrets will be saved to a temp file to disk on creation. The filepath will be added as a `File` object to the returning map. On `clear` or when the jvm gets closed these temp files are deleted again. `SecretText` secrets are just passed as `String` objects in the map.

## Changes

* ![ADD] security handling base types

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
