### PR TITLE
Add secret resolver implementations

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,12 @@
 #!groovy
 @Library('github.com/wooga/atlas-jenkins-pipeline@1.x') _
 
-withCredentials([string(credentialsId: 'atlas_build_unity_coveralls_token', variable: 'coveralls_token')]) {
-    buildGradlePlugin plaforms: ['osx','windows', 'linux'], coverallsToken: coveralls_token, testEnvironment:[]
+withCredentials([
+                    string(credentialsId: 'atlas_build_unity_coveralls_token', variable: 'coveralls_token'),
+                    string(credentialsId: 'aws.secretsmanager.integration.accesskey', variable: 'accesskey'),
+                    string(credentialsId: 'aws.secretsmanager.integration.secretkey', variable: 'secretkey'),
+                ])
+{
+    def env = ["ATLAS_AWS_INTEGRATION_ACCESS_KEY=${accesskey}", "ATLAS_AWS_INTEGRATION_SECRET_KEY=${secretkey}"]
+    buildGradlePlugin plaforms: ['osx','windows', 'linux'], coverallsToken: coveralls_token, testEnvironment:env
 }

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,7 @@ dependencies {
     compile 'gradle.plugin.net.wooga.gradle:atlas-unity:1.+'
     compile 'xmlwise:xmlwise:1.2.11'
     compile 'commons-codec:commons-codec:1.14'
+    compile 'software.amazon.awssdk:secretsmanager:2.13.42'
     testCompile 'org.apache.commons:commons-text:1.8'
     testCompile 'com.github.stefanbirkner:system-rules:1.18.0'
     testCompile('com.nagternal:spock-genesis:0.6.0') {

--- a/src/main/groovy/wooga/gradle/build/unity/secrets/BasicAWSCredentials.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/secrets/BasicAWSCredentials.groovy
@@ -1,0 +1,24 @@
+package wooga.gradle.build.unity.secrets
+
+import software.amazon.awssdk.auth.credentials.AwsCredentials
+
+class BasicAWSCredentials implements AwsCredentials {
+
+    final String accessKeyId
+    final String secretAccessKey
+
+    BasicAWSCredentials(String AWSAccessKeyId, String AWSSecretKey) {
+        this.accessKeyId = AWSAccessKeyId
+        this.secretAccessKey = AWSSecretKey
+    }
+
+    @Override
+    String accessKeyId() {
+        accessKeyId
+    }
+
+    @Override
+    String secretAccessKey() {
+        secretAccessKey
+    }
+}

--- a/src/main/groovy/wooga/gradle/build/unity/secrets/internal/AWSSecretsManagerResolver.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/secrets/internal/AWSSecretsManagerResolver.groovy
@@ -1,0 +1,46 @@
+package wooga.gradle.build.unity.secrets.internal
+
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse
+import software.amazon.awssdk.services.secretsmanager.model.ResourceNotFoundException
+import wooga.gradle.build.unity.secrets.Secret
+import wooga.gradle.build.unity.secrets.SecretResolver
+import wooga.gradle.build.unity.secrets.SecretResolverException
+
+class AWSSecretsManagerResolver implements SecretResolver {
+
+    private final SecretsManagerClient secretsManager
+
+    AWSSecretsManagerResolver(SecretsManagerClient client) {
+        secretsManager = client
+    }
+
+    AWSSecretsManagerResolver(AwsCredentialsProvider credentials, Region region) {
+        this(SecretsManagerClient.builder().credentialsProvider(credentials).region(region).build())
+    }
+
+    AWSSecretsManagerResolver(Region region) {
+        this(SecretsManagerClient.builder().region(region).build())
+    }
+
+    @Override
+    Secret<?> resolve(String secretId) {
+        GetSecretValueRequest request = GetSecretValueRequest.builder().secretId(secretId).build() as GetSecretValueRequest
+        GetSecretValueResponse response = null
+        Secret<?> secret = null
+        try {
+            response = secretsManager.getSecretValue(request)
+        } catch (ResourceNotFoundException e) {
+            throw new SecretResolverException("Unable to resolve secret with id ${secretId}", e)
+        }
+
+        if (response.secretString()) {
+            return new DefaultSecret(response.secretString())
+        }
+
+        new DefaultSecret(response.secretBinary().asByteArray())
+    }
+}

--- a/src/main/groovy/wooga/gradle/build/unity/secrets/internal/EnvironmentResolver.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/secrets/internal/EnvironmentResolver.groovy
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ *
+ */
+
+package wooga.gradle.build.unity.secrets.internal
+
+import wooga.gradle.build.unity.secrets.Secret
+import wooga.gradle.build.unity.secrets.SecretResolver
+import wooga.gradle.build.unity.secrets.SecretResolverException
+
+class EnvironmentResolver implements SecretResolver {
+    @Override
+    Secret resolve(String secretId) {
+        String secret = System.getenv(secretId.toUpperCase())
+        if(!secret) {
+            throw new SecretResolverException("Unable to resolve secret with id ${secretId}")
+        }
+
+        def f = new File(secret)
+        if(f.exists()) {
+            return new DefaultSecret(f.bytes)
+        }
+
+        new DefaultSecret(secret)
+    }
+}

--- a/src/main/groovy/wooga/gradle/build/unity/secrets/internal/SecretResolverChain.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/secrets/internal/SecretResolverChain.groovy
@@ -1,0 +1,54 @@
+package wooga.gradle.build.unity.secrets.internal
+
+import wooga.gradle.build.unity.secrets.Secret
+import wooga.gradle.build.unity.secrets.SecretResolver
+import wooga.gradle.build.unity.secrets.SecretResolverException
+
+class SecretResolverChain implements SecretResolver, List<SecretResolver> {
+
+    @Delegate
+    private final List<SecretResolver> resolverChain
+
+    SecretResolverChain(Iterable<SecretResolver> resolver) {
+        resolverChain = []
+        addAll(resolver)
+    }
+
+    SecretResolverChain() {
+        this([])
+    }
+
+    void setResolverChain(Iterable<SecretResolver> resolver) {
+        clear()
+        addAll(resolver)
+    }
+
+    void setResolverChain(SecretResolver... resolver) {
+        setResolverChain(resolver.toList())
+    }
+
+    @Override
+    Secret<?> resolve(String secretId) {
+        if(empty) {
+            throw new SecretResolverException("No secret resolvers configured.")
+        }
+
+        Secret secret = null
+
+        for(SecretResolver resolver in resolverChain) {
+            try {
+                secret = resolver.resolve(secretId)
+                if(secret) {
+                    break
+                }
+            }
+            catch(SecretResolverException ignored) {}
+        }
+
+        if(!secret) {
+            throw new SecretResolverException("Unable to resolve secret with id ${secretId}")
+        }
+
+        secret
+    }
+}

--- a/src/test/groovy/wooga/gradle/build/unity/secrets/internal/AWSSecretsManagerResolverSpec.groovy
+++ b/src/test/groovy/wooga/gradle/build/unity/secrets/internal/AWSSecretsManagerResolverSpec.groovy
@@ -1,0 +1,67 @@
+package wooga.gradle.build.unity.secrets.internal
+
+
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
+import software.amazon.awssdk.core.SdkBytes
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient
+import software.amazon.awssdk.services.secretsmanager.model.CreateSecretRequest
+import software.amazon.awssdk.services.secretsmanager.model.DeleteSecretRequest
+import spock.lang.Shared
+import wooga.gradle.build.unity.secrets.BasicAWSCredentials
+
+class AWSSecretsManagerResolverSpec extends SecretsResolverSpec<AWSSecretsManagerResolver> {
+
+    @Shared
+    SecretsManagerClient secretsManager
+
+    @Shared
+    Region region = Region.EU_WEST_1
+
+    AWSSecretsManagerResolver resolver
+
+    @Override
+    AWSSecretsManagerResolver getSubject() {
+        if(!resolver) {
+            resolver = new AWSSecretsManagerResolver(secretsManager)
+        }
+        resolver
+    }
+
+    def setupSpec() {
+        def accessKey = System.getenv("ATLAS_AWS_INTEGRATION_ACCESS_KEY")
+        def secretKey = System.getenv("ATLAS_AWS_INTEGRATION_SECRET_KEY")
+        def builder = SecretsManagerClient.builder().region(region)
+
+        if (accessKey && secretKey) {
+            def credentials = new BasicAWSCredentials(accessKey, secretKey)
+            def credentialsProvider = StaticCredentialsProvider.create(credentials)
+            builder.credentialsProvider(credentialsProvider)
+        }
+        secretsManager = builder.build()
+    }
+
+    @Override
+    void createSecret(String secretId, byte[] secretValue) {
+        def r = CreateSecretRequest.builder()
+                .name(secretId)
+                .secretBinary(SdkBytes.fromByteArray(secretValue))
+                .build() as CreateSecretRequest
+        secretsManager.createSecret(r)
+    }
+
+    @Override
+    void createSecret(String secretId, String secretValue) {
+        def r = CreateSecretRequest.builder()
+                .name(secretId)
+                .secretString(secretValue)
+                .build() as CreateSecretRequest
+        secretsManager.createSecret(r)
+    }
+
+    @Override
+    void deleteSecret(String secretId) {
+        def d = DeleteSecretRequest.builder().secretId(secretId).forceDeleteWithoutRecovery(true).build() as DeleteSecretRequest
+        secretsManager.deleteSecret(d)
+    }
+}

--- a/src/test/groovy/wooga/gradle/build/unity/secrets/internal/EnvironmentResolverSpec.groovy
+++ b/src/test/groovy/wooga/gradle/build/unity/secrets/internal/EnvironmentResolverSpec.groovy
@@ -1,0 +1,38 @@
+package wooga.gradle.build.unity.secrets.internal
+
+import org.junit.Rule
+import org.junit.contrib.java.lang.system.EnvironmentVariables
+
+class EnvironmentResolverSpec extends SecretsResolverSpec<EnvironmentResolver> {
+
+    @Rule
+    public final EnvironmentVariables environmentVariables = new EnvironmentVariables()
+
+    @Override
+    EnvironmentResolver getSubject() {
+        new EnvironmentResolver()
+    }
+
+    @Override
+    void createSecret(String secretId, byte[] secretValue) {
+        def f = File.createTempFile(secretId, "secret")
+        f.bytes = secretValue
+        f.deleteOnExit()
+
+        environmentVariables.set(secretId.toUpperCase(), f.path)
+    }
+
+    @Override
+    void createSecret(String secretId, String secretValue) {
+        environmentVariables.set(secretId.toUpperCase(), secretValue)
+    }
+
+    @Override
+    void deleteSecret(String secretId) {
+        def v = System.getenv(secretId)
+        if (v && new File(v).exists()) {
+            new File(v).delete()
+        }
+        environmentVariables.clear(secretId.toUpperCase())
+    }
+}

--- a/src/test/groovy/wooga/gradle/build/unity/secrets/internal/SecretResolverChainSpec.groovy
+++ b/src/test/groovy/wooga/gradle/build/unity/secrets/internal/SecretResolverChainSpec.groovy
@@ -1,0 +1,125 @@
+package wooga.gradle.build.unity.secrets.internal
+
+import org.apache.commons.lang3.RandomStringUtils
+import wooga.gradle.build.unity.secrets.Secret
+import wooga.gradle.build.unity.secrets.SecretResolver
+import wooga.gradle.build.unity.secrets.SecretResolverException
+
+class SecretResolverChainSpec extends SecretsResolverSpec<SecretResolverChain> {
+
+    SecretResolverChain resolverChain
+
+    private class TestSecretResolver implements SecretResolver {
+        @Override
+        Secret resolve(String secretId) {
+            throw new SecretResolverException("Unable to resolve secret with id ${secretId}")
+        }
+    }
+
+    def setup() {
+        resolverChain = new SecretResolverChain()
+        resolverChain.add(new TestSecretResolver())
+    }
+
+    def "returns the first non null secret it finds in chained resolvers"() {
+        given: "initial empty resolver chain"
+        resolverChain.clear()
+
+        and: "a resolver that throws an exception"
+        resolverChain.add(new TestSecretResolver())
+
+        and: "a resolver that returns null"
+        def nullResolver = Mock(SecretResolver)
+        nullResolver.resolve(secretId) >> null
+        resolverChain.add(nullResolver)
+
+        and: "a resolver that returns a value"
+        def valueResolver = Mock(SecretResolver)
+        valueResolver.resolve(secretId) >> new DefaultSecret("some secret")
+        resolverChain.add(valueResolver)
+
+        and: "and a second resolver that returns a value"
+        valueResolver = Mock(SecretResolver)
+        valueResolver.resolve(secretId) >> new DefaultSecret("another secret")
+        resolverChain.add(valueResolver)
+
+        expect:
+        resolverChain.resolve(secretId).secretValue == "some secret"
+
+        where:
+        secretId = "some_secret_${RandomStringUtils.randomAlphabetic(20)}"
+    }
+
+    def "fails when no resolver is configured"() {
+        given: "empty resolver chain"
+        resolverChain.clear()
+
+        when:
+        resolverChain.resolve("someSecret")
+
+        then:
+        def e = thrown(SecretResolverException)
+        e.message == "No secret resolvers configured."
+    }
+
+    def "can append resolvers"() {
+        given: "empty resolver chain"
+        resolverChain.clear()
+
+        when:
+        resolverChain.add(Mock(SecretResolver))
+
+        then:
+        resolverChain.size() == 1
+
+        when:
+        resolverChain.addAll([Mock(SecretResolver), Mock(SecretResolver)])
+
+        then:
+        resolverChain.size() == 3
+
+        when:
+        resolverChain.addAll(Mock(SecretResolver), Mock(SecretResolver))
+
+        then:
+        resolverChain.size() == 5
+    }
+
+    def "can set resolver list"() {
+        given: "empty resolver chain"
+        resolverChain.addAll(Mock(SecretResolver), Mock(SecretResolver))
+        assert resolverChain.size() == 3
+
+        when:
+        resolverChain.resolverChain = Mock(SecretResolver)
+
+        then:
+        resolverChain.size() == 1
+    }
+
+    @Override
+    SecretResolverChain getSubject() {
+        return resolverChain
+    }
+
+    @Override
+    void createSecret(String secretId, byte[] secretValue) {
+        //create fake resolver for given secret
+        def resolver = Mock(SecretResolver)
+        resolver.resolve(secretId) >> new DefaultSecret(secretValue)
+        resolverChain.add(resolver)
+    }
+
+    @Override
+    void createSecret(String secretId, String secretValue) {
+        //create fake resolver for given secret
+        def resolver = Mock(SecretResolver)
+        resolver.resolve(secretId) >> new DefaultSecret(secretValue)
+        resolverChain.add(resolver)
+    }
+
+    @Override
+    void deleteSecret(String secretId) {
+        resolverChain.resolverChain = []
+    }
+}

--- a/src/test/groovy/wooga/gradle/build/unity/secrets/internal/SecretsResolverSpec.groovy
+++ b/src/test/groovy/wooga/gradle/build/unity/secrets/internal/SecretsResolverSpec.groovy
@@ -1,0 +1,53 @@
+package wooga.gradle.build.unity.secrets.internal
+
+import org.apache.commons.lang3.RandomStringUtils
+import spock.lang.Specification
+import spock.lang.Unroll
+import wooga.gradle.build.unity.secrets.SecretResolver
+import wooga.gradle.build.unity.secrets.SecretResolverException
+
+abstract class SecretsResolverSpec<T extends SecretResolver> extends Specification {
+
+    abstract T getSubject()
+
+    @Unroll("can resolve secret #type")
+    def "can resolve secret"() {
+        given: "a secret text on AWS"
+        createSecret(secretId, secretValue)
+
+        when:
+        def result = subject.resolve(secretId)
+
+        then:
+        result != null
+        expectedType.isAssignableFrom(result.secretValue.class)
+        result.secretValue == secretValue
+
+        cleanup:
+        deleteSecret(secretId)
+
+        where:
+        secretValue                  | expectedType | type
+        "a random secret".toString() | String       | "text"
+        "a random secret".bytes      | byte[]       | "file"
+        secretId = "wdk_unified_build_system_testSecret_${RandomStringUtils.randomAlphabetic(20)}"
+    }
+
+    def "fails when secret can't be found"() {
+        when:
+        subject.resolve(secretId)
+
+        then:
+        def e = thrown(SecretResolverException.class)
+        e.message == "Unable to resolve secret with id ${secretId}"
+
+        where:
+        secretId = "wdk_unified_build_system_testSecret_${RandomStringUtils.randomAlphabetic(20)}"
+    }
+
+    abstract void createSecret(String secretId, byte[] secretValue)
+
+    abstract void createSecret(String secretId, String secretValue)
+
+    abstract void deleteSecret(String secretId)
+}


### PR DESCRIPTION
## Description

dependson #58 
This patch provides 3 implementation types for `SecretResolver`.

* `EnvironmentResolver` -> resolve secrets from the current process environment
* `AWSSecretsManagerResolver` -> resolve secrets from AWS
* `SecretResolverChain` -> Chain many resolvers together

Only two of the provided implementations are actually capeable to fetch secret values. The `SecretResolverChain`'s main purpose is to provide a way to declare multiple resolver in a fallback chain setup.

## Changes

* ![ADD] `EnvironmentResolver` class
* ![ADD] `AWSSecretsManagerResolver` class
* ![ADD] `SecretsResolverChain` class

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
