### PR TITLE
Allow appConfig lookup key to be configurable

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/build/unity/UnityBuildPluginSecretHandlingIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/unity/UnityBuildPluginSecretHandlingIntegrationSpec.groovy
@@ -57,7 +57,7 @@ class UnityBuildPluginSecretHandlingIntegrationSpec extends UnityIntegrationSpec
         ['ios_ci', 'android_ci', 'webGL_ci'].collect { createFile("${it}.asset", appConfigsDir) }.each {
             Yaml yaml = new Yaml()
             def buildTarget = it.name.split(/_/, 2).first().toLowerCase()
-            def appConfig = ['MonoBehaviour': ['bundleId': 'net.wooga.test', 'batchModeBuildTarget': buildTarget, secrets: secretIds]]
+            def appConfig = ['MonoBehaviour': ['bundleId': 'net.wooga.test', 'batchModeBuildTarget': buildTarget, secretIds: secretIds]]
             it << yaml.dump(appConfig)
         }
 

--- a/src/main/groovy/wooga/gradle/build/unity/SecretSpec.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/SecretSpec.groovy
@@ -14,5 +14,4 @@ interface SecretSpec<T extends SecretSpec> {
     T secretsKey(SecretKeySpec key)
     T secretsKey(String keyFile)
     T secretsKey(File keyFile)
-
 }

--- a/src/main/groovy/wooga/gradle/build/unity/UnityBuildPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/UnityBuildPlugin.groovy
@@ -132,6 +132,7 @@ class UnityBuildPlugin implements Plugin<Project> {
             @Override
             void execute(FetchSecrets t) {
                 t.secretsKey.set(extension.secretsKey)
+                t.appConfigSecretsKey.set(extension.appConfigSecretsKey)
                 t.secretsFile.set(project.provider({
                     project.layout.buildDirectory.dir("secret/${t.name}").get().file("secrets.yml")
                 }))

--- a/src/main/groovy/wooga/gradle/build/unity/UnityBuildPluginConsts.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/UnityBuildPluginConsts.groovy
@@ -176,6 +176,10 @@ class UnityBuildPluginConsts {
     static String SECRETS_KEY_OPTION = "unityBuild.secretsKey"
     static String SECRETS_KEY_ENV_VAR = "UNITY_BUILD_SECRETS_KEY"
 
+    static String APP_CONFIG_SECRETS_KEY_OPTION = "unityBuild.appConfigSecretsKey"
+    static String APP_CONFIG_SECRETS_KEY_ENV_VAR = "UNITY_BUILD_APP_CONFIG_SECRETS_KEY"
+    static String APP_CONFIG_SECRETS_DEFAULT = "secretIds"
+
     /**
      * Default name for the base export location.
      *

--- a/src/main/groovy/wooga/gradle/build/unity/UnityBuildPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/UnityBuildPluginExtension.groovy
@@ -42,4 +42,9 @@ interface UnityBuildPluginExtension<T extends UnityBuildPluginExtension> extends
     ConfigurableFileCollection getIgnoreFilesForExportUpToDateCheck()
 
     Property<SecretResolver> getSecretResolver()
+
+    Property<String> getAppConfigSecretsKey()
+    void setAppConfigSecretsKey(String key)
+    T appConfigSecretsKey(String key)
+
 }

--- a/src/main/groovy/wooga/gradle/build/unity/internal/DefaultUnityBuildPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/internal/DefaultUnityBuildPluginExtension.groovy
@@ -27,6 +27,7 @@ import org.gradle.api.file.RegularFile
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
+import wooga.gradle.build.unity.SecretSpec
 import wooga.gradle.build.unity.UnityBuildPluginConsts
 import wooga.gradle.build.unity.UnityBuildPluginExtension
 import wooga.gradle.build.unity.ios.internal.utils.PropertyUtils
@@ -58,6 +59,7 @@ class DefaultUnityBuildPluginExtension implements UnityBuildPluginExtension {
     final Property<File> exportBuildDirBase
     final Property<Boolean> cleanBuildDirBeforeBuild
 
+    final Property<String> appConfigSecretsKey
     final Property<SecretKeySpec> secretsKey
     final Property<SecretResolver> secretResolver
 
@@ -207,6 +209,24 @@ class DefaultUnityBuildPluginExtension implements UnityBuildPluginExtension {
         })))
 
         secretResolver = project.objects.property(SecretResolver)
+
+        appConfigSecretsKey = project.objects.property(String.class)
+        appConfigSecretsKey.set(project.provider({
+            String key = System.getenv().get(UnityBuildPluginConsts.APP_CONFIG_SECRETS_KEY_ENV_VAR) ?:
+                    project.properties.getOrDefault(UnityBuildPluginConsts.APP_CONFIG_SECRETS_KEY_OPTION, UnityBuildPluginConsts.APP_CONFIG_SECRETS_DEFAULT)
+            key
+        }))
+    }
+
+    @Override
+    void setAppConfigSecretsKey(String key) {
+        appConfigSecretsKey.set(key)
+    }
+
+    @Override
+    SecretSpec appConfigSecretsKey(String key) {
+        setAppConfigSecretsKey(key)
+        return this
     }
 
     void setSecretsKey(SecretKeySpec key) {

--- a/src/main/groovy/wooga/gradle/build/unity/tasks/FetchSecrets.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/tasks/FetchSecrets.groovy
@@ -34,9 +34,20 @@ import wooga.gradle.unity.utils.GenericUnityAsset
 import javax.crypto.spec.SecretKeySpec
 
 class FetchSecrets extends DefaultTask implements SecretSpec {
-    static String SECRETS_KEY = "secrets"
+
     private GenericUnityAsset appConfig
 
+    @Input
+    final Property<String> appConfigSecretsKey
+
+    void setAppConfigSecretsKey(String key) {
+        appConfigSecretsKey.set(key)
+    }
+
+    SecretSpec appConfigSecretsKey(String key) {
+        setAppConfigSecretsKey(key)
+        return this
+    }
     @Input
     final Property<SecretKeySpec> secretsKey
 
@@ -110,8 +121,8 @@ class FetchSecrets extends DefaultTask implements SecretSpec {
     @Internal("read from appConfig file")
     List<String> getSecretIds() {
         def appConfig = getAppConfig()
-        if(appConfig.containsKey(SECRETS_KEY)) {
-            return appConfig[SECRETS_KEY] as List<String>
+        if(appConfig.containsKey(appConfigSecretsKey.get())) {
+            return appConfig[appConfigSecretsKey.get()] as List<String>
         }
         []
     }
@@ -122,6 +133,7 @@ class FetchSecrets extends DefaultTask implements SecretSpec {
         appConfigName = appConfigFile.map { FilenameUtils.removeExtension(it.asFile.name) }
         resolver = project.objects.property(SecretResolver)
         secretsKey = project.objects.property(SecretKeySpec)
+        appConfigSecretsKey = project.objects.property(String)
     }
 
     @TaskAction


### PR DESCRIPTION
## Description

To keep the connection between this plugin and the internal library as loose as possible I changed the appConfig lookup key to be configurable. The default value is the new key used by the library `secretIds`. The key can be changed to any string value in the task or for all fetchSecret task via the plugin extension

## Changes

* ![CHANGE] make appConfig secret ids lookup key configurable

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
