### PR TITLE
Add pods and workspace support

### DIFF
--- a/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPlugin.groovy
@@ -33,6 +33,7 @@ import wooga.gradle.build.unity.ios.tasks.ImportProvisioningProfile
 import wooga.gradle.build.unity.ios.tasks.KeychainTask
 import wooga.gradle.build.unity.ios.tasks.ListKeychainTask
 import wooga.gradle.build.unity.ios.tasks.LockKeychainTask
+import wooga.gradle.build.unity.ios.tasks.PodInstallTask
 import wooga.gradle.build.unity.ios.tasks.PublishTestFlight
 import wooga.gradle.build.unity.ios.tasks.XCodeArchiveTask
 import wooga.gradle.build.unity.ios.tasks.XCodeExportTask
@@ -198,11 +199,16 @@ class IOSBuildPlugin implements Plugin<Project> {
             it.profileName = "${maybeBaseName(baseName, 'signing')}.mobileprovision"
         }
 
+        PodInstallTask podInstall = tasks.create(maybeBaseName(baseName, "podInstall"), PodInstallTask) {
+            it.projectPath = xcodeProject
+        }
+
         def xcodeArchive = tasks.create(maybeBaseName(baseName, "xcodeArchive"), XCodeArchiveTask) {
-            it.dependsOn addKeychain, unlockKeychain
+            it.dependsOn addKeychain, unlockKeychain, podInstall
 
             it.provisioningProfile = importProvisioningProfiles
             it.projectPath = xcodeProject
+            it.workspacePath = podInstall.workspace
             it.buildKeychain = buildKeychain
             it.destinationDir = project.file("${project.buildDir}/archives")
         }

--- a/src/main/groovy/wooga/gradle/build/unity/ios/tasks/PodInstallTask.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/tasks/PodInstallTask.groovy
@@ -1,0 +1,53 @@
+package wooga.gradle.build.unity.ios.tasks
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.FileCollection
+import org.gradle.api.tasks.*
+
+class PodInstallTask extends DefaultTask {
+    private Object projectPath
+
+    @Internal
+    File getProjectPath() {
+        project.files(projectPath).getSingleFile()
+    }
+
+    void setProjectPath(Object path) {
+        projectPath = path
+    }
+
+    XCodeArchiveTask projectPath(Object path) {
+        setProjectPath(path)
+    }
+
+    @InputFiles
+    @SkipWhenEmpty
+    protected FileCollection getInputFiles() {
+        def podFile = project.file("Podfile")
+        def inputFiles = [podFile]
+
+        if(podFile.exists()) {
+            inputFiles << project.file( "Podfile.lock")
+        }
+
+        project.files(inputFiles.findAll { it.exists() }.toArray())
+    }
+
+    @OutputDirectory
+    protected getPodsDir() {
+        project.file("Pods")
+    }
+
+    @OutputDirectory
+    File getWorkspace() {
+        project.file(getProjectPath().path.replaceAll('xcodeproj', 'xcworkspace'))
+    }
+
+    @TaskAction
+    protected void install() {
+        project.exec {
+            executable 'pod'
+            args 'install'
+        }
+    }
+}

--- a/src/main/groovy/wooga/gradle/build/unity/ios/tasks/XCodeArchiveTask.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/tasks/XCodeArchiveTask.groovy
@@ -28,6 +28,7 @@ import java.util.concurrent.Callable
 class XCodeArchiveTask extends ConventionTask {
 
     private Object projectPath
+    private Object workspacePath
     private Object buildKeychain
     private Object provisioningProfile
 
@@ -80,7 +81,25 @@ class XCodeArchiveTask extends ConventionTask {
     }
 
     XCodeArchiveTask projectPath(Object path) {
-        setExportOptionsPlist(path)
+        setProjectPath(path)
+    }
+
+    @Optional
+    @InputDirectory
+    File getWorkspacePath() {
+        def workspace = project.file(workspacePath)
+        if(!workspace.exists()) {
+            return null
+        }
+        workspace
+    }
+
+    void setWorkspacePath(Object path) {
+        workspacePath = path
+    }
+
+    XCodeArchiveTask projectWorkspacePath(Object path) {
+        setWorkspacePath(path)
     }
 
     @Optional
@@ -302,7 +321,9 @@ class XCodeArchiveTask extends ConventionTask {
             arguments << it.toString()
         }
 
-        if (getProjectPath()) {
+        if(getWorkspacePath()) {
+            arguments << "-workspace" << getWorkspacePath().getPath()
+        } else if (getProjectPath()) {
             arguments << "-project" << getProjectPath().getPath()
         }
 

--- a/src/main/groovy/wooga/gradle/build/unity/secrets/internal/AWSSecretsManagerResolver.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/secrets/internal/AWSSecretsManagerResolver.groovy
@@ -26,6 +26,10 @@ class AWSSecretsManagerResolver implements SecretResolver {
         this(SecretsManagerClient.builder().region(region).build())
     }
 
+    AWSSecretsManagerResolver() {
+        this(SecretsManagerClient.builder().build())
+    }
+
     @Override
     Secret<?> resolve(String secretId) {
         GetSecretValueRequest request = GetSecretValueRequest.builder().secretId(secretId).build() as GetSecretValueRequest

--- a/src/test/groovy/wooga/gradle/build/unity/secrets/internal/AWSSecretsManagerResolverSpec.groovy
+++ b/src/test/groovy/wooga/gradle/build/unity/secrets/internal/AWSSecretsManagerResolverSpec.groovy
@@ -16,7 +16,7 @@ class AWSSecretsManagerResolverSpec extends SecretsResolverSpec<AWSSecretsManage
     SecretsManagerClient secretsManager
 
     @Shared
-    Region region = Region.EU_WEST_1
+    Region region = Region.EU_CENTRAL_1
 
     AWSSecretsManagerResolver resolver
 


### PR DESCRIPTION
## Description

This patch adds a new task `podInstall` to the plugin which is a dependend task for `xcodeArchive`. It only executes when a `Podfile` is in the project directory. The `xcodeArchive` task has a new workspace property which is set by default to the workspace generated by podInstall. The workspace has a higher precedance than the project. If the workspace does not exist the task falls back to the project.

The issue is the very nature how cocoapods handles workspaces. You can configure pods to use a preexisting workspace or it generates a new workspace based on the project it finds in the same directory.

The current patch only tries to solve a current workflow issue and needs changes and tests!

## Changes

* ![ADD] `pods` and `workspace` support

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
