### PR TITLE
Change FetchSecrets dependency to AppConfig

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/build/UnityBuildPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/UnityBuildPluginIntegrationSpec.groovy
@@ -266,7 +266,6 @@ class UnityBuildPluginIntegrationSpec extends UnityIntegrationSpec {
         "1.1.0"  | "Closure"      | "1.1.0"
         "1.1.1"  | "Callable"     | "1.1.1"
         "2.0.0"  | "Object"       | "2.0.0"
-        "2.0.0"  | "List<String>" | "[2.0.0]"
 
         value = wrapValueBasedOnType(rawValue, type)
     }

--- a/src/main/groovy/wooga/gradle/build/unity/UnityBuildPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/UnityBuildPlugin.groovy
@@ -132,7 +132,6 @@ class UnityBuildPlugin implements Plugin<Project> {
             @Override
             void execute(FetchSecrets t) {
                 t.secretsKey.set(extension.secretsKey)
-                t.appConfigSecretsKey.set(extension.appConfigSecretsKey)
                 t.secretsFile.set(project.provider({
                     project.layout.buildDirectory.dir("secret/${t.name}").get().file("secrets.yml")
                 }))
@@ -153,7 +152,12 @@ class UnityBuildPlugin implements Plugin<Project> {
                 FetchSecrets fetchSecretsTask = project.tasks.create("fetchSecrets${baseName}", FetchSecrets) { FetchSecrets t ->
                     t.group = "build unity"
                     t.description = "fetches all secrets configured in ${appConfigName}"
-                    t.appConfigFile.set(appConfig)
+                    t.secretIds.set(project.provider({
+                        if(config.containsKey(extension.appConfigSecretsKey.get())) {
+                            return config[extension.appConfigSecretsKey.get()] as List<String>
+                        }
+                        []
+                    }))
                 }
 
                 UnityBuildPlayerTask exportTask = project.tasks.create("export${baseName}", UnityBuildPlayerTask) { UnityBuildPlayerTask t ->

--- a/src/main/groovy/wooga/gradle/build/unity/internal/DefaultUnityBuildPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/internal/DefaultUnityBuildPluginExtension.groovy
@@ -224,7 +224,7 @@ class DefaultUnityBuildPluginExtension implements UnityBuildPluginExtension {
     }
 
     @Override
-    SecretSpec appConfigSecretsKey(String key) {
+    DefaultUnityBuildPluginExtension appConfigSecretsKey(String key) {
         setAppConfigSecretsKey(key)
         return this
     }


### PR DESCRIPTION
## Description

This patch is a preparation to split the secrets handling code from this plugin. The `FetchSecrets` task has a property `appConfigFile` which contains a list of `secretIds` to fetch. To make the task more generic I removed these properties and replaced it with a new property: `final ListProperty<String> secretIds` and provided the implementation details where these secretsIds are coming from in the `UnityBuildPlugin` class. This allows me to split out this task into it's own plugin without ties to UBS.

## Changes

* ![CHANGE] `FetchSecrets` task AppConfig dependency

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
