### PR TITLE
Execute 'pod repo update' before install call

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/build/unity/ios/tasks/CocoaPodSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/unity/ios/tasks/CocoaPodSpec.groovy
@@ -1,0 +1,30 @@
+package wooga.gradle.build.unity.ios.tasks
+
+import wooga.gradle.build.IntegrationSpec
+
+class CocoaPodSpec extends IntegrationSpec {
+    File podMock
+    File podMockPath
+
+    def setupPodMock() {
+        podMockPath = File.createTempDir("pod", "mock")
+
+        def path = System.getenv("PATH")
+        environmentVariables.clear("PATH")
+        String newPath = "${podMockPath}${File.pathSeparator}${path}"
+        environmentVariables.set("PATH", newPath)
+        assert System.getenv("PATH") == newPath
+
+        podMock = createFile("pod", podMockPath)
+        podMock.executable = true
+        podMock << """
+            #!/usr/bin/env bash
+            echo \$@
+            env
+        """.stripIndent()
+    }
+
+    def setup() {
+        setupPodMock()
+    }
+}

--- a/src/integrationTest/groovy/wooga/gradle/build/unity/ios/tasks/PodInstallTaskSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/unity/ios/tasks/PodInstallTaskSpec.groovy
@@ -1,0 +1,95 @@
+package wooga.gradle.build.unity.ios.tasks
+
+import spock.lang.Requires
+
+/**
+ * The test examples in this class are not 100% integration/functional tests.
+ *
+ * We can't run the real pod install as this would bring to much overhead at the moment.
+ * We only test the invocation of pod and its parameters.
+ */
+@Requires({ os.macOs })
+class PodInstallTaskSpec extends CocoaPodSpec {
+    def setup() {
+        def xcodeProject = new File("test.xcodeproj")
+        xcodeProject.mkdirs()
+
+        buildFile << """
+            task podInstall(type: wooga.gradle.build.unity.ios.tasks.PodInstallTask) {
+                projectPath = "${xcodeProject.path}"
+            }
+        """.stripIndent()
+    }
+
+    def "task skips when no Pod file exist in project"() {
+        given: "a sample Pod file"
+        def podFile = createFile("Podfile")
+
+        when:
+        def result = runTasksSuccessfully(taskName)
+
+        then:
+        result.wasExecuted(taskName)
+
+        when:
+        podFile.delete()
+        result = runTasksSuccessfully(taskName)
+
+        then:
+        outputContains(result, "Task :${taskName} NO-SOURCE")
+
+        where:
+        taskName = "podInstall"
+    }
+
+    def "task executes 'repo update' before 'install'"() {
+        given: "a sample Pod file"
+        def podFile = createFile("Podfile")
+
+        when:
+        def result = runTasksSuccessfully(taskName)
+
+        then:
+        outputContains(result, "pod repo update")
+        outputContains(result, "pod install")
+
+        where:
+        taskName = "podInstall"
+    }
+
+    def "buildKeychain caches task outputs"() {
+        given: "a sample Pod file"
+        def podFile = createFile("Podfile")
+
+        and: "a Podfile.lock"
+        def lockFile = createFile("Podfile.lock")
+
+        and: "a gradle run with buildKeychain"
+        runTasksSuccessfully(taskName)
+
+        when:
+        def result = runTasksSuccessfully(taskName)
+
+        then:
+        result.wasUpToDate(taskName)
+
+        when:
+        podFile << "a change"
+        result = runTasksSuccessfully(taskName)
+
+        then:
+        !result.wasUpToDate(taskName)
+        outputContains(result,"Input property 'inputFiles' file ${podFile.path} has changed.")
+
+        when:
+        lockFile << "a change"
+        result = runTasksSuccessfully(taskName)
+
+        then:
+        !result.wasUpToDate(taskName)
+        outputContains(result,"Input property 'inputFiles' file ${lockFile.path} has changed.")
+
+        where:
+        taskName = "podInstall"
+    }
+}

--- a/src/main/groovy/wooga/gradle/build/unity/internal/ExecUtil.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/internal/ExecUtil.groovy
@@ -1,0 +1,20 @@
+package wooga.gradle.build.unity.internal
+
+class ExecUtil {
+    /**
+     * Finds path to executable in PATH.
+     *
+     * This function is aimed to make the whole task testable.
+     * The tests can override the PATH environment variable and
+     * point to a mock executable.
+     *
+     * @param executableName the name of the executable to find in PATH
+     * @return path to executable or executableName
+     */
+    static String getExecutable(String executableName) {
+        def path = System.getenv("PATH").split(File.pathSeparator)
+                .collect {path -> new File(path, executableName)}
+                .find {path -> path.exists() && path.isFile() && path.canExecute()}
+        path? path.path : executableName
+    }
+}

--- a/src/main/groovy/wooga/gradle/build/unity/ios/tasks/ImportProvisioningProfile.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/tasks/ImportProvisioningProfile.groovy
@@ -24,6 +24,7 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFiles
 import org.gradle.api.tasks.TaskAction
+import wooga.gradle.build.unity.internal.ExecUtil
 
 import java.util.concurrent.Callable
 
@@ -191,26 +192,11 @@ class ImportProvisioningProfile extends ConventionTask {
         outputs.upToDateWhen {false}
     }
 
-    /**
-     * Finds path to executable in PATH.
-     *
-     * This function is aimed to make the whole task testable.
-     * The tests can override the PATH environment variable and
-     * point to a mock executable.
-     *
-     * @param executableName the name of the executable to find in PATH
-     * @return path to executable or executableName
-     */
-    private static String getExecutable(String executableName) {
-        def path = System.getenv("PATH").split(File.pathSeparator)
-                .collect {path -> new File(path, "fastlane")}
-                .find {path -> path.exists() && path.isFile() && path.canExecute()}
-        path? path.path : executableName
-    }
+
 
     @TaskAction
     protected void importProfiles() {
-        def executablePath = getExecutable("fastlane")
+        def executablePath = ExecUtil.getExecutable("fastlane")
         project.exec {
             executable executablePath
             args "sigh"

--- a/src/main/groovy/wooga/gradle/build/unity/ios/tasks/PodInstallTask.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/tasks/PodInstallTask.groovy
@@ -3,6 +3,7 @@ package wooga.gradle.build.unity.ios.tasks
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.*
+import wooga.gradle.build.unity.internal.ExecUtil
 
 class PodInstallTask extends DefaultTask {
     private Object projectPath
@@ -45,8 +46,15 @@ class PodInstallTask extends DefaultTask {
 
     @TaskAction
     protected void install() {
+        def executablePath = ExecUtil.getExecutable("pod")
         project.exec {
-            executable 'pod'
+            executable executablePath
+            args 'repo'
+            args 'update'
+        }
+
+        project.exec {
+            executable executablePath
             args 'install'
         }
     }


### PR DESCRIPTION
## Description

Cocoapods is not autoupdating the specs repo on its own when calling pod install. This patch makes sure to call `pod repo update` before each `pod install` call.

This patch brings additional tests as well because the patch that added the pod install task did not provide any.

## Changes

* ![IMPROVE] execute `pod repo update` before `pod install`

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
