### PR TITLE
Improve internal keychain handling

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,5 +2,5 @@
 @Library('github.com/wooga/atlas-jenkins-pipeline@1.x') _
 
 withCredentials([string(credentialsId: 'atlas_build_unity_coveralls_token', variable: 'coveralls_token')]) {
-    buildGradlePlugin plaforms: ['osx','windows', 'linux'], coverallsToken: coveralls_token, testEnvironment:[]
+    buildGradlePlugin plaforms: ['osx','windows', 'linux'], coverallsToken: coveralls_token, testEnvironment:["ATLAS_BUILD_UNITY_IOS_EXECUTE_KEYCHAIN_SPEC=YES"]
 }

--- a/src/integrationTest/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginIntegrationSpec.groovy
@@ -17,12 +17,12 @@
 
 package wooga.gradle.build.unity.ios
 
-import org.junit.ClassRule
-import org.junit.contrib.java.lang.system.ProvideSystemProperty
+
 import spock.lang.Requires
 import spock.lang.Shared
 import spock.lang.Unroll
 import wooga.gradle.build.IntegrationSpec
+
 import wooga.gradle.build.unity.ios.internal.utils.SecurityUtil
 
 @Requires({ os.macOs })
@@ -69,7 +69,6 @@ class IOSBuildPluginIntegrationSpec extends IntegrationSpec {
     }
 
     def setup() {
-        SecurityUtil.getKeychainConfigFile().parentFile.mkdirs()
         buildFile << """
             ${applyPlugin(IOSBuildPlugin)}
 
@@ -88,6 +87,11 @@ class IOSBuildPluginIntegrationSpec extends IntegrationSpec {
 
         createTestCertificate(new File(projectDir, "test_ca.p12"), certPassword)
 
+        keychainLookupList.clear()
+    }
+
+    def cleanup() {
+        keychainLookupList.clear()
     }
 
     def "creates custom build keychain"() {
@@ -110,7 +114,7 @@ class IOSBuildPluginIntegrationSpec extends IntegrationSpec {
         def result = runTasksSuccessfully("addKeychain")
         assert !result.wasUpToDate("addKeychain")
         assert buildKeychain.exists()
-        assert SecurityUtil.keychainIsAdded(buildKeychain)
+        assert keychainLookupList.contains(buildKeychain)
 
         when:
         runTasksSuccessfully("removeKeychain")

--- a/src/integrationTest/groovy/wooga/gradle/build/unity/ios/tasks/KeychainTaskSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/unity/ios/tasks/KeychainTaskSpec.groovy
@@ -22,6 +22,7 @@ import spock.lang.Shared
 import wooga.gradle.build.IntegrationSpec
 import wooga.gradle.build.unity.ios.IOSBuildPlugin
 import wooga.gradle.build.unity.ios.KeychainLookupList
+
 import wooga.gradle.build.unity.ios.internal.utils.SecurityUtil
 
 @Requires({ os.macOs })
@@ -66,7 +67,6 @@ class KeychainTaskSpec extends IntegrationSpec {
     }
 
     def setup() {
-        SecurityUtil.getKeychainConfigFile().parentFile.mkdirs()
         buildFile << """
             ${applyPlugin(IOSBuildPlugin)}
 


### PR DESCRIPTION
## Description

second patch for current mainline (master) Original Patch here #70 

The `KeychainLookupList` first added to this project missused an undocumented feature in macOS to implement all keychain additions and removals without the need to execute the `security` commandline tool. The logic worked by altering the config plist for the security tool: `com.apple.security.plist`. This worked great and allowed to run the tests on a mocked config file without altering the state of the executing machine.

Since macOS 10.15 this solution became more and more brittle as this file was no longer created by default and is sometimes deleted. Multiple issues came up over the last few month so I decided to move the logic back to the `security` cli tool.

There is a huge drawback when it comes to tests. We would like to test the logic in isolation but there is only one global keychain lookup mechanims on macOS. So altering this under test means to leave a broken state. To limit issues with broken/failing or forced closed tests I decided to implement the tests with a simple reset function.

Before and After each test we reset the keychain lookup list to a default state. This state is by default the login keychain + the configured default keychain. One can also provide a list of keychains via a custom environment variable `ATLAS_BUILD_UNITY_IOS_DEFAULT_KEYCHAINS`. This variable should provide a list separated by `:` (unix) or `;` (windows) to the default user keychains. The `KeychainLookupListSpec` is also not running by default to not break any system configs. To opt in declare the `ATLAS_BUILD_UNITY_IOS_EXECUTE_KEYCHAIN_SPEC` environment variable.

The implementation of the tests and the changed `KeychainLookupList` has one minor breaking behavior change. The method `clear` will do an internal `reset` instead of removing all keychains.

## Changes

* ![IMPROVE] internal keychain handling

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
