### PR TITLE
Add conditional reset of the keychains before adding build keychain

### DIFF
--- a/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPlugin.groovy
@@ -182,9 +182,15 @@ class IOSBuildPlugin implements Plugin<Project> {
             it.keychain = buildKeychain
         }
 
+        def resetKeychains = tasks.create(maybeBaseName(baseName, "resetKeychains"), ListKeychainTask) {
+            it.action = ListKeychainTask.Action.reset
+            it.keychain buildKeychain
+        }
+
         def addKeychain = tasks.create(maybeBaseName(baseName, "addKeychain"), ListKeychainTask) {
             it.action = ListKeychainTask.Action.add
             it.keychain buildKeychain
+            dependsOn(resetKeychains)
         }
 
         def removeKeychain = tasks.create(maybeBaseName(baseName, "removeKeychain"), ListKeychainTask) {

--- a/src/test/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginSpec.groovy
@@ -98,6 +98,7 @@ class IOSBuildPluginSpec extends ProjectSpec {
         "buildKeychain"              | KeychainTask
         "unlockKeychain"             | LockKeychainTask
         "lockKeychain"               | LockKeychainTask
+        "resetKeychains"             | ListKeychainTask
         "addKeychain"                | ListKeychainTask
         "removeKeychain"             | ListKeychainTask
         "importProvisioningProfiles" | ImportProvisioningProfile
@@ -132,6 +133,7 @@ class IOSBuildPluginSpec extends ProjectSpec {
         "buildKeychain"              | KeychainTask
         "unlockKeychain"             | LockKeychainTask
         "lockKeychain"               | LockKeychainTask
+        "resetKeychains"             | ListKeychainTask
         "addKeychain"                | ListKeychainTask
         "removeKeychain"             | ListKeychainTask
         "importProvisioningProfiles" | ImportProvisioningProfile


### PR DESCRIPTION
## Description

second patch for current mainline (master) Original Patch here #72 

This patch adds a new action `reset` to the `ListKeychainTask`. This action is conditional and bount to the environment variable `ATLAS_BUILD_UNITY_IOS_RESET_KEYCHAINS`. The variable is checked directly in the task implementation for now. The plugin configures a new task called `resetKeychains` and adds it as a dependency to the `addKeychain` task.

This change should help with _ghost keychains_ on the CI system.

## Changes

* ![ADD] conditional reset of keychains


[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
