### PR TITLE
Add xcodebuild plugin setup

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/xcodebuild/IntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/xcodebuild/IntegrationSpec.groovy
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ *
+ */
+
+package wooga.gradle.xcodebuild
+
+import nebula.test.functional.ExecutionResult
+import org.apache.commons.text.StringEscapeUtils
+import org.junit.Rule
+import org.junit.contrib.java.lang.system.EnvironmentVariables
+import org.junit.contrib.java.lang.system.ProvideSystemProperty
+import spock.lang.Requires
+
+@Requires({ os.macOs })
+class IntegrationSpec extends nebula.test.IntegrationSpec {
+
+    @Rule
+    ProvideSystemProperty properties = new ProvideSystemProperty("ignoreDeprecations", "true")
+
+    @Rule
+    public final EnvironmentVariables environmentVariables = new EnvironmentVariables()
+
+    def escapedPath(String path) {
+        String osName = System.getProperty("os.name").toLowerCase()
+        if (osName.contains("windows")) {
+            return StringEscapeUtils.escapeJava(path)
+        }
+        path
+    }
+
+    def setup() {
+        def gradleVersion = System.getenv("GRADLE_VERSION")
+        if (gradleVersion) {
+            this.gradleVersion = gradleVersion
+            fork = true
+        }
+    }
+
+    Boolean outputContains(ExecutionResult result, String message) {
+        result.standardOutput.contains(message) || result.standardError.contains(message)
+    }
+
+    String wrapValueBasedOnType(Object rawValue, Class type) {
+        wrapValueBasedOnType(rawValue, type.simpleName)
+    }
+
+    String wrapValueBasedOnType(Object rawValue, String type) {
+        def value
+        def rawValueEscaped = String.isInstance(rawValue) ? "'${rawValue}'" : rawValue
+        def subtypeMatches = type =~ /(?<mainType>\w+)<(?<subType>[\w<>]+)>/
+        def subType = (subtypeMatches.matches()) ? subtypeMatches.group("subType") : null
+        type = (subtypeMatches.matches()) ? subtypeMatches.group("mainType") : type
+        switch (type) {
+            case "Closure":
+                if (subType) {
+                    value = "{${wrapValueBasedOnType(rawValue, subType)}}"
+                } else {
+                    value = "{$rawValueEscaped}"
+                }
+                break
+            case "Callable":
+                value = "new java.util.concurrent.Callable<${rawValue.class.typeName}>() {@Override ${rawValue.class.typeName} call() throws Exception { $rawValueEscaped }}"
+                break
+            case "Object":
+                value = "new Object() {@Override String toString() { ${rawValueEscaped}.toString() }}"
+                break
+            case "Provider":
+                switch (subType) {
+                    case "RegularFile":
+                        value = "project.layout.file(${wrapValueBasedOnType(rawValue, "Provider<File>")})"
+                        break
+                    case "Directory":
+                        value = """
+                                project.provider({
+                                    def d = project.layout.directoryProperty()
+                                    d.set(${wrapValueBasedOnType(rawValue, "File")})
+                                    d.get()
+                                })
+                        """.trim().stripIndent()
+                        break
+                    default:
+                        value = "project.provider(${wrapValueBasedOnType(rawValue, "Closure<${subType}>")})"
+                        break
+                }
+                break
+            case "String":
+                value = "${escapedPath(rawValueEscaped.toString())}"
+                break
+            case "String[]":
+                value = "'{${rawValue.collect { '"' + it + '"' }.join(",")}}'.split(',')"
+                break
+            case "File":
+                value = "new File('${escapedPath(rawValue.toString())}')"
+                break
+            case "String...":
+                value = "${rawValue.collect { '"' + it + '"' }.join(", ")}"
+                break
+            case "List":
+                value = "[${rawValue.collect { '"' + it + '"' }.join(", ")}]"
+                break
+            case "Map":
+                value = "[" + rawValue.collect { k, v -> "${wrapValueBasedOnType(k, k.getClass())} : ${wrapValueBasedOnType(v, v.getClass())}" }.join(", ") + "]"
+                value = value == "[]" ? "[:]" : value
+                break
+            default:
+                value = rawValue
+        }
+        value
+    }
+}

--- a/src/integrationTest/groovy/wooga/gradle/xcodebuild/XcodeBuildIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/xcodebuild/XcodeBuildIntegrationSpec.groovy
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ *
+ */
+
+package wooga.gradle.xcodebuild
+
+abstract class XcodeBuildIntegrationSpec extends IntegrationSpec {
+   def setup() {
+       buildFile << """
+          group = 'test'
+          ${applyPlugin(XcodeBuildPlugin)}
+       """.stripIndent()
+   }
+}

--- a/src/main/groovy/wooga/gradle/xcodebuild/XcodeBuildPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/xcodebuild/XcodeBuildPlugin.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ *
+ */
+
+package wooga.gradle.xcodebuild
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import wooga.gradle.xcodebuild.internal.DefaultXcodeBuildPluginExtension
+
+class XcodeBuildPlugin implements Plugin<Project> {
+
+    static final String EXTENSION_NAME = "xcodebuild"
+
+    @Override
+    void apply(Project project) {
+        project.extensions.create(XcodeBuildPluginExtension, EXTENSION_NAME, DefaultXcodeBuildPluginExtension, project)
+    }
+}

--- a/src/main/groovy/wooga/gradle/xcodebuild/XcodeBuildPluginConsts.groovy
+++ b/src/main/groovy/wooga/gradle/xcodebuild/XcodeBuildPluginConsts.groovy
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wooga.gradle.xcodebuild
+
+class XcodeBuildPluginConsts {
+}

--- a/src/main/groovy/wooga/gradle/xcodebuild/XcodeBuildPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/xcodebuild/XcodeBuildPluginExtension.groovy
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wooga.gradle.xcodebuild
+
+interface XcodeBuildPluginExtension {
+
+}

--- a/src/main/groovy/wooga/gradle/xcodebuild/internal/DefaultXcodeBuildPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/xcodebuild/internal/DefaultXcodeBuildPluginExtension.groovy
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wooga.gradle.xcodebuild.internal
+
+import org.gradle.api.Project
+import wooga.gradle.xcodebuild.XcodeBuildPluginExtension
+
+class DefaultXcodeBuildPluginExtension implements XcodeBuildPluginExtension {
+
+    final Project project
+
+    DefaultXcodeBuildPluginExtension(Project project) {
+        this.project = project
+    }
+}

--- a/src/main/resources/META-INF/gradle-plugins/net.wooga.xcodebuild.properties
+++ b/src/main/resources/META-INF/gradle-plugins/net.wooga.xcodebuild.properties
@@ -1,0 +1,20 @@
+#
+# Copyright 2018-2020 Wooga GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+#
+#
+
+implementation-class=wooga.gradle.xcodebuild.XcodeBuildPlugin

--- a/src/test/groovy/wooga/gradle/xcodebuild/XcodeBuildPluginActivationSpec.groovy
+++ b/src/test/groovy/wooga/gradle/xcodebuild/XcodeBuildPluginActivationSpec.groovy
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wooga.gradle.xcodebuild
+
+import nebula.test.PluginProjectSpec
+
+class XcodeBuildPluginActivationSpec extends PluginProjectSpec {
+    @Override
+    String getPluginName() {
+        return 'net.wooga.xcodebuild'
+    }
+}

--- a/src/test/groovy/wooga/gradle/xcodebuild/XcodeBuildPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/xcodebuild/XcodeBuildPluginSpec.groovy
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wooga.gradle.xcodebuild
+
+
+import nebula.test.ProjectSpec
+import wooga.gradle.build.unity.UnityBuildPlugin
+import wooga.gradle.xcodebuild.internal.DefaultXcodeBuildPluginExtension
+
+class XcodeBuildPluginSpec extends ProjectSpec {
+    public static final String PLUGIN_NAME = 'net.wooga.xcodebuild'
+
+    def 'Creates the [xcodebuild] extension'() {
+        given:
+        assert !project.plugins.hasPlugin(PLUGIN_NAME)
+        assert !project.extensions.findByName(XcodeBuildPlugin.EXTENSION_NAME)
+
+        when:
+        project.plugins.apply(PLUGIN_NAME)
+
+        then:
+        def extension = project.extensions.findByName(XcodeBuildPlugin.EXTENSION_NAME)
+        extension instanceof DefaultXcodeBuildPluginExtension
+    }
+}


### PR DESCRIPTION
## Description

This patch adds the base skeleton for the new `net.wooga.xcodebuild` plugin. The functionality with the first task will come in multiple patches

## Changes

* ![ADD] `net.wooga.xcodebuild` plugin setup

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
