### PR TITLE
Add file and pretty console logging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,9 @@ dependencies {
     compile 'xmlwise:xmlwise:1.2.11'
     compile 'commons-codec:commons-codec:1.14'
     compile 'software.amazon.awssdk:secretsmanager:2.13.42'
+    compile('com.wooga.xcodebuild:xcpretty:1.+') {
+        exclude group: "org.codehaus.groovy", module: "groovy-all"
+    }
     testCompile 'org.apache.commons:commons-text:1.8'
     testCompile 'com.github.stefanbirkner:system-rules:1.18.0'
     testCompile('com.nagternal:spock-genesis:0.6.0') {

--- a/src/integrationTest/groovy/wooga/gradle/xcodebuild/IntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/xcodebuild/IntegrationSpec.groovy
@@ -51,6 +51,28 @@ class IntegrationSpec extends nebula.test.IntegrationSpec {
         }
     }
 
+    enum PropertyLocation {
+        none, script, property, env
+
+        String reason() {
+            switch (this) {
+                case script:
+                    return "value is provided in script"
+                case property:
+                    return "value is provided in props"
+                case env:
+                    return "value is set in env"
+                default:
+                    return "no value was configured"
+            }
+        }
+    }
+
+    String envNameFromProperty(String extensionName, String property) {
+        "${extensionName.toUpperCase()}_${property.replaceAll(/([A-Z])/, "_\$1").toUpperCase()}"
+    }
+
+
     Boolean outputContains(ExecutionResult result, String message) {
         result.standardOutput.contains(message) || result.standardError.contains(message)
     }

--- a/src/integrationTest/groovy/wooga/gradle/xcodebuild/XcodeBuildIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/xcodebuild/XcodeBuildIntegrationSpec.groovy
@@ -26,4 +26,6 @@ abstract class XcodeBuildIntegrationSpec extends IntegrationSpec {
           ${applyPlugin(XcodeBuildPlugin)}
        """.stripIndent()
    }
+
+
 }

--- a/src/integrationTest/groovy/wooga/gradle/xcodebuild/XcodeBuildPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/xcodebuild/XcodeBuildPluginIntegrationSpec.groovy
@@ -1,0 +1,283 @@
+package wooga.gradle.xcodebuild
+
+import spock.lang.Requires
+import spock.lang.Unroll
+import wooga.gradle.xcodebuild.tasks.XcodeArchive
+
+@Requires({ os.macOs })
+class XcodeBuildPluginIntegrationSpec extends XcodeBuildIntegrationSpec {
+
+    @Unroll()
+    def "extension property :#property returns '#testValue' if #reason"() {
+        given:
+        buildFile << """
+            task(custom) {
+                doLast {
+                    def value = ${extensionName}.${property}.getOrNull()
+                    println("${extensionName}.${property}: " + value)
+                }
+            }
+        """
+
+        and: "a gradle.properties"
+        def propertiesFile = createFile("gradle.properties")
+
+        switch (location) {
+            case PropertyLocation.script:
+                buildFile << "${extensionName}.${invocation}"
+                break
+            case PropertyLocation.property:
+                propertiesFile << "${extensionName}.${property} = ${escapedValue}"
+                break
+            case PropertyLocation.env:
+                environmentVariables.set(envNameFromProperty(extensionName, property), "${value}")
+                break
+            default:
+                break
+        }
+
+        and: "the test value with replace placeholders"
+        if (testValue instanceof String) {
+            testValue = testValue.replaceAll("#projectDir#", escapedPath(projectDir.path))
+        }
+
+        when: ""
+        def result = runTasksSuccessfully("custom")
+
+        then:
+        result.standardOutput.contains("${extensionName}.${property}: ${testValue}")
+
+        where:
+        property          | method                | rawValue                   | expectedValue                                                          | type                        | location                  | additionalInfo
+        "logsDir"         | _                     | "custom/logs"              | "#projectDir#/build/custom/logs"                                       | _                           | PropertyLocation.env      | " as relative path"
+        "logsDir"         | _                     | "custom/logs"              | "#projectDir#/build/custom/logs"                                       | _                           | PropertyLocation.property | " as relative path"
+        "logsDir"         | _                     | "build/custom/logs"        | "#projectDir#/build/custom/logs"                                       | "File"                      | PropertyLocation.script   | " as relative path"
+        "logsDir"         | _                     | "build/custom/logs"        | "#projectDir#/build/custom/logs"                                       | "Provider<Directory>"       | PropertyLocation.script   | " as relative path"
+        "logsDir"         | "logsDir.set"         | "build/custom/logs"        | "#projectDir#/build/custom/logs"                                       | "File"                      | PropertyLocation.script   | " as relative path"
+        "logsDir"         | "logsDir.set"         | "build/custom/logs"        | "#projectDir#/build/custom/logs"                                       | "Provider<Directory>"       | PropertyLocation.script   | " as relative path"
+        "logsDir"         | "logsDir"             | "build/custom/logs"        | "#projectDir#/build/custom/logs"                                       | "File"                      | PropertyLocation.script   | " as relative path"
+        "logsDir"         | "logsDir"             | "build/custom/logs"        | "#projectDir#/build/custom/logs"                                       | "Provider<Directory>"       | PropertyLocation.script   | " as relative path"
+        "logsDir"         | _                     | _                          | "#projectDir#/build/logs"                                              | _                           | PropertyLocation.none     | ""
+
+        "logsDir"         | _                     | "/custom/logs"             | _                                                                      | _                           | PropertyLocation.env      | " as absolute path"
+        "logsDir"         | _                     | "/custom/logs"             | _                                                                      | _                           | PropertyLocation.property | " as absolute path"
+        "logsDir"         | _                     | "/custom/logs"             | _                                                                      | "File"                      | PropertyLocation.script   | " as absolute path"
+        "logsDir"         | _                     | "/custom/logs"             | _                                                                      | "Provider<Directory>"       | PropertyLocation.script   | " as absolute path"
+        "logsDir"         | "logsDir.set"         | "/custom/logs"             | _                                                                      | "File"                      | PropertyLocation.script   | " as absolute path"
+        "logsDir"         | "logsDir.set"         | "/custom/logs"             | _                                                                      | "Provider<Directory>"       | PropertyLocation.script   | " as absolute path"
+        "logsDir"         | "logsDir"             | "/custom/logs"             | _                                                                      | "File"                      | PropertyLocation.script   | " as absolute path"
+        "logsDir"         | "logsDir"             | "/custom/logs"             | _                                                                      | "Provider<Directory>"       | PropertyLocation.script   | " as absolute path"
+
+        "derivedDataPath" | _                     | "custom/derivedData"       | "#projectDir#/build/custom/derivedData"                                | _                           | PropertyLocation.env      | " as relative path"
+        "derivedDataPath" | _                     | "custom/derivedData"       | "#projectDir#/build/custom/derivedData"                                | _                           | PropertyLocation.property | " as relative path"
+        "derivedDataPath" | _                     | "build/custom/derivedData" | "#projectDir#/build/custom/derivedData"                                | "File"                      | PropertyLocation.script   | " as relative path"
+        "derivedDataPath" | _                     | "build/custom/derivedData" | "#projectDir#/build/custom/derivedData"                                | "Provider<Directory>"       | PropertyLocation.script   | " as relative path"
+        "derivedDataPath" | "derivedDataPath.set" | "build/custom/derivedData" | "#projectDir#/build/custom/derivedData"                                | "File"                      | PropertyLocation.script   | " as relative path"
+        "derivedDataPath" | "derivedDataPath.set" | "build/custom/derivedData" | "#projectDir#/build/custom/derivedData"                                | "Provider<Directory>"       | PropertyLocation.script   | " as relative path"
+        "derivedDataPath" | "derivedDataPath"     | "build/custom/derivedData" | "#projectDir#/build/custom/derivedData"                                | "File"                      | PropertyLocation.script   | " as relative path"
+        "derivedDataPath" | "derivedDataPath"     | "build/custom/derivedData" | "#projectDir#/build/custom/derivedData"                                | "Provider<Directory>"       | PropertyLocation.script   | " as relative path"
+        "derivedDataPath" | _                     | _                          | "#projectDir#/build/derivedData"                                       | _                           | PropertyLocation.none     | ""
+
+        "derivedDataPath" | _                     | "/custom/derivedData"      | _                                                                      | _                           | PropertyLocation.env      | " as absolute path"
+        "derivedDataPath" | _                     | "/custom/derivedData"      | _                                                                      | _                           | PropertyLocation.property | " as absolute path"
+        "derivedDataPath" | _                     | "/custom/derivedData"      | _                                                                      | "File"                      | PropertyLocation.script   | " as absolute path"
+        "derivedDataPath" | _                     | "/custom/derivedData"      | _                                                                      | "Provider<Directory>"       | PropertyLocation.script   | " as absolute path"
+        "derivedDataPath" | "derivedDataPath.set" | "/custom/derivedData"      | _                                                                      | "File"                      | PropertyLocation.script   | " as absolute path"
+        "derivedDataPath" | "derivedDataPath.set" | "/custom/derivedData"      | _                                                                      | "Provider<Directory>"       | PropertyLocation.script   | " as absolute path"
+        "derivedDataPath" | "derivedDataPath"     | "/custom/derivedData"      | _                                                                      | "File"                      | PropertyLocation.script   | " as absolute path"
+        "derivedDataPath" | "derivedDataPath"     | "/custom/derivedData"      | _                                                                      | "Provider<Directory>"       | PropertyLocation.script   | " as absolute path"
+
+        "xarchivesDir"    | _                     | "custom/archives"          | "#projectDir#/build/custom/archives"                                   | _                           | PropertyLocation.env      | " as relative path"
+        "xarchivesDir"    | _                     | "custom/archives"          | "#projectDir#/build/custom/archives"                                   | _                           | PropertyLocation.property | " as relative path"
+        "xarchivesDir"    | _                     | "build/custom/archives"    | "#projectDir#/build/custom/archives"                                   | "File"                      | PropertyLocation.script   | " as relative path"
+        "xarchivesDir"    | _                     | "build/custom/archives"    | "#projectDir#/build/custom/archives"                                   | "Provider<Directory>"       | PropertyLocation.script   | " as relative path"
+        "xarchivesDir"    | "xarchivesDir.set"    | "build/custom/archives"    | "#projectDir#/build/custom/archives"                                   | "File"                      | PropertyLocation.script   | " as relative path"
+        "xarchivesDir"    | "xarchivesDir.set"    | "build/custom/archives"    | "#projectDir#/build/custom/archives"                                   | "Provider<Directory>"       | PropertyLocation.script   | " as relative path"
+        "xarchivesDir"    | "xarchivesDir"        | "build/custom/archives"    | "#projectDir#/build/custom/archives"                                   | "File"                      | PropertyLocation.script   | " as relative path"
+        "xarchivesDir"    | "xarchivesDir"        | "build/custom/archives"    | "#projectDir#/build/custom/archives"                                   | "Provider<Directory>"       | PropertyLocation.script   | " as relative path"
+        "xarchivesDir"    | _                     | _                          | "#projectDir#/build/archives"                                          | _                           | PropertyLocation.none     | ""
+
+        "xarchivesDir"    | _                     | "/custom/archives"         | _                                                                      | _                           | PropertyLocation.env      | " as absolute path"
+        "xarchivesDir"    | _                     | "/custom/archives"         | _                                                                      | _                           | PropertyLocation.property | " as absolute path"
+        "xarchivesDir"    | _                     | "/custom/archives"         | _                                                                      | "File"                      | PropertyLocation.script   | " as absolute path"
+        "xarchivesDir"    | _                     | "/custom/archives"         | _                                                                      | "Provider<Directory>"       | PropertyLocation.script   | " as absolute path"
+        "xarchivesDir"    | "xarchivesDir.set"    | "/custom/archives"         | _                                                                      | "File"                      | PropertyLocation.script   | " as absolute path"
+        "xarchivesDir"    | "xarchivesDir.set"    | "/custom/archives"         | _                                                                      | "Provider<Directory>"       | PropertyLocation.script   | " as absolute path"
+        "xarchivesDir"    | "xarchivesDir"        | "/custom/archives"         | _                                                                      | "File"                      | PropertyLocation.script   | " as absolute path"
+        "xarchivesDir"    | "xarchivesDir"        | "/custom/archives"         | _                                                                      | "Provider<Directory>"       | PropertyLocation.script   | " as absolute path"
+
+        "consoleSettings" | "consoleSettings.set" | "plain"                    | "ConsoleSettings{prettyPrint=true, useUnicode=false, colorize=never}"  | "ConsoleSettings"           | PropertyLocation.script   | ""
+        "consoleSettings" | "consoleSettings.set" | "rich"                     | "ConsoleSettings{prettyPrint=true, useUnicode=true, colorize=always}"  | "Provider<ConsoleSettings>" | PropertyLocation.script   | ""
+        "consoleSettings" | "consoleSettings"     | "verbose"                  | "ConsoleSettings{prettyPrint=false, useUnicode=false, colorize=never}" | "ConsoleSettings"           | PropertyLocation.script   | ""
+        "consoleSettings" | "consoleSettings"     | "auto"                     | "ConsoleSettings{prettyPrint=true, useUnicode=true, colorize=auto}"    | "Provider<ConsoleSettings>" | PropertyLocation.script   | ""
+
+        extensionName = "xcodebuild"
+        value = (type != _) ? wrapValueBasedOnType(rawValue, type, { type ->
+            switch (type) {
+                case ConsoleSettings.class.simpleName:
+                    return "${ConsoleSettings.class.name}.fromGradleOutput(org.gradle.api.logging.configuration.ConsoleOutput.${rawValue.toString().capitalize()})"
+                default:
+                    return rawValue
+            }
+        }) : rawValue
+        providedValue = (location == PropertyLocation.script) ? type : value
+        testValue = (expectedValue == _) ? rawValue : expectedValue
+        reason = location.reason() + ((location == PropertyLocation.none) ? "" : "  with '$providedValue' ") + additionalInfo
+        escapedValue = (value instanceof String) ? escapedPath(value) : value
+        invocation = (method != _) ? "${method}(${escapedValue})" : "${property} = ${escapedValue}"
+    }
+
+    @Unroll("can configure console settings with #useConfigureBlockMessage #invocation and type #type")
+    def "can configure console settings"() {
+        given: "a task to read back the value"
+        buildFile << """
+            task("readValue") {
+                doLast {
+                    println("property: " + ${extensionName}.consoleSettings.get().${property})
+                }
+            }
+        """.stripIndent()
+
+        and: "a set property"
+        and: "a set property"
+        if(useConfigureBlock) {
+            buildFile << """
+            ${extensionName}.consoleSettings {
+                ${invocation}
+            }
+            """.stripIndent()
+        } else {
+            buildFile << "${extensionName}.consoleSettings.get().${invocation}"
+        }
+
+        when:
+        def result = runTasksSuccessfully("readValue")
+
+        then:
+        outputContains(result, "property: " + expectedValue.toString())
+
+        where:
+        property      | method           | rawValue                           | type          | useConfigureBlock
+        "prettyPrint" | "setPrettyPrint" | true                               | "Boolean"     | false
+        "prettyPrint" | "setPrettyPrint" | false                              | "Boolean"     | false
+        "useUnicode"  | "setUseUnicode"  | true                               | "Boolean"     | false
+        "useUnicode"  | "setUseUnicode"  | false                              | "Boolean"     | false
+        "colorize"    | "setColorize"    | ConsoleSettings.ColorOption.always | "ColorOption" | false
+        "colorize"    | "setColorize"    | ConsoleSettings.ColorOption.never  | "ColorOption" | false
+        "colorize"    | "setColorize"    | ConsoleSettings.ColorOption.auto   | "ColorOption" | false
+        "colorize"    | _                | "always"                           | "String"      | false
+        "colorize"    | _                | "never"                            | "String"      | false
+        "colorize"    | _                | "auto"                             | "String"      | false
+
+        "prettyPrint" | "setPrettyPrint" | true                               | "Boolean"     | true
+        "prettyPrint" | "setPrettyPrint" | false                              | "Boolean"     | true
+        "useUnicode"  | "setUseUnicode"  | true                               | "Boolean"     | true
+        "useUnicode"  | "setUseUnicode"  | false                              | "Boolean"     | true
+        "colorize"    | "setColorize"    | ConsoleSettings.ColorOption.always | "ColorOption" | true
+        "colorize"    | "setColorize"    | ConsoleSettings.ColorOption.never  | "ColorOption" | true
+        "colorize"    | "setColorize"    | ConsoleSettings.ColorOption.auto   | "ColorOption" | true
+        "colorize"    | _                | "always"                           | "String"      | true
+        "colorize"    | _                | "never"                            | "String"      | true
+        "colorize"    | _                | "auto"                             | "String"      | true
+
+        value = wrapValueBasedOnType(rawValue, type) { type ->
+            switch (type) {
+                case ConsoleSettings.ColorOption.simpleName:
+                    return ConsoleSettings.ColorOption.name + ".${rawValue.toString()}"
+                default:
+                    return rawValue
+            }
+        }
+        extensionName = "xcodebuild"
+        useConfigureBlockMessage = useConfigureBlock ? "configuration closure and" : ""
+        invocation = (method == _) ? "${property} = ${value}" : "${method}(${value})"
+        expectedValue = rawValue
+    }
+
+    @Unroll("property #property of type #tasktype.simpleName is bound to property #extensionProperty of extension #extensionName")
+    def "task property is connected with extension"() {
+        given:
+        buildFile << """
+            task ${taskName}(type: ${tasktype.name})
+
+            task(custom) {
+                doLast {
+                    def value = ${taskName}.${property}.getOrNull()
+                    println("${taskName}.${property}: " + value)
+                }
+            }
+            
+            ${extensionName}.${invocation}
+        """.stripIndent()
+
+        and: "the test value with replace placeholders"
+        if (testValue instanceof String) {
+            testValue = testValue.replaceAll("#projectDir#", escapedPath(projectDir.path))
+            testValue = testValue.replaceAll("#taskName#", taskName)
+        }
+
+        when: ""
+        def result = runTasksSuccessfully("custom")
+
+        then:
+        result.standardOutput.contains("${taskName}.${property}: ${testValue}")
+
+        where:
+        property          | extensionProperty | tasktype     | rawValue                   | expectedValue                                      | type
+        "logFile"         | "logsDir"         | XcodeArchive | "build/custom/logs"        | "#projectDir#/build/custom/logs/#taskName#.log"    | "File"
+        "derivedDataPath" | "derivedDataPath" | XcodeArchive | "build/custom/derivedData" | "#projectDir#/build/custom/derivedData/#taskName#" | "File"
+        "destinationDir"  | "xarchivesDir"    | XcodeArchive | "build/custom/archives"    | "#projectDir#/build/custom/archives"               | "File"
+
+        extensionName = "xcodebuild"
+        taskName = "xcodebuildTask"
+        value = (type != _) ? wrapValueBasedOnType(rawValue, type) : rawValue
+        testValue = (expectedValue == _) ? rawValue : expectedValue
+        escapedValue = (value instanceof String) ? escapedPath(value) : value
+        invocation = "${extensionProperty}.set(${escapedValue})"
+    }
+
+    @Unroll("gradle console #console sets default value for consoleSettings.#consoleSettingProperty: #expectedValue")
+    def "consoleSettings fallback to gradle console settings"() {
+        given: "a properties file with console selected"
+        def propertiesFile = createFile("gradle.properties")
+        propertiesFile << "org.gradle.console=${console}"
+
+        and: "a task to read out the value"
+        buildFile << """
+            task(readValue) {
+                doLast {
+                    def consoleSettings = ${extensionName}.consoleSettings.get()
+                    println("${extensionName}.consoleSettings.${consoleSettingProperty}: " + consoleSettings.${consoleSettingProperty})
+                }
+            }
+        """
+
+        when:
+        def result = runTasksSuccessfully('readValue')
+
+        then:
+        outputContains(result, "${extensionName}.consoleSettings.${consoleSettingProperty}: ${expectedValue}")
+
+        where:
+        console   | consoleSettingProperty | expectedValue
+        "rich"    | "prettyPrint"          | true
+        "rich"    | "useUnicode"           | true
+        "rich"    | "colorize"             | ConsoleSettings.ColorOption.always
+
+        "plain"   | "prettyPrint"          | true
+        "plain"   | "useUnicode"           | false
+        "plain"   | "colorize"             | ConsoleSettings.ColorOption.never
+
+        "verbose" | "prettyPrint"          | false
+        "verbose" | "useUnicode"           | false
+        "verbose" | "colorize"             | ConsoleSettings.ColorOption.never
+
+        "auto"    | "prettyPrint"          | true
+        "auto"    | "useUnicode"           | true
+        "auto"    | "colorize"             | ConsoleSettings.ColorOption.auto
+
+        extensionName = "xcodebuild"
+
+    }
+
+}

--- a/src/integrationTest/groovy/wooga/gradle/xcodebuild/tasks/AbstractXcodeTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/xcodebuild/tasks/AbstractXcodeTaskIntegrationSpec.groovy
@@ -1,0 +1,199 @@
+package wooga.gradle.xcodebuild.tasks
+
+import spock.lang.Unroll
+import wooga.gradle.xcodebuild.ConsoleSettings
+import wooga.gradle.xcodebuild.XcodeBuildIntegrationSpec
+
+abstract class AbstractXcodeTaskIntegrationSpec extends XcodeBuildIntegrationSpec {
+
+    abstract String getTestTaskName()
+
+    abstract Class getTaskType()
+
+    abstract String getWorkingXcodebuildTaskConfig()
+
+    @Unroll("can set property #property with #method and type #type")
+    def "can set property #property with #method and type #type base"() {
+        given: "a custom xcodebuild task"
+        buildFile << """
+            task("${testTaskName}", type: ${taskType.name})
+        """.stripIndent()
+
+        and: "a task to read back the value"
+        buildFile << """
+            task("readValue") {
+                doLast {
+                    println("property: " + ${testTaskName}.${property}.get())
+                }
+            }
+        """.stripIndent()
+
+        and: "a set property"
+        buildFile << """
+            ${testTaskName}.${invocation}
+        """.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully("readValue")
+
+        then:
+        outputContains(result, "property: " + testValue.toString())
+
+        where:
+        property          | method                | rawValue               | expectedValue                                                          | type
+        "logFile"         | "logFile"             | "/some/path/test1.log" | _                                                                      | "File"
+        "logFile"         | "logFile"             | "/some/path/test2.log" | _                                                                      | "Provider<RegularFile>"
+        "logFile"         | "logFile.set"         | "/some/path/test3.log" | _                                                                      | "File"
+        "logFile"         | "logFile.set"         | "/some/path/test4.log" | _                                                                      | "Provider<RegularFile>"
+        "logFile"         | "setLogFile"          | "/some/path/test5.log" | _                                                                      | "File"
+        "logFile"         | "setLogFile"          | "/some/path/test6.log" | _                                                                      | "Provider<RegularFile>"
+        "consoleSettings" | "consoleSettings.set" | "plain"                | "ConsoleSettings{prettyPrint=true, useUnicode=false, colorize=never}"  | "ConsoleSettings"
+        "consoleSettings" | "consoleSettings.set" | "rich"                 | "ConsoleSettings{prettyPrint=true, useUnicode=true, colorize=always}"  | "Provider<ConsoleSettings>"
+        "consoleSettings" | "consoleSettings"     | "verbose"              | "ConsoleSettings{prettyPrint=false, useUnicode=false, colorize=never}" | "ConsoleSettings"
+        "consoleSettings" | "consoleSettings"     | "auto"                 | "ConsoleSettings{prettyPrint=true, useUnicode=true, colorize=auto}"    | "Provider<ConsoleSettings>"
+
+        value = wrapValueBasedOnType(rawValue, type, { type ->
+            switch (type) {
+                case ConsoleSettings.class.simpleName:
+                    return "${ConsoleSettings.class.name}.fromGradleOutput(org.gradle.api.logging.configuration.ConsoleOutput.${rawValue.toString().capitalize()})"
+                default:
+                    return rawValue
+            }
+        })
+        invocation = (method == _) ? "${property} = ${value}" : "${method}(${value})"
+        testValue = (expectedValue == _) ? rawValue : expectedValue
+    }
+
+    @Unroll("can configure console settings with #useConfigureBlockMessage #invocation and type #type")
+    def "can configure console settings"() {
+        given: "a custom xcodebuild task"
+        buildFile << """
+            task("${testTaskName}", type: ${taskType.name})
+        """.stripIndent()
+
+        and: "a task to read back the value"
+        buildFile << """
+            task("readValue") {
+                doLast {
+                    println("property: " + ${testTaskName}.consoleSettings.get().${property})
+                }
+            }
+        """.stripIndent()
+
+        and: "a set property"
+        if (useConfigureBlock) {
+            buildFile << """
+            ${testTaskName}.consoleSettings {
+                ${invocation}
+            }
+            """.stripIndent()
+        } else {
+            buildFile << "${testTaskName}.consoleSettings.get().${invocation}"
+        }
+
+        when:
+        def result = runTasksSuccessfully("readValue")
+
+        then:
+        outputContains(result, "property: " + expectedValue.toString())
+
+        where:
+        property      | method           | rawValue                           | type          | useConfigureBlock
+        "prettyPrint" | "setPrettyPrint" | true                               | "Boolean"     | false
+        "prettyPrint" | "setPrettyPrint" | false                              | "Boolean"     | false
+        "useUnicode"  | "setUseUnicode"  | true                               | "Boolean"     | false
+        "useUnicode"  | "setUseUnicode"  | false                              | "Boolean"     | false
+        "colorize"    | "setColorize"    | ConsoleSettings.ColorOption.always | "ColorOption" | false
+        "colorize"    | "setColorize"    | ConsoleSettings.ColorOption.never  | "ColorOption" | false
+        "colorize"    | "setColorize"    | ConsoleSettings.ColorOption.auto   | "ColorOption" | false
+        "colorize"    | _                | "always"                           | "String"      | false
+        "colorize"    | _                | "never"                            | "String"      | false
+        "colorize"    | _                | "auto"                             | "String"      | false
+
+        "prettyPrint" | "setPrettyPrint" | true                               | "Boolean"     | true
+        "prettyPrint" | "setPrettyPrint" | false                              | "Boolean"     | true
+        "useUnicode"  | "setUseUnicode"  | true                               | "Boolean"     | true
+        "useUnicode"  | "setUseUnicode"  | false                              | "Boolean"     | true
+        "colorize"    | "setColorize"    | ConsoleSettings.ColorOption.always | "ColorOption" | true
+        "colorize"    | "setColorize"    | ConsoleSettings.ColorOption.never  | "ColorOption" | true
+        "colorize"    | "setColorize"    | ConsoleSettings.ColorOption.auto   | "ColorOption" | true
+        "colorize"    | _                | "always"                           | "String"      | true
+        "colorize"    | _                | "never"                            | "String"      | true
+        "colorize"    | _                | "auto"                             | "String"      | true
+
+        value = wrapValueBasedOnType(rawValue, type) { type ->
+            switch (type) {
+                case ConsoleSettings.ColorOption.simpleName:
+                    return ConsoleSettings.ColorOption.name + ".${rawValue.toString()}"
+                default:
+                    return rawValue
+            }
+        }
+        useConfigureBlockMessage = useConfigureBlock ? "configuration closure and" : ""
+        invocation = (method == _) ? "${property} = ${value}" : "${method}(${value})"
+        expectedValue = rawValue
+    }
+
+    def "task :#taskname writes log output"() {
+        given:
+        buildFile << workingXcodebuildTaskConfig
+
+        and: "a future log file"
+        def logFile = new File(projectDir, "build/logs/${testTaskName}.log")
+        assert !logFile.exists()
+
+        when:
+        runTasks(testTaskName)
+
+        then:
+        logFile.exists()
+        !logFile.text.empty
+    }
+
+    abstract String getExpectedPrettyLogOutput()
+
+    abstract String getExpectedPrettyUnicodeLogOutput()
+
+    @Unroll("prints #logType xcodebuild log to console when #reason")
+    def "prints xcodebuild log to console"() {
+        given: "export task with pretty print enabled"
+        buildFile << workingXcodebuildTaskConfig
+        buildFile << """
+        ${testTaskName} {
+            consoleSettings {
+                prettyPrint = ${usePrettyPrint}
+                useUnicode = ${useUniCode}
+                colorize = "never"
+            }
+        }
+        """.stripIndent()
+
+        and: "a future log file"
+        def logFile = new File(projectDir, "build/logs/${testTaskName}.log")
+        assert !logFile.exists()
+
+        when:
+        def result = runTasks(testTaskName)
+
+        then:
+        if (usePrettyPrint) {
+            if (useUniCode) {
+                outputContains(result, expectedPrettyUnicodeLogOutput)
+            } else {
+                outputContains(result, expectedPrettyLogOutput)
+            }
+            !outputContains(result, logFile.text)
+        } else {
+            !outputContains(result, expectedPrettyUnicodeLogOutput)
+            !outputContains(result, expectedPrettyLogOutput)
+            outputContains(result, logFile.text)
+        }
+
+        where:
+        usePrettyPrint | useUniCode | logType         | reason
+        true           | true       | "short unicode" | "pretty print and unicode is enabled"
+        true           | false      | "short ascii"   | "pretty print is enabled"
+        false          | true       | "full ascii"    | "pretty print is disabled"
+        false          | false      | "full ascii"    | "pretty print and unicode is disabled"
+    }
+}

--- a/src/main/groovy/wooga/gradle/xcodebuild/ConsoleSettings.groovy
+++ b/src/main/groovy/wooga/gradle/xcodebuild/ConsoleSettings.groovy
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ *
+ */
+
+package wooga.gradle.xcodebuild
+
+import org.gradle.api.logging.configuration.ConsoleOutput
+
+class ConsoleSettings {
+    enum ColorOption {
+        never,
+        always,
+        auto
+    }
+
+    Boolean prettyPrint
+    Boolean useUnicode
+    ColorOption colorize = ColorOption.auto
+
+    Boolean hasColors() {
+        switch (colorize) {
+            case ColorOption.never:
+                return false
+            case ColorOption.always:
+                return true
+            case ColorOption.auto:
+                // normally one would do a check if stdout is a tty.
+                // that is not possible here because of issues with java (solvable)
+                // and gradle. If one needs to pipe the output of gradle to a file
+                // --console plain will do the trick
+                return (System.getenv("CLICOLOR") != "0" ||
+                        System.getenv("CLICOLOR_FORCE") == "1")
+        }
+    }
+
+    ConsoleSettings() {
+        this(true, true, ColorOption.auto)
+    }
+
+    static ConsoleSettings fromGradleOutput(ConsoleOutput output) {
+        switch (output) {
+            case ConsoleOutput.Rich:
+                return new ConsoleSettings(true, true, ColorOption.always)
+                break
+            case ConsoleOutput.Verbose:
+                return new ConsoleSettings(false, false, ColorOption.never)
+                break
+
+            case ConsoleOutput.Plain:
+                return new ConsoleSettings(true, false, ColorOption.never)
+                break
+            case ConsoleOutput.Auto:
+                return new ConsoleSettings()
+                break
+        }
+    }
+
+    ConsoleSettings(Boolean prettyPrint, Boolean useUnicode, ColorOption colorize) {
+        this.prettyPrint = prettyPrint
+        this.useUnicode = useUnicode
+        this.colorize = colorize
+    }
+
+    @Override
+    String toString() {
+        return "ConsoleSettings{" +
+                "prettyPrint=" + prettyPrint +
+                ", useUnicode=" + useUnicode +
+                ", colorize=" + colorize +
+                '}';
+    }
+}

--- a/src/main/groovy/wooga/gradle/xcodebuild/XcodeAction.groovy
+++ b/src/main/groovy/wooga/gradle/xcodebuild/XcodeAction.groovy
@@ -22,5 +22,4 @@ package wooga.gradle.xcodebuild
 import org.gradle.api.provider.Provider
 
 interface XcodeAction {
-    Provider<List<String>> getBuildArguments()
 }

--- a/src/main/groovy/wooga/gradle/xcodebuild/XcodeActionSpec.groovy
+++ b/src/main/groovy/wooga/gradle/xcodebuild/XcodeActionSpec.groovy
@@ -20,11 +20,33 @@
 package wooga.gradle.xcodebuild
 
 import org.gradle.api.Action
+import org.gradle.api.file.RegularFile
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import wooga.gradle.xcodebuild.config.BuildSettings
 
 interface XcodeActionSpec<T extends XcodeActionSpec> extends XcodeAction {
+    Provider<List<String>> getBuildArguments()
+
+    Property<ConsoleSettings> getConsoleSettings()
+
+    void setConsoleSettings(ConsoleSettings value)
+    void setConsoleSettings(Provider<ConsoleSettings> value)
+
+    T consoleSettings(ConsoleSettings value)
+    T consoleSettings(Provider<ConsoleSettings> value)
+
+    T consoleSettings(Closure configuration)
+    T consoleSettings(Action<ConsoleSettings> action)
+
+    RegularFileProperty getLogFile()
+
+    void setLogFile(File value)
+    void setLogFile(Provider<RegularFile> value)
+
+    T logFile(File value)
+    T logFile(Provider<RegularFile> value)
 
     void setAdditionalBuildArguments(Iterable<String> value)
     void setAdditionalBuildArguments(Provider<? extends Iterable<String>> value)

--- a/src/main/groovy/wooga/gradle/xcodebuild/XcodeBuildPluginConsts.groovy
+++ b/src/main/groovy/wooga/gradle/xcodebuild/XcodeBuildPluginConsts.groovy
@@ -16,6 +16,39 @@
 
 package wooga.gradle.xcodebuild
 
+import wooga.gradle.xcodebuild.internal.PropertyLookup
+
 class XcodeBuildPluginConsts {
     static final String INVALID_XCODE_PROJECT_ERROR_MESSAGE = "xcode project path must be a valid .xcodeproj or .xcworkspace"
+
+    /**
+     * Gradle property lookup object with values for fetching the default xcodebuild logs directiory.
+     *
+     * @environmentVariable "XCODEBUILD_LOGS_DIR"
+     * @propertyName "xcodebuild.logsDir"
+     * @defaultValue "logs"
+     * @see wooga.gradle.xcodebuild.XcodeBuildPluginExtension#getLogsDir()
+     */
+    static final PropertyLookup LOGS_DIR_LOOKUP = new PropertyLookup("XCODEBUILD_LOGS_DIR", "xcodebuild.logsDir", "logs")
+
+    /**
+     * Gradle property lookup object with values to fetch default derived data path.
+     *
+     * @environmentVariable "XCODEBUILD_DERIVED_DATA_PATH"
+     * @propertyName "xcodebuild.derivedDataPath"
+     * @defaultValue "derivedData"
+     * @see wooga.gradle.xcodebuild.XcodeBuildPluginExtension#getDerivedDataPath()
+     */
+    static final PropertyLookup DERIVED_DATA_PATH_LOOKUP = new PropertyLookup("XCODEBUILD_DERIVED_DATA_PATH", "xcodebuild.derivedDataPath", "derivedData")
+
+
+    /**
+     * Gradle property lookup object with values to fetch default xarchives path.
+     *
+     * @environmentVariable "XCODEBUILD_XARCHIVES_DIR"
+     * @propertyName "xcodebuild.xarchivesDir"
+     * @defaultValue "archives"
+     * @see wooga.gradle.xcodebuild.XcodeBuildPluginExtension#getXarchivesDir()
+     */
+    static final PropertyLookup XARCHIVES_DIR_LOOKUP = new PropertyLookup("XCODEBUILD_XARCHIVES_DIR", "xcodebuild.xarchivesDir", "archives")
 }

--- a/src/main/groovy/wooga/gradle/xcodebuild/XcodeBuildPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/xcodebuild/XcodeBuildPluginExtension.groovy
@@ -16,6 +16,49 @@
 
 package wooga.gradle.xcodebuild
 
-interface XcodeBuildPluginExtension {
+import org.gradle.api.Action
+import org.gradle.api.file.Directory
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 
+interface XcodeBuildPluginExtension<T extends XcodeBuildPluginExtension> {
+    DirectoryProperty getLogsDir()
+
+    void setLogsDir(File value)
+
+    void setLogsDir(Provider<Directory> value)
+
+    T logsDir(File value)
+
+    T logsDir(Provider<Directory> value)
+
+    DirectoryProperty getDerivedDataPath()
+
+    void setDerivedDataPath(File value)
+
+    void setDerivedDataPath(Provider<Directory> value)
+
+    T derivedDataPath(File value)
+
+    T derivedDataPath(Provider<Directory> value)
+
+    DirectoryProperty  getXarchivesDir()
+
+    void setXarchivesDir(File value)
+    void setXarchivesDir(Provider<Directory> value)
+
+    T xarchivesDir(File value)
+    T xarchivesDir(Provider<Directory> value)
+
+    Property<ConsoleSettings> getConsoleSettings()
+
+    void setConsoleSettings(ConsoleSettings value)
+    void setConsoleSettings(Provider<ConsoleSettings> value)
+
+    T consoleSettings(ConsoleSettings value)
+    T consoleSettings(Provider<ConsoleSettings> value)
+
+    T consoleSettings(Closure configuration)
+    T consoleSettings(Action<ConsoleSettings> action)
 }

--- a/src/main/groovy/wooga/gradle/xcodebuild/internal/DefaultXcodeBuildPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/xcodebuild/internal/DefaultXcodeBuildPluginExtension.groovy
@@ -16,14 +16,136 @@
 
 package wooga.gradle.xcodebuild.internal
 
+import org.gradle.api.Action
 import org.gradle.api.Project
+import org.gradle.api.file.Directory
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import wooga.gradle.xcodebuild.ConsoleSettings
 import wooga.gradle.xcodebuild.XcodeBuildPluginExtension
+
+import static org.gradle.util.ConfigureUtil.configureUsing
 
 class DefaultXcodeBuildPluginExtension implements XcodeBuildPluginExtension {
 
     final Project project
 
+    final DirectoryProperty logsDir
+
+    final Property<ConsoleSettings> consoleSettings
+
+    @Override
+    void setConsoleSettings(ConsoleSettings value) {
+        consoleSettings.set(value)
+    }
+
+    @Override
+    void setConsoleSettings(Provider<ConsoleSettings> value) {
+        consoleSettings.set(value)
+    }
+
+    @Override
+    DefaultXcodeBuildPluginExtension consoleSettings(ConsoleSettings value) {
+        setConsoleSettings(value)
+        this
+    }
+
+    @Override
+    DefaultXcodeBuildPluginExtension consoleSettings(Provider<ConsoleSettings> value) {
+        setConsoleSettings(value)
+        this
+    }
+
+    @Override
+    void setLogsDir(File value) {
+        logsDir.set(value)
+    }
+
+    @Override
+    void setLogsDir(Provider<Directory> value) {
+        logsDir.set(value)
+    }
+
+    @Override
+    DefaultXcodeBuildPluginExtension logsDir(File value) {
+        setLogsDir(value)
+        this
+    }
+
+    @Override
+    DefaultXcodeBuildPluginExtension logsDir(Provider<Directory> value) {
+        setLogsDir(value)
+        this
+    }
+
+    final DirectoryProperty derivedDataPath
+
+    @Override
+    void setDerivedDataPath(File value) {
+        derivedDataPath.set(value)
+    }
+
+    @Override
+    void setDerivedDataPath(Provider<Directory> value) {
+        derivedDataPath.set(value)
+    }
+
+    @Override
+    DefaultXcodeBuildPluginExtension derivedDataPath(File value) {
+        setDerivedDataPath(value)
+        this
+    }
+
+    @Override
+    DefaultXcodeBuildPluginExtension derivedDataPath(Provider<Directory> value) {
+        setDerivedDataPath(value)
+        this
+    }
+
+    final DirectoryProperty xarchivesDir
+
+    @Override
+    void setXarchivesDir(File value) {
+        xarchivesDir.set(value)
+    }
+
+    @Override
+    void setXarchivesDir(Provider<Directory> value) {
+        xarchivesDir.set(value)
+    }
+
+    @Override
+    DefaultXcodeBuildPluginExtension xarchivesDir(File value) {
+        setXarchivesDir(value)
+        this
+    }
+
+    @Override
+    DefaultXcodeBuildPluginExtension xarchivesDir(Provider<Directory> value) {
+        setXarchivesDir(value)
+        this
+    }
+
+    @Override
+    XcodeBuildPluginExtension consoleSettings(Closure configuration) {
+        consoleSettings(configureUsing(configuration))
+        this
+    }
+
+    @Override
+    XcodeBuildPluginExtension consoleSettings(Action action) {
+        def settings = consoleSettings.getOrElse(new ConsoleSettings())
+        action.execute(settings)
+        consoleSettings.set(settings)
+        this
+    }
+
     DefaultXcodeBuildPluginExtension(Project project) {
         this.project = project
+        logsDir = project.layout.directoryProperty()
+        derivedDataPath = project.layout.directoryProperty()
+        xarchivesDir = project.layout.directoryProperty()
+        consoleSettings = project.objects.property(ConsoleSettings)
     }
 }

--- a/src/main/groovy/wooga/gradle/xcodebuild/internal/ForkTextStream.groovy
+++ b/src/main/groovy/wooga/gradle/xcodebuild/internal/ForkTextStream.groovy
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ *
+ */
+
+package wooga.gradle.xcodebuild.internal
+
+import org.gradle.api.Nullable
+import org.gradle.internal.io.TextStream
+
+class ForkTextStream implements TextStream {
+
+    private final List<Writer> writerList = []
+
+    void addWriter(Writer writer) {
+
+        this.writerList.add(writer)
+    }
+
+    @Override
+    void text(String text) {
+
+        List<Writer> writersToRemove = []
+        writerList.each {
+            try {
+                it.write(text)
+            }
+            catch (IOException ignored) {
+                writersToRemove.add(it)
+            }
+        }
+
+        writerList.removeAll(writersToRemove)
+    }
+
+    @Override
+    void endOfStream(@Nullable Throwable failure) {
+        writerList.each {
+            try {
+                it.close()
+            }
+            finally {
+
+            }
+        }
+    }
+}

--- a/src/main/groovy/wooga/gradle/xcodebuild/internal/PropertyLookup.groovy
+++ b/src/main/groovy/wooga/gradle/xcodebuild/internal/PropertyLookup.groovy
@@ -1,0 +1,13 @@
+package wooga.gradle.xcodebuild.internal
+
+class PropertyLookup {
+    final String env
+    final String property
+    final String defaultValue
+
+    PropertyLookup(String env, String property, String defaultValue) {
+        this.env = env
+        this.property = property
+        this.defaultValue = defaultValue
+    }
+}

--- a/src/test/groovy/wooga/gradle/xcodebuild/ConsoleSettingsSpec.groovy
+++ b/src/test/groovy/wooga/gradle/xcodebuild/ConsoleSettingsSpec.groovy
@@ -1,0 +1,25 @@
+package wooga.gradle.xcodebuild
+
+import org.gradle.api.logging.configuration.ConsoleOutput
+import spock.lang.Specification
+
+class ConsoleSettingsSpec extends Specification {
+
+    def "can create console Settings from gradle console output"() {
+        given:
+        def consoleSettings = ConsoleSettings.fromGradleOutput(output)
+
+        expect:
+        consoleSettings.prettyPrint == expectedPrettyPrint
+        consoleSettings.useUnicode == expectedUseColors
+        consoleSettings.colorize == expectedColorize
+        consoleSettings.hasColors() == expectedHasColors
+
+        where:
+        output                | expectedPrettyPrint | expectedUseColors | expectedColorize                   | expectedHasColors
+        ConsoleOutput.Rich    | true                | true              | ConsoleSettings.ColorOption.always | true
+        ConsoleOutput.Plain   | true                | false             | ConsoleSettings.ColorOption.never  | false
+        ConsoleOutput.Verbose | false               | false             | ConsoleSettings.ColorOption.never  | false
+        ConsoleOutput.Auto    | true                | true              | ConsoleSettings.ColorOption.auto   | true
+    }
+}

--- a/src/test/groovy/wooga/gradle/xcodebuild/internal/ForkTextStreamSpec.groovy
+++ b/src/test/groovy/wooga/gradle/xcodebuild/internal/ForkTextStreamSpec.groovy
@@ -1,0 +1,128 @@
+package wooga.gradle.xcodebuild.internal
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class ForkTextStreamSpec extends Specification {
+    ForkTextStream forkStream
+    static String testString = "Test text to fork"
+
+    def setup() {
+        forkStream = new ForkTextStream()
+    }
+
+    @Unroll
+    def "forks outputs stream to #amount"() {
+        given: "a stream to output to"
+        List<File> files = []
+        List<Writer> writer = []
+
+        for (int i = 0; i < numberOfForks; i++) {
+            def f = File.createTempFile("stream", "out_${i}")
+            def w = new FileWriter(f, true)
+
+            files.add(f)
+            writer.add(w)
+
+            forkStream.addWriter(w)
+        }
+
+        when:
+        forkStream.text(testString)
+        forkStream.text(testString)
+        forkStream.text(testString)
+        forkStream.endOfStream()
+
+        then:
+        files.each {
+            it.text == "${testString}${testString}${testString}"
+        }
+
+        cleanup:
+        writer.each {
+            it.close()
+        }
+
+        where:
+        numberOfForks << [1, 10]
+        amount = numberOfForks > 1 ? "multiple streams" : "single stream"
+    }
+
+    def "closes all sub streams when fork stream gets closed"() {
+        given: "a stream to output to"
+        List<File> files = []
+        List<Writer> writer = []
+
+        for (int i = 0; i < numberOfForks; i++) {
+            def f = File.createTempFile("stream", "out_${i}")
+            def w = new PrintWriter(f)
+
+            files.add(f)
+            writer.add(w)
+
+            forkStream.addWriter(w)
+        }
+
+        when:
+        forkStream.text(testString)
+
+        forkStream.endOfStream()
+
+        forkStream.text(testString)
+        forkStream.text(testString)
+        forkStream.endOfStream()
+
+        then:
+        files.each {
+            it.text == "${testString}"
+        }
+
+        cleanup:
+        writer.each {
+            it.close()
+        }
+
+        where:
+        numberOfForks << [10]
+    }
+
+    def "removes sub streams when fork stream throws IO Exception"() {
+        given: "a stream to output to"
+        List<File> files = []
+        List<Writer> writer = []
+
+        for (int i = 0; i < numberOfForks; i++) {
+            def f = File.createTempFile("stream", "out_${i}")
+            def w = new FileWriter(f)
+
+            files.add(f)
+            writer.add(w)
+
+            forkStream.addWriter(w)
+        }
+
+        when:
+        forkStream.text(testString)
+        forkStream.text(testString)
+
+        writer[0].close()
+
+        forkStream.text(testString)
+        forkStream.endOfStream()
+
+        then:
+
+        files[0].text == "${testString}${testString}"
+        files.subList(1, files.size()).every {
+            it.text == "${testString}${testString}${testString}"
+        }
+
+        cleanup:
+        writer.each {
+            it.close()
+        }
+
+        where:
+        numberOfForks = 10
+    }
+}


### PR DESCRIPTION
## Description

This patch builds on top of the last addition and prepares a foundation for future tasks with some common settings for logging and console printing.

### ConsoleSettings

The console settings config object controls the logoutput of `xcodebuild` to the standart output. The tool is by nature very verbose and does't allow any verbosity levels to be set except to quiten it completely. In the apple  development szene is a tool available to help out with that [xcpretty]. It's main use is to transform the output of `xcodebuild` and format it in a shorter more human readable format. It also has formatters to reformat unit test output into different formats. The tool is written in ruby which doesn't help us much so I ported it over to groovy [xcpretty.groovy]. It is not a 100% port as code snippet colering is missing and only the `Simple` formatter is supported. This extra library is added and used when `prettyPrint` is enabled in the console settings object. The logfile written to disk is not formatted!

The console settings can be set on the plugin level for all `xcodebuild` tasks or individual for each task.

```groovy
xcodebuild.consoleSettings {
    prettyPrint = true // use xcpretty for console output
    useUnicode = true  // use unicode or ascii output
    colorize = "auto"  // colorize output (always, never, auto)
}
```

The default values are set based on the gradle console settings which can be changed with the commandline switch `--console=(auto,plain,rich,verbose)` or via gradle property `-Dorg.gradle.console=(auto,plain,rich,verbose)`

| console setting value | pretty print enabled | unicode enabled    | colorized          |
| --------------------- | -------------------- | ------------------ | ------------------ |
| rich                  | :white_check_mark:   | :white_check_mark: | :white_check_mark: |
| plain                 | :white_check_mark:   |                    |                    |
| verbose               |                      |                    |                    |
| auto                  | :white_check_mark:   | :white_check_mark: | :white_check_mark: |

> because of technical issues with java and gradle it was impossible for me to determine a good value if color output should be enabled or not. Normally one checks if the desired output stream is a tty. This is not possible so I set the `rich` option as the default because that is what normal invocation will fallback to.

### Extension config settings

I added a few config values to the `XcodeBuildPluginExtion` to set the default log directory, archive directory and derived data directory.

Each xcodebuild task, at the moment only `XcodeArchive` will bind to these values by default and append the task name to the log file or as a sub directory. The common values can be set in the `build.gradle` script or via environment variable or gradle property.

## Changes

* ![ADD] file and pretty console logging

[xcpretty]:        https://github.com/xcpretty/xcpretty
[xcpretty.groovy]: https://github.com/wooga/xcpretty.groovy/

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
