### PR TITLE
Add ExportArchive task

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/xcodebuild/tasks/AbstractXcodeArchiveTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/xcodebuild/tasks/AbstractXcodeArchiveTaskIntegrationSpec.groovy
@@ -1,0 +1,203 @@
+package wooga.gradle.xcodebuild.tasks
+
+import spock.lang.Unroll
+
+abstract class AbstractXcodeArchiveTaskIntegrationSpec extends AbstractXcodeTaskIntegrationSpec {
+
+    @Unroll("can set property #property with #method and type #type")
+    def "can set property AbstractXcodeArchiveTask"() {
+        given: "a custom archive task"
+        buildFile << """
+            task("${testTaskName}", type: ${XcodeArchive.name})
+        """.stripIndent()
+
+        and: "a task to read back the value"
+        buildFile << """
+            task("readValue") {
+                doLast {
+                    println("property: " + ${testTaskName}.${property}.get())
+                }
+            }
+        """.stripIndent()
+
+        and: "a set property"
+        buildFile << """
+            ${testTaskName}.${method}($value)
+        """.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully("readValue")
+
+        then:
+        outputContains(result, "property: " + expectedValue.toString())
+
+        where:
+        property         | method               | rawValue     | type
+        "archiveName"    | "archiveName"        | "Test1"      | "String"
+        "archiveName"    | "archiveName"        | "Test2"      | "Provider<String>"
+        "archiveName"    | "archiveName.set"    | "Test1"      | "String"
+        "archiveName"    | "archiveName.set"    | "Test2"      | "Provider<String>"
+        "archiveName"    | "setArchiveName"     | "Test3"      | "String"
+        "archiveName"    | "setArchiveName"     | "Test4"      | "Provider<String>"
+
+        "baseName"       | "baseName"           | "Test1"      | "String"
+        "baseName"       | "baseName"           | "Test2"      | "Provider<String>"
+        "baseName"       | "baseName.set"       | "Test1"      | "String"
+        "baseName"       | "baseName.set"       | "Test2"      | "Provider<String>"
+        "baseName"       | "setBaseName"        | "Test3"      | "String"
+        "baseName"       | "setBaseName"        | "Test4"      | "Provider<String>"
+
+        "appendix"       | "appendix"           | "Test1"      | "String"
+        "appendix"       | "appendix"           | "Test2"      | "Provider<String>"
+        "appendix"       | "appendix.set"       | "Test1"      | "String"
+        "appendix"       | "appendix.set"       | "Test2"      | "Provider<String>"
+        "appendix"       | "setAppendix"        | "Test3"      | "String"
+        "appendix"       | "setAppendix"        | "Test4"      | "Provider<String>"
+
+        "version"        | "version"            | "Test1"      | "String"
+        "version"        | "version"            | "Test2"      | "Provider<String>"
+        "version"        | "version.set"        | "Test1"      | "String"
+        "version"        | "version.set"        | "Test2"      | "Provider<String>"
+        "version"        | "setVersion"         | "Test3"      | "String"
+        "version"        | "setVersion"         | "Test4"      | "Provider<String>"
+
+        "extension"      | "extension"          | "Test1"      | "String"
+        "extension"      | "extension"          | "Test2"      | "Provider<String>"
+        "extension"      | "extension.set"      | "Test1"      | "String"
+        "extension"      | "extension.set"      | "Test2"      | "Provider<String>"
+        "extension"      | "setExtension"       | "Test3"      | "String"
+        "extension"      | "setExtension"       | "Test4"      | "Provider<String>"
+
+        "classifier"     | "classifier"         | "Test1"      | "String"
+        "classifier"     | "classifier"         | "Test2"      | "Provider<String>"
+        "classifier"     | "classifier.set"     | "Test1"      | "String"
+        "classifier"     | "classifier.set"     | "Test2"      | "Provider<String>"
+        "classifier"     | "setClassifier"      | "Test3"      | "String"
+        "classifier"     | "setClassifier"      | "Test4"      | "Provider<String>"
+
+        "destinationDir" | "destinationDir"     | "/some/path" | "File"
+        "destinationDir" | "destinationDir"     | "/some/path" | "Provider<Directory>"
+        "destinationDir" | "destinationDir.set" | "/some/path" | "File"
+        "destinationDir" | "destinationDir.set" | "/some/path" | "Provider<Directory>"
+        "destinationDir" | "setDestinationDir"  | "/some/path" | "File"
+        "destinationDir" | "setDestinationDir"  | "/some/path" | "Provider<Directory>"
+
+        value = wrapValueBasedOnType(rawValue, type)
+        expectedValue = rawValue
+    }
+
+
+    @Unroll("constructs archive name #expectedValue from baseName: #baseName, appendix: #appendix version: #version classifier: #classifier extension: extension archiveName: #archiveName")
+    def "set archive name"() {
+        given: "a custom archive task"
+        buildFile << """
+            task("${testTaskName}", type: ${XcodeArchive.name})
+        """.stripIndent()
+
+        and: "a custom project name"
+        settingsFile.text = """
+        rootProject.name='${defaultBaseName}'
+        """.trim().stripIndent()
+
+        and: "a custom project version"
+        buildFile << """
+            version = '${defaultVersion}'
+        """.stripIndent()
+
+        and: "a task to read back the value"
+        buildFile << """
+            task("readValue") {
+                doLast {
+                    println("archiveName: '" + ${testTaskName}.archiveName.get() + "'")
+                }
+            }
+        """.stripIndent()
+
+        and: "a set propertis"
+        archiveNameParts.each {
+            if (it.value != _) {
+                buildFile << """
+                ${testTaskName}.${it.key}(${wrapValueBasedOnType(it.value, "String")})
+                """.stripIndent()
+            }
+        }
+
+        when:
+        def result = runTasksSuccessfully("readValue")
+
+        then:
+
+        outputContains(result, "archiveName: '" + expectedValue.toString() + "'")
+
+        where:
+        baseName | appendix | version | classifier | extension | archiveName  | expectedArchivePattern
+        _        | null     | _       | null       | _         | _            | "#baseName-#version.#extension"
+        null     | null     | _       | null       | _         | _            | "#version.#extension"
+        'test'   | 'suite'  | '0.1.0' | 'case'     | 'xml'     | _            | "#baseName-#appendix-#version-#classifier.#extension"
+        'test'   | 'suite'  | '0.1.0' | 'case'     | null      | _            | "#baseName-#appendix-#version-#classifier"
+        'test'   | 'suite'  | '0.1.0' | 'case'     | null      | _            | "#baseName-#appendix-#version-#classifier"
+        'test'   | 'suite'  | '0.1.0' | null       | 'xml'     | _            | "#baseName-#appendix-#version.#extension"
+        'test'   | 'suite'  | '0.1.0' | null       | null      | _            | "#baseName-#appendix-#version"
+        'test'   | 'suite'  | null    | 'case'     | 'xml'     | _            | "#baseName-#appendix-#classifier.#extension"
+        'test'   | 'suite'  | null    | null       | 'xml'     | _            | "#baseName-#appendix.#extension"
+        'test'   | 'suite'  | null    | null       | null      | _            | "#baseName-#appendix"
+        'test'   | null     | '0.1.0' | 'case'     | 'xml'     | _            | "#baseName-#version-#classifier.#extension"
+        'test'   | null     | '0.1.0' | null       | 'xml'     | _            | "#baseName-#version.#extension"
+        'test'   | null     | '0.1.0' | null       | null      | _            | "#baseName-#version"
+        'test'   | null     | null    | 'case'     | 'xml'     | _            | "#baseName-#classifier.#extension"
+        'test'   | null     | null    | null       | 'xml'     | _            | "#baseName.#extension"
+        'test'   | null     | null    | null       | null      | _            | "#baseName"
+        null     | 'suite'  | '0.1.0' | 'case'     | 'xml'     | _            | "#appendix-#version-#classifier.#extension"
+        null     | 'suite'  | null    | 'case'     | 'xml'     | _            | "#appendix-#classifier.#extension"
+        null     | 'suite'  | null    | 'case'     | null      | _            | "#appendix-#classifier"
+        null     | 'suite'  | null    | null       | 'xml'     | _            | "#appendix.#extension"
+        null     | 'suite'  | null    | null       | null      | _            | "#appendix"
+        null     | null     | '0.1.0' | 'case'     | 'xml'     | _            | "#version-#classifier.#extension"
+        null     | null     | '0.1.0' | null       | 'xml'     | _            | "#version.#extension"
+        null     | null     | '0.1.0' | null       | null      | _            | "#version"
+        null     | null     | null    | 'case'     | 'xml'     | _            | "#classifier.#extension"
+        null     | null     | null    | 'case'     | null      | _            | "#classifier"
+        null     | null     | null    | null       | 'xml'     | _            | ".#extension"
+        null     | null     | null    | null       | null      | _            | ""
+        _        | null     | _       | null       | _         | 'customName' | 'customName'
+        null     | null     | _       | null       | _         | 'customName' | 'customName'
+        'test'   | 'suite'  | '0.1.0' | 'case'     | 'xml'     | 'customName' | 'customName'
+        'test'   | 'suite'  | '0.1.0' | 'case'     | null      | 'customName' | 'customName'
+        'test'   | 'suite'  | '0.1.0' | 'case'     | null      | 'customName' | 'customName'
+        'test'   | 'suite'  | '0.1.0' | null       | 'xml'     | 'customName' | 'customName'
+        'test'   | 'suite'  | '0.1.0' | null       | null      | 'customName' | 'customName'
+        'test'   | 'suite'  | null    | 'case'     | 'xml'     | 'customName' | 'customName'
+        'test'   | 'suite'  | null    | null       | 'xml'     | 'customName' | 'customName'
+        'test'   | 'suite'  | null    | null       | null      | 'customName' | 'customName'
+        'test'   | null     | '0.1.0' | 'case'     | 'xml'     | 'customName' | 'customName'
+        'test'   | null     | '0.1.0' | null       | 'xml'     | 'customName' | 'customName'
+        'test'   | null     | '0.1.0' | null       | null      | 'customName' | 'customName'
+        'test'   | null     | null    | 'case'     | 'xml'     | 'customName' | 'customName'
+        'test'   | null     | null    | null       | 'xml'     | 'customName' | 'customName'
+        'test'   | null     | null    | null       | null      | 'customName' | 'customName'
+        null     | 'suite'  | '0.1.0' | 'case'     | 'xml'     | 'customName' | 'customName'
+        null     | 'suite'  | null    | 'case'     | 'xml'     | 'customName' | 'customName'
+        null     | 'suite'  | null    | 'case'     | null      | 'customName' | 'customName'
+        null     | 'suite'  | null    | null       | 'xml'     | 'customName' | 'customName'
+        null     | 'suite'  | null    | null       | null      | 'customName' | 'customName'
+        null     | null     | '0.1.0' | 'case'     | 'xml'     | 'customName' | 'customName'
+        null     | null     | '0.1.0' | null       | 'xml'     | 'customName' | 'customName'
+        null     | null     | '0.1.0' | null       | null      | 'customName' | 'customName'
+        null     | null     | null    | 'case'     | 'xml'     | 'customName' | 'customName'
+        null     | null     | null    | 'case'     | null      | 'customName' | 'customName'
+        null     | null     | null    | null       | 'xml'     | 'customName' | 'customName'
+        null     | null     | null    | null       | null      | 'customName' | 'customName'
+
+        defaultVersion = '0.0.0'
+        defaultBaseName = 'atlasBuildIos'
+        defaultExtension = 'xcarchive'
+
+        expectedValue = expectedArchivePattern.replace('#baseName', (baseName == _ ? defaultBaseName : baseName ?: '').toString())
+                .replace('#version', (version == _ ? defaultVersion : version ?: '').toString())
+                .replace('#extension', (extension == _ ? defaultExtension : extension ?: '').toString())
+                .replace('#appendix', (appendix ?: '').toString())
+                .replace('#classifier', (classifier ?: '').toString())
+
+        archiveNameParts = ['baseName': baseName, 'version': version, 'appendix': appendix, 'extension': extension, 'classifier': classifier, 'archiveName': archiveName]
+    }
+}

--- a/src/integrationTest/groovy/wooga/gradle/xcodebuild/tasks/ExportArchiveIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/xcodebuild/tasks/ExportArchiveIntegrationSpec.groovy
@@ -1,0 +1,211 @@
+package wooga.gradle.xcodebuild.tasks
+
+import net.wooga.test.xcode.XcodeTestProject
+import org.junit.ClassRule
+import spock.lang.Requires
+import spock.lang.Shared
+import spock.lang.Unroll
+import wooga.gradle.xcodebuild.config.BuildSettings
+
+@Requires({ os.macOs })
+class ExportArchiveIntegrationSpec extends AbstractXcodeArchiveTaskIntegrationSpec {
+
+    @Shared
+    @ClassRule
+    XcodeTestProject xcodeProject = new XcodeTestProject()
+
+    Class taskType = ExportArchive
+
+    String testTaskName = "customExportArchive"
+
+    String workingXcodebuildTaskConfig = """
+    task exportArchive(type: ${XcodeArchive.name}) {
+        scheme = "${xcodeProject.schemeName}"
+        baseName = "custom"
+        version = "0.1.0"
+        buildSettings {
+            codeSignIdentity ""
+            codeSigningRequired false
+            codeSigningAllowed false
+            ${System.getenv("TEST_TEAM_ID") ? "developmentTeam = '${System.getenv("TEST_TEAM_ID")}'" : ""}
+        }
+        
+        buildArgument('-allowProvisioningUpdates')
+        clean = true
+        projectPath = new File("${xcodeProject.xcodeProject}")
+    }
+
+    task ${testTaskName}(type: ${taskType.name}) {
+        dependsOn exportArchive
+        baseName = "custom"
+        version = "0.1.0"
+        xcArchivePath = exportArchive.xcArchivePath
+        exportOptionsPlist = file("exportOptions.plist")
+    }
+    """.stripIndent()
+
+    @Override
+    String getExpectedPrettyColoredUnicodeLogOutput() {
+        // we can't test the success case without a valid team id.
+        if (System.getenv("TEST_TEAM_ID")) {
+            return "▸ \u001B[39;1mExport\u001B[0m Succeeded"
+        }
+
+        return """error: exportArchive: No signing certificate "iOS Development" found"""
+    }
+
+    @Override
+    String getExpectedPrettyLogOutput() {
+        // we can't test the success case without a valid team id.
+        if (System.getenv("TEST_TEAM_ID")) {
+            return "> Export Succeeded"
+        }
+        return """error: exportArchive: No signing certificate "iOS Development" found"""
+    }
+
+    @Override
+    String getExpectedPrettyUnicodeLogOutput() {
+        // we can't test the success case without a valid team id.
+        if (System.getenv("TEST_TEAM_ID")) {
+            return "▸ Export Succeeded"
+        }
+        return """error: exportArchive: No signing certificate "iOS Development" found"""
+    }
+
+    File exportOptions
+
+    def setup() {
+        exportOptions = createFile("exportOptions.plist")
+        exportOptions << """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>teamID</key>
+            <string>${System.getenv("TEST_TEAM_ID")}</string>
+            <key>method</key>
+            <string>development</string>
+            
+            <key>provisioningProfiles</key>
+            <dict>
+                <key>net.wooga.xcodebuildPluginTest</key>
+                <string>xcodebuildPluginTest</string>
+            </dict>
+        </dict>
+        </plist>
+        """.stripIndent().trim()
+    }
+
+    @Unroll("property #property sets flag #expectedCommandlineFlag")
+    def "constructs build arguments"() {
+        given:
+        buildFile << """
+        task("${testTaskName}", type: ${taskType.name}) {
+            exportOptionsPlist = file("/some/path/exportOptions1.plist")
+            xcArchivePath = file("/some/path/test1.xcarchive")
+        }
+        """.stripIndent()
+
+        and: "a task to read the build arguments"
+        buildFile << """
+            task("readValue") {
+                doLast {
+                    println("arguments: " + ${testTaskName}.buildArguments.get().join(" "))
+                }
+            }
+        """.stripIndent()
+
+        and: "a set property"
+        buildFile << """
+            ${testTaskName}.${method}($value)
+        """.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully("readValue")
+
+        then:
+        outputContains(result, expectedCommandlineFlag)
+
+        where:
+        property             | method                   | rawValue                          | type   | expectedCommandlineFlag
+        "exportOptionsPlist" | "exportOptionsPlist.set" | "/some/path/exportOptions1.plist" | "File" | "-exportOptionsPlist /some/path/exportOptions1.plist"
+        "xcArchivePath"      | "xcArchivePath.set"      | "/some/path/test1.xcarchive"      | "File" | "-archivePath /some/path/test1.xcarchive"
+
+        value = wrapValueBasedOnType(rawValue, type)
+    }
+
+    @Unroll("can set property #property with #method and type #type")
+    def "can set property ExportArchive"() {
+        given: "a custom archive task"
+        buildFile << """
+            task("${testTaskName}", type: ${taskType.name})
+        """.stripIndent()
+
+        and: "a task to read back the value"
+        buildFile << """
+            task("readValue") {
+                doLast {
+                    println("property: " + ${testTaskName}.${property}.get())
+                }
+            }
+        """.stripIndent()
+
+        and: "a set property"
+        buildFile << """
+            ${testTaskName}.${method}($value)
+        """.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully("readValue")
+
+        then:
+        outputContains(result, "property: " + expectedValue.toString())
+
+        where:
+        property             | method                   | rawValue                          | type
+        "exportOptionsPlist" | "exportOptionsPlist"     | "/some/path/exportOptions1.plist" | "File"
+        "exportOptionsPlist" | "exportOptionsPlist"     | "/some/path/exportOptions2.plist" | "Provider<RegularFile>"
+        "exportOptionsPlist" | "exportOptionsPlist.set" | "/some/path/exportOptions3.plist" | "File"
+        "exportOptionsPlist" | "exportOptionsPlist.set" | "/some/path/exportOptions4.plist" | "Provider<RegularFile>"
+        "exportOptionsPlist" | "setExportOptionsPlist"  | "/some/path/exportOptions5.plist" | "File"
+        "exportOptionsPlist" | "setExportOptionsPlist"  | "/some/path/exportOptions8.plist" | "Provider<RegularFile>"
+
+        "xcArchivePath"      | "xcArchivePath"          | "/some/path/test1.xcarchive"      | "File"
+        "xcArchivePath"      | "xcArchivePath"          | "/some/path/test2.xcarchive"      | "Provider<Directory>"
+        "xcArchivePath"      | "xcArchivePath.set"      | "/some/path/test3.xcarchive"      | "File"
+        "xcArchivePath"      | "xcArchivePath.set"      | "/some/path/test4.xcarchive"      | "Provider<Directory>"
+        "xcArchivePath"      | "setXcArchivePath"       | "/some/path/test5.xcarchive"      | "File"
+        "xcArchivePath"      | "setXcArchivePath"       | "/some/path/test6.xcarchive"      | "Provider<Directory>"
+
+        value = wrapValueBasedOnType(rawValue, type) { type ->
+            switch (type) {
+                case BuildSettings.class.simpleName:
+                    return "new ${BuildSettings.class.name}()" + rawValue.replaceAll(/(\[|\])/, '').split(',').collect({
+                        List<String> parts = it.split("=")
+                        ".put('${parts[0].trim()}', '${parts[1].trim()}')"
+                    }).join("")
+                default:
+                    return rawValue
+            }
+        }
+        expectedValue = rawValue
+    }
+
+    @Requires({ env.TEST_TEAM_ID })
+    def "can export ipa from xcarchive"() {
+        given:
+        buildFile << workingXcodebuildTaskConfig
+
+        and: "a future ipa file"
+        def archive = new File(projectDir, "build/archives/custom-0.1.0.ipa")
+        assert !archive.exists()
+
+        when:
+        def result = runTasks(testTaskName)
+
+        then:
+        result.success
+        archive.exists()
+        archive.isFile()
+    }
+}

--- a/src/integrationTest/resources/xcodeProject/xcodebuildPluginTest.xcodeproj/project.pbxproj
+++ b/src/integrationTest/resources/xcodeProject/xcodebuildPluginTest.xcodeproj/project.pbxproj
@@ -271,7 +271,7 @@
 				DEVELOPMENT_ASSET_PATHS = "\"xcodebuildPluginTest/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = xcodebuildPluginTest/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -292,7 +292,7 @@
 				DEVELOPMENT_ASSET_PATHS = "\"xcodebuildPluginTest/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = xcodebuildPluginTest/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/src/main/groovy/wooga/gradle/xcodebuild/XcodeArchiveActionSpec.groovy
+++ b/src/main/groovy/wooga/gradle/xcodebuild/XcodeArchiveActionSpec.groovy
@@ -26,8 +26,8 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 
-interface XcodeArchiveActionSpec<T extends XcodeArchiveActionSpec> {
-    Provider<Set<XcodeBuildAction>> getBuildActions()
+interface XcodeArchiveActionSpec<T extends XcodeArchiveActionSpec> extends XcodeArchiveActionSpecBase<T> {
+
     Provider<Directory> getXcArchivePath()
 
     Property<String> getConfiguration()
@@ -85,61 +85,4 @@ interface XcodeArchiveActionSpec<T extends XcodeArchiveActionSpec> {
 
     T projectPath(File value)
     T projectPath(Provider<Directory> value)
-
-    Property<String> getArchiveName()
-
-    void setArchiveName(String value)
-    void setArchiveName(Provider<String> value)
-
-    T archiveName(String value)
-    T archiveName(Provider<String> value)
-
-    Property<String> getBaseName()
-
-    void setBaseName(String value)
-    void setBaseName(Provider<String> value)
-
-    T baseName(String value)
-    T baseName(Provider<String> value)
-
-    Property<String> getAppendix()
-
-    void setAppendix(String value)
-    void setAppendix(Provider<String> value)
-
-    T appendix(String value)
-    T appendix(Provider<String> value)
-
-    Property<String> getVersion()
-
-    void setVersion(String value)
-    void setVersion(Provider<String> value)
-
-    T version(String value)
-    T version(Provider<String> value)
-
-    Property<String> getExtension()
-
-    void setExtension(String value)
-    void setExtension(Provider<String> value)
-
-    T extension(String value)
-    T extension(Provider<String> value)
-
-    Property<String> getClassifier()
-
-    void setClassifier(String value)
-    void setClassifier(Provider<String> value)
-
-    T classifier(String value)
-    T classifier(Provider<String> value)
-
-    DirectoryProperty getDestinationDir()
-
-    void setDestinationDir(File value)
-    void setDestinationDir(Provider<Directory> value)
-
-    T destinationDir(File value)
-    T destinationDir(Provider<Directory> value)
-
 }

--- a/src/main/groovy/wooga/gradle/xcodebuild/XcodeArchiveActionSpecBase.groovy
+++ b/src/main/groovy/wooga/gradle/xcodebuild/XcodeArchiveActionSpecBase.groovy
@@ -1,0 +1,64 @@
+package wooga.gradle.xcodebuild
+
+import org.gradle.api.file.Directory
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+
+interface XcodeArchiveActionSpecBase<T extends XcodeArchiveActionSpecBase> {
+    Property<String> getArchiveName()
+
+    void setArchiveName(String value)
+    void setArchiveName(Provider<String> value)
+
+    T archiveName(String value)
+    T archiveName(Provider<String> value)
+
+    Property<String> getBaseName()
+
+    void setBaseName(String value)
+    void setBaseName(Provider<String> value)
+
+    T baseName(String value)
+    T baseName(Provider<String> value)
+
+    Property<String> getAppendix()
+
+    void setAppendix(String value)
+    void setAppendix(Provider<String> value)
+
+    T appendix(String value)
+    T appendix(Provider<String> value)
+
+    Property<String> getVersion()
+
+    void setVersion(String value)
+    void setVersion(Provider<String> value)
+
+    T version(String value)
+    T version(Provider<String> value)
+
+    Property<String> getExtension()
+
+    void setExtension(String value)
+    void setExtension(Provider<String> value)
+
+    T extension(String value)
+    T extension(Provider<String> value)
+
+    Property<String> getClassifier()
+
+    void setClassifier(String value)
+    void setClassifier(Provider<String> value)
+
+    T classifier(String value)
+    T classifier(Provider<String> value)
+
+    DirectoryProperty getDestinationDir()
+
+    void setDestinationDir(File value)
+    void setDestinationDir(Provider<Directory> value)
+
+    T destinationDir(File value)
+    T destinationDir(Provider<Directory> value)
+}

--- a/src/main/groovy/wooga/gradle/xcodebuild/XcodeBuildPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/xcodebuild/XcodeBuildPlugin.groovy
@@ -26,7 +26,9 @@ import org.gradle.api.logging.configuration.ConsoleOutput
 import org.gradle.api.provider.Provider
 import wooga.gradle.xcodebuild.internal.DefaultXcodeBuildPluginExtension
 import wooga.gradle.xcodebuild.internal.PropertyLookup
+import wooga.gradle.xcodebuild.tasks.AbstractXcodeArchiveTask
 import wooga.gradle.xcodebuild.tasks.AbstractXcodeTask
+import wooga.gradle.xcodebuild.tasks.ExportArchive
 import wooga.gradle.xcodebuild.tasks.XcodeArchive
 
 import static wooga.gradle.xcodebuild.XcodeBuildPluginConsts.*
@@ -49,11 +51,24 @@ class XcodeBuildPlugin implements Plugin<Project> {
         project.tasks.withType(XcodeArchive.class, new Action<XcodeArchive>() {
             @Override
             void execute(XcodeArchive task) {
+                task.extension.set("xcarchive")
+                task.derivedDataPath.set(extension.derivedDataPath.dir(task.name))
+            }
+        })
+
+        project.tasks.withType(ExportArchive.class, new Action<ExportArchive>() {
+            @Override
+            void execute(ExportArchive task) {
+                task.extension.set("ipa")
+            }
+        })
+
+        project.tasks.withType(AbstractXcodeArchiveTask.class, new Action<AbstractXcodeArchiveTask>() {
+            @Override
+            void execute(AbstractXcodeArchiveTask task) {
                 task.version.set(project.provider({ project.version.toString() }))
                 task.baseName.set(project.name)
-                task.extension.set("xcarchive")
                 task.destinationDir.set(extension.xarchivesDir)
-                task.derivedDataPath.set(extension.derivedDataPath.dir(task.name))
             }
         })
 

--- a/src/main/groovy/wooga/gradle/xcodebuild/XcodeExportActionSpec.groovy
+++ b/src/main/groovy/wooga/gradle/xcodebuild/XcodeExportActionSpec.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ *
+ */
+
+package wooga.gradle.xcodebuild
+
+import org.gradle.api.file.Directory
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFile
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Provider
+
+interface XcodeExportActionSpec<T extends XcodeExportActionSpec> extends XcodeActionSpec<T>, XcodeArchiveActionSpecBase<T> {
+    RegularFileProperty getExportOptionsPlist()
+
+    void setExportOptionsPlist(Provider<RegularFile> value)
+    void setExportOptionsPlist(File value)
+
+    T exportOptionsPlist(Provider<RegularFile> value)
+    T exportOptionsPlist(File value)
+
+    DirectoryProperty getXcArchivePath()
+
+    void setXcArchivePath(Provider<Directory> value)
+    void setXcArchivePath(File value)
+
+    T xcArchivePath(Provider<Directory> value)
+    T xcArchivePath(File value)
+}

--- a/src/main/groovy/wooga/gradle/xcodebuild/config/BuildSettings.groovy
+++ b/src/main/groovy/wooga/gradle/xcodebuild/config/BuildSettings.groovy
@@ -19,13 +19,21 @@
 
 package wooga.gradle.xcodebuild.config
 
+import sun.invoke.empty.Empty
+
 class BuildSettings implements GroovyInterceptable {
 
-    final Map<String, List<String>> rawSettings
+    private final Map<String, List<String>> rawSettings
 
     BuildSettings() {
-        rawSettings = [:]
+        this(new HashMap<String, List<String>>())
     }
+
+    private BuildSettings(Map<String, List<String>> rawSettings) {
+        this.rawSettings = rawSettings
+    }
+
+    static EMPTY = new BuildSettings()
 
     BuildSettings otherCodeSignFlags(String flag) {
         if (!rawSettings["OTHER_CODE_SIGN_FLAGS"]) {
@@ -33,6 +41,10 @@ class BuildSettings implements GroovyInterceptable {
         }
         rawSettings["OTHER_CODE_SIGN_FLAGS"] << flag
         this
+    }
+
+    BuildSettings clone() {
+        new BuildSettings(rawSettings)
     }
 
     BuildSettings otherCodeSignFlags(String flag, String value) {
@@ -82,7 +94,7 @@ class BuildSettings implements GroovyInterceptable {
             }).join(' ')
 
             "${key}=${value}".toString()
-        }
+        }.sort()
     }
 
     @Override

--- a/src/main/groovy/wooga/gradle/xcodebuild/internal/ForkTextStream.groovy
+++ b/src/main/groovy/wooga/gradle/xcodebuild/internal/ForkTextStream.groovy
@@ -19,8 +19,6 @@
 
 package wooga.gradle.xcodebuild.internal
 
-import org.gradle.api.Nullable
-import org.gradle.internal.io.TextStream
 
 class ForkTextStream implements TextStream {
 
@@ -48,7 +46,7 @@ class ForkTextStream implements TextStream {
     }
 
     @Override
-    void endOfStream(@Nullable Throwable failure) {
+    void endOfStream(Throwable failure) {
         writerList.each {
             try {
                 it.close()

--- a/src/main/groovy/wooga/gradle/xcodebuild/internal/LineBufferingOutputStream.groovy
+++ b/src/main/groovy/wooga/gradle/xcodebuild/internal/LineBufferingOutputStream.groovy
@@ -1,0 +1,67 @@
+package wooga.gradle.xcodebuild.internal
+
+import org.gradle.internal.SystemProperties
+import org.gradle.internal.io.StreamByteBuffer
+
+class LineBufferingOutputStream extends OutputStream {
+    private static final int LINE_MAX_LENGTH = 1048576
+    private boolean hasBeenClosed
+    private final TextStream handler
+    private StreamByteBuffer buffer
+    private final OutputStream output
+    private final byte lastLineSeparatorByte
+    private final int lineMaxLength
+    private int counter
+
+    LineBufferingOutputStream(TextStream handler) {
+        this(handler, 2048)
+    }
+
+    LineBufferingOutputStream(TextStream handler, int bufferLength) {
+        this(handler, bufferLength, LINE_MAX_LENGTH)
+    }
+
+    LineBufferingOutputStream(TextStream handler, int bufferLength, int lineMaxLength) {
+        this.handler = handler
+        this.buffer = new StreamByteBuffer(bufferLength)
+        this.lineMaxLength = lineMaxLength
+        this.output = this.buffer.getOutputStream()
+        byte[] lineSeparator = SystemProperties.getInstance().getLineSeparator().getBytes()
+        this.lastLineSeparatorByte = lineSeparator[lineSeparator.length - 1]
+    }
+
+    void close() throws IOException {
+        this.hasBeenClosed = true
+        this.flushLine()
+        this.handler.endOfStream((Throwable)null)
+    }
+
+    void write(int b) throws IOException {
+        if (this.hasBeenClosed) {
+            throw new IOException("The stream has been closed.")
+        } else {
+            this.output.write(b)
+            ++this.counter
+            if (this.endsWithLineSeparator(b) || this.counter >= this.lineMaxLength) {
+                this.flushLine()
+            }
+        }
+    }
+
+    private boolean endsWithLineSeparator(int b) {
+        byte currentByte = (byte)(b & 255)
+        return currentByte == this.lastLineSeparatorByte || currentByte == 10
+    }
+
+    private void flushLine() {
+        String text = this.buffer.readAsString()
+        if (text.length() > 0) {
+            this.handler.text(text)
+        }
+
+        this.counter = 0
+    }
+
+    void flush(){
+    }
+}

--- a/src/main/groovy/wooga/gradle/xcodebuild/internal/TextStream.groovy
+++ b/src/main/groovy/wooga/gradle/xcodebuild/internal/TextStream.groovy
@@ -1,0 +1,7 @@
+package wooga.gradle.xcodebuild.internal
+
+interface TextStream {
+    void text(String text);
+
+    void endOfStream(Throwable stream);
+}

--- a/src/main/groovy/wooga/gradle/xcodebuild/internal/XcodeBuildAction.groovy
+++ b/src/main/groovy/wooga/gradle/xcodebuild/internal/XcodeBuildAction.groovy
@@ -64,7 +64,6 @@ class XcodeBuildAction implements XcodeAction {
                 exec.with {
                     executable "/usr/bin/xcrun"
                     args = buildArguments
-                    errorOutput = outStream
                     standardOutput = outStream
                 }
             }

--- a/src/main/groovy/wooga/gradle/xcodebuild/internal/XcodeBuildAction.groovy
+++ b/src/main/groovy/wooga/gradle/xcodebuild/internal/XcodeBuildAction.groovy
@@ -23,8 +23,6 @@ import com.wooga.xcodebuild.xcpretty.Printer
 import com.wooga.xcodebuild.xcpretty.formatters.Simple
 import org.gradle.api.Action
 import org.gradle.api.Project
-import org.gradle.internal.io.LineBufferingOutputStream
-import org.gradle.internal.io.TextStream
 import org.gradle.process.ExecResult
 import org.gradle.process.ExecSpec
 import wooga.gradle.xcodebuild.ConsoleSettings

--- a/src/main/groovy/wooga/gradle/xcodebuild/tasks/AbstractXcodeArchiveTask.groovy
+++ b/src/main/groovy/wooga/gradle/xcodebuild/tasks/AbstractXcodeArchiveTask.groovy
@@ -1,0 +1,211 @@
+package wooga.gradle.xcodebuild.tasks
+
+import org.gradle.api.file.Directory
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Input
+import org.gradle.util.GUtil
+import wooga.gradle.xcodebuild.XcodeArchiveActionSpecBase
+
+abstract class AbstractXcodeArchiveTask extends AbstractXcodeTask implements XcodeArchiveActionSpecBase {
+    @Input
+    final Property<String> archiveName
+
+    @Override
+    void setArchiveName(String value) {
+        archiveName.set(value)
+    }
+
+    @Override
+    void setArchiveName(Provider<String> value) {
+        archiveName.set(value)
+    }
+
+    @Override
+    XcodeArchive archiveName(String value) {
+        setArchiveName(value)
+        this
+    }
+
+    @Override
+    XcodeArchive archiveName(Provider<String> value) {
+        setArchiveName(value)
+        this
+    }
+
+    final Property<String> baseName
+
+    @Override
+    void setBaseName(String value) {
+        baseName.set(value)
+    }
+
+    @Override
+    void setBaseName(Provider<String> value) {
+        baseName.set(value)
+    }
+
+    @Override
+    XcodeArchive baseName(String value) {
+        setBaseName(value)
+        this
+    }
+
+    @Override
+    XcodeArchive baseName(Provider<String> value) {
+        setBaseName(value)
+        this
+    }
+
+    final Property<String> appendix
+
+    @Override
+    void setAppendix(String value) {
+        appendix.set(value)
+    }
+
+    @Override
+    void setAppendix(Provider<String> value) {
+        appendix.set(value)
+    }
+
+    @Override
+    XcodeArchive appendix(String value) {
+        setAppendix(value)
+        this
+    }
+
+    @Override
+    XcodeArchive appendix(Provider<String> value) {
+        setAppendix(value)
+        this
+    }
+
+    final Property<String> version
+
+    @Override
+    void setVersion(String value) {
+        version.set(value)
+    }
+
+    @Override
+    void setVersion(Provider<String> value) {
+        version.set(value)
+    }
+
+    @Override
+    XcodeArchive version(String value) {
+        setVersion(value)
+        this
+    }
+
+    @Override
+    XcodeArchive version(Provider<String> value) {
+        setVersion(value)
+        this
+    }
+
+
+    final Property<String> extension
+
+    @Override
+    void setExtension(String value) {
+        extension.set(value)
+    }
+
+    @Override
+    void setExtension(Provider<String> value) {
+        extension.set(value)
+    }
+
+    @Override
+    XcodeArchive extension(String value) {
+        setExtension(value)
+        this
+    }
+
+    @Override
+    XcodeArchive extension(Provider<String> value) {
+        setExtension(value)
+        this
+    }
+
+    final Property<String> classifier
+
+    @Override
+    void setClassifier(String value) {
+        classifier.set(value)
+    }
+
+    @Override
+    void setClassifier(Provider<String> value) {
+        classifier.set(value)
+    }
+
+    @Override
+    XcodeArchive classifier(String value) {
+        setClassifier(value)
+        this
+    }
+
+    @Override
+    XcodeArchive classifier(Provider<String> value) {
+        setClassifier(value)
+        this
+    }
+
+    final DirectoryProperty destinationDir
+
+    @Override
+    void setDestinationDir(File value) {
+        destinationDir.set(value)
+    }
+
+    @Override
+    void setDestinationDir(Provider<Directory> value) {
+        destinationDir.set(value)
+    }
+
+    @Override
+    XcodeArchive destinationDir(File value) {
+        setDestinationDir(value)
+        this
+    }
+
+    @Override
+    XcodeArchive destinationDir(Provider<Directory> value) {
+        setDestinationDir(value)
+        this
+    }
+
+    AbstractXcodeArchiveTask() {
+        baseName = project.objects.property(String)
+        appendix = project.objects.property(String)
+        version = project.objects.property(String)
+        extension = project.objects.property(String)
+        classifier = project.objects.property(String)
+
+        archiveName = project.objects.property(String)
+        archiveName.set(project.provider({
+            String name = baseName.getOrElse("") + maybe(baseName.getOrElse(""), appendix)
+            name += maybe(name, version)
+            name += maybe(name, classifier)
+            name += extension.isPresent() && extension.get() != "" ? "." + extension.get() : ""
+            name
+        }))
+
+        destinationDir = project.layout.directoryProperty()
+    }
+
+    protected static String maybe(String prefix, Provider<String> value) {
+        if (value.isPresent() && value.get().size() > 0) {
+            if (GUtil.isTrue(prefix)) {
+                return "-".concat(value.get())
+            } else {
+                return value.get()
+            }
+        }
+        return ""
+    }
+}

--- a/src/main/groovy/wooga/gradle/xcodebuild/tasks/AbstractXcodeTask.groovy
+++ b/src/main/groovy/wooga/gradle/xcodebuild/tasks/AbstractXcodeTask.groovy
@@ -164,7 +164,7 @@ abstract class AbstractXcodeTask extends DefaultTask implements XcodeActionSpec 
 
     @Override
     AbstractXcodeTask buildSettings(Action<BuildSettings> action) {
-        def settings = buildSettings.getOrElse(new BuildSettings())
+        def settings = buildSettings.getOrElse(BuildSettings.EMPTY).clone() as BuildSettings
         action.execute(settings)
         buildSettings.set(settings)
         this

--- a/src/main/groovy/wooga/gradle/xcodebuild/tasks/ExportArchive.groovy
+++ b/src/main/groovy/wooga/gradle/xcodebuild/tasks/ExportArchive.groovy
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ *
+ */
+
+package wooga.gradle.xcodebuild.tasks
+
+import org.gradle.api.Action
+import org.gradle.api.file.*
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.SkipWhenEmpty
+import wooga.gradle.xcodebuild.XcodeExportActionSpec
+import wooga.gradle.xcodebuild.config.BuildSettings
+
+class ExportArchive extends AbstractXcodeArchiveTask implements XcodeExportActionSpec {
+
+    final RegularFileProperty exportOptionsPlist
+
+    @Override
+    void setExportOptionsPlist(Provider value) {
+        exportOptionsPlist.set(value)
+    }
+
+    @Override
+    void setExportOptionsPlist(File value) {
+        exportOptionsPlist.set(value)
+    }
+
+    @Override
+    ExportArchive exportOptionsPlist(Provider value) {
+        setExportOptionsPlist(value)
+        this
+    }
+
+    @Override
+    ExportArchive exportOptionsPlist(File value) {
+        setExportOptionsPlist(value)
+        this
+    }
+
+    final DirectoryProperty xcArchivePath
+
+    @Override
+    void setXcArchivePath(Provider value) {
+        xcArchivePath.set(value)
+    }
+
+    @Override
+    void setXcArchivePath(File value) {
+        xcArchivePath.set(value)
+    }
+
+    @Override
+    ExportArchive xcArchivePath(Provider value) {
+        setXcArchivePath(value)
+        this
+    }
+
+    @Override
+    ExportArchive xcArchivePath(File value) {
+        setXcArchivePath(value)
+        this
+    }
+
+    @OutputFile
+    final Provider<RegularFile> outputPath
+
+    @Input
+    final Provider<List<String>> buildArguments
+
+    @SkipWhenEmpty
+    @InputFiles
+    protected FileCollection getInputFiles() {
+        project.files(xcArchivePath, exportOptionsPlist)
+    }
+
+    ExportArchive() {
+        super()
+        exportOptionsPlist = project.layout.fileProperty()
+        xcArchivePath = project.layout.directoryProperty()
+
+        outputPath = destinationDir.file(archiveName)
+        buildArguments = project.provider({
+            List<String> arguments = new ArrayList<String>()
+            BuildSettings buildSettings = buildSettings.getOrElse(BuildSettings.EMPTY)
+            arguments << "xcodebuild"
+            arguments << "-exportArchive"
+            arguments << "-exportPath" << temporaryDir.path
+            arguments << "-exportOptionsPlist" << exportOptionsPlist.get().asFile.path
+            arguments << "-archivePath" << xcArchivePath.get().asFile.path
+
+            if (additionalBuildArguments.present) {
+                additionalBuildArguments.get().each {
+                    arguments << it
+                }
+            }
+
+            arguments.addAll(buildSettings.toList())
+            arguments
+        })
+    }
+
+    @Override
+    protected void exec() {
+        super.exec()
+
+        project.copy(new Action<CopySpec>() {
+            @Override
+            void execute(CopySpec copySpec) {
+                copySpec.with {
+                    from temporaryDir.path
+                    include "*.ipa"
+                    into destinationDir.get().asFile
+                    it.rename { filename ->
+                        archiveName.get()
+                    }
+                }
+            }
+        })
+    }
+}

--- a/src/main/groovy/wooga/gradle/xcodebuild/tasks/XcodeArchive.groovy
+++ b/src/main/groovy/wooga/gradle/xcodebuild/tasks/XcodeArchive.groovy
@@ -21,6 +21,7 @@ package wooga.gradle.xcodebuild.tasks
 
 import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFile
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
@@ -32,7 +33,7 @@ import wooga.gradle.xcodebuild.XcodeBuildAction
 import wooga.gradle.xcodebuild.XcodeBuildPluginConsts
 import wooga.gradle.xcodebuild.config.BuildSettings
 
-class XcodeArchive extends AbstractXcodeTask implements XcodeArchiveActionSpec {
+class XcodeArchive extends AbstractXcodeArchiveTask implements XcodeArchiveActionSpec {
 
     @Optional
     @Input
@@ -84,9 +85,6 @@ class XcodeArchive extends AbstractXcodeTask implements XcodeArchiveActionSpec {
         setClean(value)
         this
     }
-
-    @Input
-    final Provider<Set<XcodeBuildAction>> buildActions
 
     @Input
     final Property<String> scheme
@@ -221,178 +219,12 @@ class XcodeArchive extends AbstractXcodeTask implements XcodeArchiveActionSpec {
         this
     }
 
-    @OutputDirectory
+    @OutputFiles
+    protected FileCollection getOutputFiles() {
+        project.files(xcArchivePath)
+    }
+
     final Provider<Directory> xcArchivePath
-
-    @Input
-    final Property<String> archiveName
-
-    @Override
-    void setArchiveName(String value) {
-        archiveName.set(value)
-    }
-
-    @Override
-    void setArchiveName(Provider<String> value) {
-        archiveName.set(value)
-    }
-
-    @Override
-    XcodeArchive archiveName(String value) {
-        setArchiveName(value)
-        this
-    }
-
-    @Override
-    XcodeArchive archiveName(Provider<String> value) {
-        setArchiveName(value)
-        this
-    }
-
-    final Property<String> baseName
-
-    @Override
-    void setBaseName(String value) {
-        baseName.set(value)
-    }
-
-    @Override
-    void setBaseName(Provider<String> value) {
-        baseName.set(value)
-    }
-
-    @Override
-    XcodeArchive baseName(String value) {
-        setBaseName(value)
-        this
-    }
-
-    @Override
-    XcodeArchive baseName(Provider<String> value) {
-        setBaseName(value)
-        this
-    }
-
-    final Property<String> appendix
-
-    @Override
-    void setAppendix(String value) {
-        appendix.set(value)
-    }
-
-    @Override
-    void setAppendix(Provider<String> value) {
-        appendix.set(value)
-    }
-
-    @Override
-    XcodeArchive appendix(String value) {
-        setAppendix(value)
-        this
-    }
-
-    @Override
-    XcodeArchive appendix(Provider<String> value) {
-        setAppendix(value)
-        this
-    }
-
-    final Property<String> version
-
-    @Override
-    void setVersion(String value) {
-        version.set(value)
-    }
-
-    @Override
-    void setVersion(Provider<String> value) {
-        version.set(value)
-    }
-
-    @Override
-    XcodeArchive version(String value) {
-        setVersion(value)
-        this
-    }
-
-    @Override
-    XcodeArchive version(Provider<String> value) {
-        setVersion(value)
-        this
-    }
-
-
-    final Property<String> extension
-
-    @Override
-    void setExtension(String value) {
-        extension.set(value)
-    }
-
-    @Override
-    void setExtension(Provider<String> value) {
-        extension.set(value)
-    }
-
-    @Override
-    XcodeArchive extension(String value) {
-        setExtension(value)
-        this
-    }
-
-    @Override
-    XcodeArchive extension(Provider<String> value) {
-        setExtension(value)
-        this
-    }
-
-    final Property<String> classifier
-
-    @Override
-    void setClassifier(String value) {
-        classifier.set(value)
-    }
-
-    @Override
-    void setClassifier(Provider<String> value) {
-        classifier.set(value)
-    }
-
-    @Override
-    XcodeArchive classifier(String value) {
-        setClassifier(value)
-        this
-    }
-
-    @Override
-    XcodeArchive classifier(Provider<String> value) {
-        setClassifier(value)
-        this
-    }
-
-    final DirectoryProperty destinationDir
-
-    @Override
-    void setDestinationDir(File value) {
-        destinationDir.set(value)
-    }
-
-    @Override
-    void setDestinationDir(Provider<Directory> value) {
-        destinationDir.set(value)
-    }
-
-    @Override
-    XcodeArchive destinationDir(File value) {
-        setDestinationDir(value)
-        this
-    }
-
-    @Override
-    XcodeArchive destinationDir(Provider<Directory> value) {
-        setDestinationDir(value)
-        this
-    }
 
     @Input
     final Provider<List<String>> buildArguments
@@ -408,42 +240,18 @@ class XcodeArchive extends AbstractXcodeTask implements XcodeArchiveActionSpec {
         derivedDataPath = project.layout.directoryProperty()
         buildKeychain = project.layout.fileProperty()
 
-        buildActions = project.provider({
-            def s = new HashSet<XcodeBuildAction>()
-            s << XcodeBuildAction.archive
-
-            if (clean.present && clean.get()) {
-                s << XcodeBuildAction.clean
-            }
-            s
-        })
-
-        baseName = project.objects.property(String)
-        appendix = project.objects.property(String)
-        version = project.objects.property(String)
-        extension = project.objects.property(String)
-        classifier = project.objects.property(String)
-
-        archiveName = project.objects.property(String)
-        archiveName.set(project.provider({
-            String name = baseName.getOrElse("") + maybe(baseName.getOrElse(""), appendix)
-            name += maybe(name, version)
-            name += maybe(name, classifier)
-            name += extension.isPresent() && extension.get() != "" ? "." + extension.get() : ""
-            name
-        }))
-
-        destinationDir = project.layout.directoryProperty()
         xcArchivePath = archiveName.map({ destinationDir.get().dir(it) })
 
         buildArguments = project.provider({
             List<String> arguments = new ArrayList<String>()
-            BuildSettings settings = buildSettings.getOrElse(new BuildSettings())
+            BuildSettings settings = buildSettings.getOrElse(BuildSettings.EMPTY)
             arguments << "xcodebuild"
 
-            buildActions.get().each {
-                arguments << it.toString()
+            if (clean.present && clean.get()) {
+                arguments << XcodeBuildAction.clean.toString()
             }
+
+            arguments << XcodeBuildAction.archive.toString()
 
             def projectOrWorkspace = projectPath.get().asFile
 
@@ -483,19 +291,6 @@ class XcodeArchive extends AbstractXcodeTask implements XcodeArchiveActionSpec {
 
             arguments.addAll(settings.toList())
             arguments
-
-            arguments
         })
-    }
-
-    protected static String maybe(String prefix, Provider<String> value) {
-        if (value.isPresent() && value.get().size() > 0) {
-            if (GUtil.isTrue(prefix)) {
-                return "-".concat(value.get())
-            } else {
-                return value.get()
-            }
-        }
-        return ""
     }
 }

--- a/src/test/groovy/wooga/gradle/xcodebuild/internal/LineBufferingOutputStreamSpec.groovy
+++ b/src/test/groovy/wooga/gradle/xcodebuild/internal/LineBufferingOutputStreamSpec.groovy
@@ -1,0 +1,118 @@
+package wooga.gradle.xcodebuild.internal
+
+import spock.lang.Specification
+
+class LineBufferingOutputStreamSpec extends Specification {
+
+
+    def handler = Mock(TextStream)
+    def stream = new LineBufferingOutputStream(handler)
+    def w = stream.newWriter()
+
+    def "writes whole lines to handler"() {
+        when:
+        w.write("hello")
+        w.flush()
+        w.write(" world")
+        w.flush()
+        w.write("!\n")
+        w.flush()
+
+        w.write("hi")
+        w.flush()
+        w.write(" you")
+        w.flush()
+        w.write(" too!\n")
+        w.flush()
+
+        then:
+        1 * handler.text("hello world!\n")
+        1 * handler.text("hi you too!\n")
+    }
+
+    def "writes multiple lines from single String"() {
+        when:
+        w.write("""
+        First line
+        Second line
+        Third line
+        """.stripIndent().trim())
+        w.flush()
+        w.close()
+
+        then:
+        1 * handler.text("First line\n")
+        1 * handler.text("Second line\n")
+        1 * handler.text("Third line")
+    }
+
+    def "writes line to handler when line length exceeds max line lenght"() {
+        given: "a stream with a short linelength"
+        stream = new LineBufferingOutputStream(handler, 2048, 5)
+        w = stream.newWriter()
+
+        when: "write a few lines which are too long"
+        w.write("hello world!\n")
+        w.write("hi you too!\n")
+        w.flush()
+
+        then:
+        1 * handler.text("hello")
+        1 * handler.text(" worl")
+        1 * handler.text("d!\n")
+        1 * handler.text("hi yo")
+        1 * handler.text("u too")
+        1 * handler.text("!\n")
+    }
+
+    def "flushes last written bytes when stream closes"() {
+        given: "a written line without line ending"
+        w.write("a line without ending")
+
+        when:
+        w.flush()
+
+        then:
+        0 * handler.text("a line without ending")
+
+
+        when:
+        stream.close()
+
+        then:
+        1 * handler.text("a line without ending")
+    }
+
+    def "calls endOfStream on handler when stream closes"() {
+        when:
+        stream.close()
+
+        then:
+        1 * handler.endOfStream(null)
+    }
+
+    def "throws IOException when attempt to write on closed stream"() {
+        given: "a closed stream"
+        stream.close()
+
+        when:
+        w.write("one last string please")
+        w.flush()
+
+        then:
+        def e = thrown(IOException)
+        e.message == "The stream has been closed."
+    }
+
+    def "flush is a no-op"() {
+        given: "an unfinished written line"
+        w.write("a line without ending")
+        w.flush()
+
+        when:
+        stream.flush()
+
+        then:
+        0 * handler.text("a line without ending")
+    }
+}


### PR DESCRIPTION
## Description

This patch adds the second most important xcodebuild functionality, the ability to create an `ipa` file from an exported `xcarchive`. The task is based on the new added abstract type `AbstractXcodeArchiveTask`. This new type shares the majority of properties with `XcodeArchive` and `ExportArchive`. I also changed the test setup to reflect this.

Exporting an unsigned ipa is not possible with `xcodebuild` because that is exactly what the command is for. Create a signed `ipa` package to upload apple or use to install a local version.

I added tests to verify the creation of an `ipa` file but guarded this with an `@Requires({ env.TEST_TEAM_ID })` statement. `TEST_TEAM_ID` should refer to a valid team for which both signing certificate and provisioning profile for appID `net.wooga.xcodebuildPluginTest` is available on the system that runs the tests. I used personal signing to test this and the teamID was the only setting needed.

## Changes

* ![ADD] `ExportArchive` task

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
