### PR TITLE
Fix line buffering output for logfile handling

### DIFF
--- a/src/main/groovy/wooga/gradle/xcodebuild/internal/ForkTextStream.groovy
+++ b/src/main/groovy/wooga/gradle/xcodebuild/internal/ForkTextStream.groovy
@@ -19,8 +19,6 @@
 
 package wooga.gradle.xcodebuild.internal
 
-import org.gradle.api.Nullable
-import org.gradle.internal.io.TextStream
 
 class ForkTextStream implements TextStream {
 
@@ -48,7 +46,7 @@ class ForkTextStream implements TextStream {
     }
 
     @Override
-    void endOfStream(@Nullable Throwable failure) {
+    void endOfStream(Throwable failure) {
         writerList.each {
             try {
                 it.close()

--- a/src/main/groovy/wooga/gradle/xcodebuild/internal/LineBufferingOutputStream.groovy
+++ b/src/main/groovy/wooga/gradle/xcodebuild/internal/LineBufferingOutputStream.groovy
@@ -1,0 +1,67 @@
+package wooga.gradle.xcodebuild.internal
+
+import org.gradle.internal.SystemProperties
+import org.gradle.internal.io.StreamByteBuffer
+
+class LineBufferingOutputStream extends OutputStream {
+    private static final int LINE_MAX_LENGTH = 1048576
+    private boolean hasBeenClosed
+    private final TextStream handler
+    private StreamByteBuffer buffer
+    private final OutputStream output
+    private final byte lastLineSeparatorByte
+    private final int lineMaxLength
+    private int counter
+
+    LineBufferingOutputStream(TextStream handler) {
+        this(handler, 2048)
+    }
+
+    LineBufferingOutputStream(TextStream handler, int bufferLength) {
+        this(handler, bufferLength, LINE_MAX_LENGTH)
+    }
+
+    LineBufferingOutputStream(TextStream handler, int bufferLength, int lineMaxLength) {
+        this.handler = handler
+        this.buffer = new StreamByteBuffer(bufferLength)
+        this.lineMaxLength = lineMaxLength
+        this.output = this.buffer.getOutputStream()
+        byte[] lineSeparator = SystemProperties.getInstance().getLineSeparator().getBytes()
+        this.lastLineSeparatorByte = lineSeparator[lineSeparator.length - 1]
+    }
+
+    void close() throws IOException {
+        this.hasBeenClosed = true
+        this.flushLine()
+        this.handler.endOfStream((Throwable)null)
+    }
+
+    void write(int b) throws IOException {
+        if (this.hasBeenClosed) {
+            throw new IOException("The stream has been closed.")
+        } else {
+            this.output.write(b)
+            ++this.counter
+            if (this.endsWithLineSeparator(b) || this.counter >= this.lineMaxLength) {
+                this.flushLine()
+            }
+        }
+    }
+
+    private boolean endsWithLineSeparator(int b) {
+        byte currentByte = (byte)(b & 255)
+        return currentByte == this.lastLineSeparatorByte || currentByte == 10
+    }
+
+    private void flushLine() {
+        String text = this.buffer.readAsString()
+        if (text.length() > 0) {
+            this.handler.text(text)
+        }
+
+        this.counter = 0
+    }
+
+    void flush(){
+    }
+}

--- a/src/main/groovy/wooga/gradle/xcodebuild/internal/TextStream.groovy
+++ b/src/main/groovy/wooga/gradle/xcodebuild/internal/TextStream.groovy
@@ -1,0 +1,7 @@
+package wooga.gradle.xcodebuild.internal
+
+interface TextStream {
+    void text(String text);
+
+    void endOfStream(Throwable stream);
+}

--- a/src/main/groovy/wooga/gradle/xcodebuild/internal/XcodeBuildAction.groovy
+++ b/src/main/groovy/wooga/gradle/xcodebuild/internal/XcodeBuildAction.groovy
@@ -23,8 +23,6 @@ import com.wooga.xcodebuild.xcpretty.Printer
 import com.wooga.xcodebuild.xcpretty.formatters.Simple
 import org.gradle.api.Action
 import org.gradle.api.Project
-import org.gradle.internal.io.LineBufferingOutputStream
-import org.gradle.internal.io.TextStream
 import org.gradle.process.ExecResult
 import org.gradle.process.ExecSpec
 import wooga.gradle.xcodebuild.ConsoleSettings

--- a/src/test/groovy/wooga/gradle/xcodebuild/internal/LineBufferingOutputStreamSpec.groovy
+++ b/src/test/groovy/wooga/gradle/xcodebuild/internal/LineBufferingOutputStreamSpec.groovy
@@ -1,0 +1,118 @@
+package wooga.gradle.xcodebuild.internal
+
+import spock.lang.Specification
+
+class LineBufferingOutputStreamSpec extends Specification {
+
+
+    def handler = Mock(TextStream)
+    def stream = new LineBufferingOutputStream(handler)
+    def w = stream.newWriter()
+
+    def "writes whole lines to handler"() {
+        when:
+        w.write("hello")
+        w.flush()
+        w.write(" world")
+        w.flush()
+        w.write("!\n")
+        w.flush()
+
+        w.write("hi")
+        w.flush()
+        w.write(" you")
+        w.flush()
+        w.write(" too!\n")
+        w.flush()
+
+        then:
+        1 * handler.text("hello world!\n")
+        1 * handler.text("hi you too!\n")
+    }
+
+    def "writes multiple lines from single String"() {
+        when:
+        w.write("""
+        First line
+        Second line
+        Third line
+        """.stripIndent().trim())
+        w.flush()
+        w.close()
+
+        then:
+        1 * handler.text("First line\n")
+        1 * handler.text("Second line\n")
+        1 * handler.text("Third line")
+    }
+
+    def "writes line to handler when line length exceeds max line lenght"() {
+        given: "a stream with a short linelength"
+        stream = new LineBufferingOutputStream(handler, 2048, 5)
+        w = stream.newWriter()
+
+        when: "write a few lines which are too long"
+        w.write("hello world!\n")
+        w.write("hi you too!\n")
+        w.flush()
+
+        then:
+        1 * handler.text("hello")
+        1 * handler.text(" worl")
+        1 * handler.text("d!\n")
+        1 * handler.text("hi yo")
+        1 * handler.text("u too")
+        1 * handler.text("!\n")
+    }
+
+    def "flushes last written bytes when stream closes"() {
+        given: "a written line without line ending"
+        w.write("a line without ending")
+
+        when:
+        w.flush()
+
+        then:
+        0 * handler.text("a line without ending")
+
+
+        when:
+        stream.close()
+
+        then:
+        1 * handler.text("a line without ending")
+    }
+
+    def "calls endOfStream on handler when stream closes"() {
+        when:
+        stream.close()
+
+        then:
+        1 * handler.endOfStream(null)
+    }
+
+    def "throws IOException when attempt to write on closed stream"() {
+        given: "a closed stream"
+        stream.close()
+
+        when:
+        w.write("one last string please")
+        w.flush()
+
+        then:
+        def e = thrown(IOException)
+        e.message == "The stream has been closed."
+    }
+
+    def "flush is a no-op"() {
+        given: "an unfinished written line"
+        w.write("a line without ending")
+        w.flush()
+
+        when:
+        stream.flush()
+
+        then:
+        0 * handler.text("a line without ending")
+    }
+}


### PR DESCRIPTION
## Description

This is a tempoary fix. The whole outputhandling for xcpretty and logfile needs to be readressed. I copied the first solution from a different codebase which used the `LineBufferingOutputStream` from gradle without need that lines are only written when complete.

Ok the problem at hand that this patch will fix. I need an `OutputStream` implementation that waits for whole lines to be written before passing that down to another instance. I used a class from withing gradle without checking the implementatin details. The problem with this class is, that it writes out to the connected handler on the call `flush`. This method can and will be also called from the outside which can lead to chopped of lines.

I created now my own version of `LineBufferingOutputStream` to solve this little usability bug. As stated this whole solution is just a quick fix. I will refactor the whole output handling once more at a later stage.

## Changes

* ![FIX] line buffering output stream for logfile printing




[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
