### PR TITLE
Add ArchiveDebugSymbols task type

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/xcodebuild/XcodeBuildPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/xcodebuild/XcodeBuildPluginIntegrationSpec.groovy
@@ -1,11 +1,20 @@
 package wooga.gradle.xcodebuild
 
+import net.wooga.test.xcode.XcodeTestProject
+import org.junit.ClassRule
 import spock.lang.Requires
+import spock.lang.Shared
 import spock.lang.Unroll
+import wooga.gradle.xcodebuild.tasks.ArchiveDebugSymbols
+import wooga.gradle.xcodebuild.tasks.ExportArchive
 import wooga.gradle.xcodebuild.tasks.XcodeArchive
 
 @Requires({ os.macOs })
 class XcodeBuildPluginIntegrationSpec extends XcodeBuildIntegrationSpec {
+
+    @Shared
+    @ClassRule
+    XcodeTestProject xcodeProject = new XcodeTestProject()
 
     @Unroll()
     def "extension property :#property returns '#testValue' if #reason"() {
@@ -106,6 +115,25 @@ class XcodeBuildPluginIntegrationSpec extends XcodeBuildIntegrationSpec {
         "xarchivesDir"    | "xarchivesDir"        | "/custom/archives"         | _                                                                      | "File"                      | PropertyLocation.script   | " as absolute path"
         "xarchivesDir"    | "xarchivesDir"        | "/custom/archives"         | _                                                                      | "Provider<Directory>"       | PropertyLocation.script   | " as absolute path"
 
+        "debugSymbolsDir" | _                     | "custom/symbols"           | "#projectDir#/build/custom/symbols"                                    | _                           | PropertyLocation.env      | " as relative path"
+        "debugSymbolsDir" | _                     | "custom/symbols"           | "#projectDir#/build/custom/symbols"                                    | _                           | PropertyLocation.property | " as relative path"
+        "debugSymbolsDir" | _                     | "build/custom/symbols"     | "#projectDir#/build/custom/symbols"                                    | "File"                      | PropertyLocation.script   | " as relative path"
+        "debugSymbolsDir" | _                     | "build/custom/symbols"     | "#projectDir#/build/custom/symbols"                                    | "Provider<Directory>"       | PropertyLocation.script   | " as relative path"
+        "debugSymbolsDir" | "debugSymbolsDir.set" | "build/custom/symbols"     | "#projectDir#/build/custom/symbols"                                    | "File"                      | PropertyLocation.script   | " as relative path"
+        "debugSymbolsDir" | "debugSymbolsDir.set" | "build/custom/symbols"     | "#projectDir#/build/custom/symbols"                                    | "Provider<Directory>"       | PropertyLocation.script   | " as relative path"
+        "debugSymbolsDir" | "debugSymbolsDir"     | "build/custom/symbols"     | "#projectDir#/build/custom/symbols"                                    | "File"                      | PropertyLocation.script   | " as relative path"
+        "debugSymbolsDir" | "debugSymbolsDir"     | "build/custom/symbols"     | "#projectDir#/build/custom/symbols"                                    | "Provider<Directory>"       | PropertyLocation.script   | " as relative path"
+        "debugSymbolsDir" | _                     | _                          | "#projectDir#/build/symbols"                                           | _                           | PropertyLocation.none     | ""
+
+        "debugSymbolsDir" | _                     | "/custom/symbols"          | _                                                                      | _                           | PropertyLocation.env      | " as absolute path"
+        "debugSymbolsDir" | _                     | "/custom/symbols"          | _                                                                      | _                           | PropertyLocation.property | " as absolute path"
+        "debugSymbolsDir" | _                     | "/custom/symbols"          | _                                                                      | "File"                      | PropertyLocation.script   | " as absolute path"
+        "debugSymbolsDir" | _                     | "/custom/symbols"          | _                                                                      | "Provider<Directory>"       | PropertyLocation.script   | " as absolute path"
+        "debugSymbolsDir" | "debugSymbolsDir.set" | "/custom/symbols"          | _                                                                      | "File"                      | PropertyLocation.script   | " as absolute path"
+        "debugSymbolsDir" | "debugSymbolsDir.set" | "/custom/symbols"          | _                                                                      | "Provider<Directory>"       | PropertyLocation.script   | " as absolute path"
+        "debugSymbolsDir" | "debugSymbolsDir"     | "/custom/symbols"          | _                                                                      | "File"                      | PropertyLocation.script   | " as absolute path"
+        "debugSymbolsDir" | "debugSymbolsDir"     | "/custom/symbols"          | _                                                                      | "Provider<Directory>"       | PropertyLocation.script   | " as absolute path"
+
         "consoleSettings" | "consoleSettings.set" | "plain"                    | "ConsoleSettings{prettyPrint=true, useUnicode=false, colorize=never}"  | "ConsoleSettings"           | PropertyLocation.script   | ""
         "consoleSettings" | "consoleSettings.set" | "rich"                     | "ConsoleSettings{prettyPrint=true, useUnicode=true, colorize=always}"  | "Provider<ConsoleSettings>" | PropertyLocation.script   | ""
         "consoleSettings" | "consoleSettings"     | "verbose"                  | "ConsoleSettings{prettyPrint=false, useUnicode=false, colorize=never}" | "ConsoleSettings"           | PropertyLocation.script   | ""
@@ -140,7 +168,7 @@ class XcodeBuildPluginIntegrationSpec extends XcodeBuildIntegrationSpec {
 
         and: "a set property"
         and: "a set property"
-        if(useConfigureBlock) {
+        if (useConfigureBlock) {
             buildFile << """
             ${extensionName}.consoleSettings {
                 ${invocation}
@@ -202,7 +230,7 @@ class XcodeBuildPluginIntegrationSpec extends XcodeBuildIntegrationSpec {
 
             task(custom) {
                 doLast {
-                    def value = ${taskName}.${property}.getOrNull()
+                    def value = ${taskName}.${property}${providerInvocation}
                     println("${taskName}.${property}: " + value)
                 }
             }
@@ -223,10 +251,14 @@ class XcodeBuildPluginIntegrationSpec extends XcodeBuildIntegrationSpec {
         result.standardOutput.contains("${taskName}.${property}: ${testValue}")
 
         where:
-        property          | extensionProperty | tasktype     | rawValue                   | expectedValue                                      | type
-        "logFile"         | "logsDir"         | XcodeArchive | "build/custom/logs"        | "#projectDir#/build/custom/logs/#taskName#.log"    | "File"
-        "derivedDataPath" | "derivedDataPath" | XcodeArchive | "build/custom/derivedData" | "#projectDir#/build/custom/derivedData/#taskName#" | "File"
-        "destinationDir"  | "xarchivesDir"    | XcodeArchive | "build/custom/archives"    | "#projectDir#/build/custom/archives"               | "File"
+        property          | extensionProperty | tasktype            | rawValue                   | expectedValue                                      | type   | useProviderApi
+        "logFile"         | "logsDir"         | XcodeArchive        | "build/custom/logs"        | "#projectDir#/build/custom/logs/#taskName#.log"    | "File" | true
+        "logFile"         | "logsDir"         | ExportArchive       | "build/custom/logs"        | "#projectDir#/build/custom/logs/#taskName#.log"    | "File" | true
+        "derivedDataPath" | "derivedDataPath" | XcodeArchive        | "build/custom/derivedData" | "#projectDir#/build/custom/derivedData/#taskName#" | "File" | true
+        "destinationDir"  | "xarchivesDir"    | XcodeArchive        | "build/custom/archives"    | "#projectDir#/build/custom/archives"               | "File" | true
+        "destinationDir"  | "xarchivesDir"    | ExportArchive       | "build/custom/archives"    | "#projectDir#/build/custom/archives"               | "File" | true
+        "destinationDir"  | "debugSymbolsDir" | ArchiveDebugSymbols | "build/custom/symbols"     | "#projectDir#/build/custom/symbols"                | "File" | false
+
 
         extensionName = "xcodebuild"
         taskName = "xcodebuildTask"
@@ -234,6 +266,7 @@ class XcodeBuildPluginIntegrationSpec extends XcodeBuildIntegrationSpec {
         testValue = (expectedValue == _) ? rawValue : expectedValue
         escapedValue = (value instanceof String) ? escapedPath(value) : value
         invocation = "${extensionProperty}.set(${escapedValue})"
+        providerInvocation = (useProviderApi) ? ".getOrNull()" : ""
     }
 
     @Unroll("gradle console #console sets default value for consoleSettings.#consoleSettingProperty: #expectedValue")
@@ -277,7 +310,5 @@ class XcodeBuildPluginIntegrationSpec extends XcodeBuildIntegrationSpec {
         "auto"    | "colorize"             | ConsoleSettings.ColorOption.auto
 
         extensionName = "xcodebuild"
-
     }
-
 }

--- a/src/integrationTest/groovy/wooga/gradle/xcodebuild/tasks/ArchiveDebugSymbolsIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/xcodebuild/tasks/ArchiveDebugSymbolsIntegrationSpec.groovy
@@ -1,0 +1,52 @@
+package wooga.gradle.xcodebuild.tasks
+
+import net.wooga.test.xcode.XcodeTestProject
+import org.junit.ClassRule
+import spock.lang.Requires
+import spock.lang.Shared
+import wooga.gradle.xcodebuild.XcodeBuildIntegrationSpec
+
+@Requires({ os.macOs })
+class ArchiveDebugSymbolsIntegrationSpec extends XcodeBuildIntegrationSpec {
+
+    @Shared
+    @ClassRule
+    XcodeTestProject xcodeProject = new XcodeTestProject()
+
+    def "creates zip archive with dsym files from xcarchive file"() {
+        given: "a XcodeArchive task"
+        buildFile << """
+        task xcodeArchive(type: ${XcodeArchive.name}) {
+            scheme = "${xcodeProject.schemeName}"
+            baseName = "custom"
+            version = "0.1.0"
+            buildSettings {
+                codeSignIdentity ""
+                codeSigningRequired false
+                codeSigningAllowed false
+            }
+            projectPath = new File("${xcodeProject.xcodeProject}")
+        } 
+        """.stripIndent()
+
+        and: "the generated ArchiveDsym task"
+        buildFile << """
+        xcodeArchiveArchiveDSYMs {
+            baseName = "custom"
+            version = "0.1.0"
+        }
+        """
+
+        and: "a future dsym archive"
+        def dsymArchive = new File(projectDir, "build/symbols/custom-0.1.0-dSYM.zip")
+        assert !dsymArchive.exists()
+
+        when:
+        def result = runTasksSuccessfully("xcodeArchiveArchiveDSYMs")
+
+        then:
+        result.success
+        result.wasExecuted("xcodeArchive")
+        dsymArchive.exists()
+    }
+}

--- a/src/integrationTest/groovy/wooga/gradle/xcodebuild/tasks/ExportArchiveIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/xcodebuild/tasks/ExportArchiveIntegrationSpec.groovy
@@ -17,10 +17,11 @@ class ExportArchiveIntegrationSpec extends AbstractXcodeArchiveTaskIntegrationSp
 
     Class taskType = ExportArchive
 
-    String testTaskName = "customExportArchive"
+    String archiveTaskName = "xcodeArchive"
+    String testTaskName = archiveTaskName + "Export"
 
     String workingXcodebuildTaskConfig = """
-    task exportArchive(type: ${XcodeArchive.name}) {
+    task ${archiveTaskName}(type: ${XcodeArchive.name}) {
         scheme = "${xcodeProject.schemeName}"
         baseName = "custom"
         version = "0.1.0"
@@ -36,11 +37,9 @@ class ExportArchiveIntegrationSpec extends AbstractXcodeArchiveTaskIntegrationSp
         projectPath = new File("${xcodeProject.xcodeProject}")
     }
 
-    task ${testTaskName}(type: ${taskType.name}) {
-        dependsOn exportArchive
+    ${testTaskName} {
         baseName = "custom"
         version = "0.1.0"
-        xcArchivePath = exportArchive.xcArchivePath
         exportOptionsPlist = file("exportOptions.plist")
     }
     """.stripIndent()
@@ -258,6 +257,7 @@ class ExportArchiveIntegrationSpec extends AbstractXcodeArchiveTaskIntegrationSp
 
         then:
         result.success
+        result.wasExecuted(archiveTaskName)
         archive.exists()
         archive.isFile()
     }

--- a/src/main/groovy/wooga/gradle/xcodebuild/XcodeBuildPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/xcodebuild/XcodeBuildPlugin.groovy
@@ -22,12 +22,16 @@ package wooga.gradle.xcodebuild
 import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.logging.configuration.ConsoleOutput
+import org.gradle.api.Transformer
+import org.gradle.api.file.Directory
+import org.gradle.api.plugins.BasePlugin
 import org.gradle.api.provider.Provider
+import wooga.gradle.build.unity.ios.internal.utils.PropertyUtils
 import wooga.gradle.xcodebuild.internal.DefaultXcodeBuildPluginExtension
 import wooga.gradle.xcodebuild.internal.PropertyLookup
 import wooga.gradle.xcodebuild.tasks.AbstractXcodeArchiveTask
 import wooga.gradle.xcodebuild.tasks.AbstractXcodeTask
+import wooga.gradle.xcodebuild.tasks.ArchiveDebugSymbols
 import wooga.gradle.xcodebuild.tasks.ExportArchive
 import wooga.gradle.xcodebuild.tasks.XcodeArchive
 
@@ -36,29 +40,58 @@ import static wooga.gradle.xcodebuild.XcodeBuildPluginConsts.*
 class XcodeBuildPlugin implements Plugin<Project> {
 
     static final String EXTENSION_NAME = "xcodebuild"
+    static final String ARCHIVE_DEBUG_SYMBOLS_TASK_POSTFIX = "ArchiveDSYMs"
+    static final String EXPORT_ARCHIVE_TASK_POSTFIX = "Export"
     private Project project
 
     @Override
     void apply(Project project) {
         this.project = project
         def extension = project.extensions.create(XcodeBuildPluginExtension, EXTENSION_NAME, DefaultXcodeBuildPluginExtension, project)
+        def tasks = project.tasks
 
         extension.logsDir.set(project.layout.buildDirectory.dir(lookupValueInEnvAndPropertiesProvider(LOGS_DIR_LOOKUP)))
         extension.derivedDataPath.set(project.layout.buildDirectory.dir(lookupValueInEnvAndPropertiesProvider(DERIVED_DATA_PATH_LOOKUP)))
         extension.xarchivesDir.set(project.layout.buildDirectory.dir(lookupValueInEnvAndPropertiesProvider(XARCHIVES_DIR_LOOKUP)))
+        extension.debugSymbolsDir.set(project.layout.buildDirectory.dir(lookupValueInEnvAndPropertiesProvider(DEBUG_SYMBOLS_DIR_LOOKUP)))
         extension.consoleSettings.set(ConsoleSettings.fromGradleOutput(project.gradle.startParameter.consoleOutput))
 
         project.tasks.withType(XcodeArchive.class, new Action<XcodeArchive>() {
             @Override
             void execute(XcodeArchive task) {
+
+                task.group = BasePlugin.BUILD_GROUP
+                task.description = "export .xcarchive from given Xcode project"
+
                 task.extension.set("xcarchive")
                 task.derivedDataPath.set(extension.derivedDataPath.dir(task.name))
+
+                //each XcodeArchive task creates an archive symbols task
+                tasks.create(task.name + ARCHIVE_DEBUG_SYMBOLS_TASK_POSTFIX, ArchiveDebugSymbols) {
+                    it.dependsOn(task)
+                    it.from(task.xcArchivePath.map(new Transformer<Directory, Directory>() {
+                        @Override
+                        Directory transform(Directory archivePath) {
+                            archivePath.dir("dSYMs")
+                        }
+                    })
+                    )
+                }
+
+                //each XcodeArchive task creates an exportArchive task
+                tasks.create(task.name + EXPORT_ARCHIVE_TASK_POSTFIX, ExportArchive) {
+                    it.dependsOn(task)
+                    it.xcArchivePath(task.xcArchivePath)
+                }
             }
         })
 
         project.tasks.withType(ExportArchive.class, new Action<ExportArchive>() {
             @Override
             void execute(ExportArchive task) {
+                task.group = BasePlugin.BUILD_GROUP
+                task.description = "export ipa file from given .xcarchive"
+
                 task.extension.set("ipa")
             }
         })
@@ -77,6 +110,23 @@ class XcodeBuildPlugin implements Plugin<Project> {
             void execute(AbstractXcodeTask task) {
                 task.logFile.set(extension.logsDir.file("${task.name}.log"))
                 task.consoleSettings.set(extension.consoleSettings)
+            }
+        })
+
+        project.tasks.withType(ArchiveDebugSymbols.class, new Action<ArchiveDebugSymbols>() {
+            @Override
+            void execute(ArchiveDebugSymbols task) {
+                task.group = BasePlugin.BUILD_GROUP
+                task.description = "export debug symbols (dSYMs) from given .xcarchive"
+
+                def conventionMapping = task.getConventionMapping()
+                conventionMapping.map("version", { PropertyUtils.convertToString(project.version) })
+                conventionMapping.map("destinationDir", {
+                    extension.debugSymbolsDir.get().asFile
+                })
+                conventionMapping.map("baseName", { project.name })
+                conventionMapping.map("classifier", { "dSYM" })
+                conventionMapping.map("extension", { "zip" })
             }
         })
     }

--- a/src/main/groovy/wooga/gradle/xcodebuild/XcodeBuildPluginConsts.groovy
+++ b/src/main/groovy/wooga/gradle/xcodebuild/XcodeBuildPluginConsts.groovy
@@ -51,4 +51,14 @@ class XcodeBuildPluginConsts {
      * @see wooga.gradle.xcodebuild.XcodeBuildPluginExtension#getXarchivesDir()
      */
     static final PropertyLookup XARCHIVES_DIR_LOOKUP = new PropertyLookup("XCODEBUILD_XARCHIVES_DIR", "xcodebuild.xarchivesDir", "archives")
+
+    /**
+     * Gradle property lookup object with values for default debug symbols output path.
+     *
+     * @environmentVariable "XCODEBUILD_DEBUG_SYMBOLS_DIR"
+     * @propertyName "xcodebuild.debugSymbolsDir"
+     * @defaultValue "symbols"
+     * @see wooga.gradle.xcodebuild.XcodeBuildPluginExtension#getDebugSymbolsDir()
+     */
+    static final PropertyLookup DEBUG_SYMBOLS_DIR_LOOKUP = new PropertyLookup("XCODEBUILD_DEBUG_SYMBOLS_DIR", "xcodebuild.debugSymbolsDir", "symbols")
 }

--- a/src/main/groovy/wooga/gradle/xcodebuild/XcodeBuildPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/xcodebuild/XcodeBuildPluginExtension.groovy
@@ -51,6 +51,14 @@ interface XcodeBuildPluginExtension<T extends XcodeBuildPluginExtension> {
     T xarchivesDir(File value)
     T xarchivesDir(Provider<Directory> value)
 
+    DirectoryProperty getDebugSymbolsDir()
+
+    void setDebugSymbolsDir(File value)
+    void setDebugSymbolsDir(Provider<Directory> value)
+
+    T debugSymbolsDir(File value)
+    T debugSymbolsDir(Provider<Directory> value)
+
     Property<ConsoleSettings> getConsoleSettings()
 
     void setConsoleSettings(ConsoleSettings value)

--- a/src/main/groovy/wooga/gradle/xcodebuild/internal/DefaultXcodeBuildPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/xcodebuild/internal/DefaultXcodeBuildPluginExtension.groovy
@@ -127,6 +127,30 @@ class DefaultXcodeBuildPluginExtension implements XcodeBuildPluginExtension {
         this
     }
 
+    final DirectoryProperty debugSymbolsDir
+
+    @Override
+    void setDebugSymbolsDir(File value) {
+        debugSymbolsDir.set(value)
+    }
+
+    @Override
+    void setDebugSymbolsDir(Provider<Directory> value) {
+        debugSymbolsDir.set(value)
+    }
+
+    @Override
+    DefaultXcodeBuildPluginExtension debugSymbolsDir(File value) {
+        setDebugSymbolsDir(value)
+        this
+    }
+
+    @Override
+    DefaultXcodeBuildPluginExtension debugSymbolsDir(Provider<Directory> value) {
+        setDebugSymbolsDir(value)
+        this
+    }
+
     @Override
     XcodeBuildPluginExtension consoleSettings(Closure configuration) {
         consoleSettings(configureUsing(configuration))
@@ -146,6 +170,7 @@ class DefaultXcodeBuildPluginExtension implements XcodeBuildPluginExtension {
         logsDir = project.layout.directoryProperty()
         derivedDataPath = project.layout.directoryProperty()
         xarchivesDir = project.layout.directoryProperty()
+        debugSymbolsDir = project.layout.directoryProperty()
         consoleSettings = project.objects.property(ConsoleSettings)
     }
 }

--- a/src/main/groovy/wooga/gradle/xcodebuild/tasks/ArchiveDebugSymbols.groovy
+++ b/src/main/groovy/wooga/gradle/xcodebuild/tasks/ArchiveDebugSymbols.groovy
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.xcodebuild.tasks
+
+import org.gradle.api.tasks.bundling.Zip
+
+class ArchiveDebugSymbols extends Zip {
+}

--- a/src/main/groovy/wooga/gradle/xcodebuild/tasks/XcodeArchive.groovy
+++ b/src/main/groovy/wooga/gradle/xcodebuild/tasks/XcodeArchive.groovy
@@ -19,6 +19,7 @@
 
 package wooga.gradle.xcodebuild.tasks
 
+import org.gradle.api.Transformer
 import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileCollection
@@ -224,6 +225,7 @@ class XcodeArchive extends AbstractXcodeArchiveTask implements XcodeArchiveActio
         project.files(xcArchivePath)
     }
 
+    @OutputDirectory
     final Provider<Directory> xcArchivePath
 
     @Input
@@ -240,7 +242,12 @@ class XcodeArchive extends AbstractXcodeArchiveTask implements XcodeArchiveActio
         derivedDataPath = project.layout.directoryProperty()
         buildKeychain = project.layout.fileProperty()
 
-        xcArchivePath = archiveName.map({ destinationDir.get().dir(it) })
+        xcArchivePath = destinationDir.map(new Transformer<Directory, Directory>() {
+            @Override
+            Directory transform(Directory directory) {
+                directory.dir(archiveName.get())
+            }
+        })
 
         buildArguments = project.provider({
             List<String> arguments = new ArrayList<String>()

--- a/src/test/groovy/wooga/gradle/xcodebuild/XcodeBuildPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/xcodebuild/XcodeBuildPluginSpec.groovy
@@ -18,8 +18,11 @@ package wooga.gradle.xcodebuild
 
 
 import nebula.test.ProjectSpec
-import wooga.gradle.build.unity.UnityBuildPlugin
+import spock.lang.Unroll
 import wooga.gradle.xcodebuild.internal.DefaultXcodeBuildPluginExtension
+import wooga.gradle.xcodebuild.tasks.ArchiveDebugSymbols
+import wooga.gradle.xcodebuild.tasks.ExportArchive
+import wooga.gradle.xcodebuild.tasks.XcodeArchive
 
 class XcodeBuildPluginSpec extends ProjectSpec {
     public static final String PLUGIN_NAME = 'net.wooga.xcodebuild'
@@ -35,5 +38,28 @@ class XcodeBuildPluginSpec extends ProjectSpec {
         then:
         def extension = project.extensions.findByName(XcodeBuildPlugin.EXTENSION_NAME)
         extension instanceof DefaultXcodeBuildPluginExtension
+    }
+
+    @Unroll
+    def "generates task of type #taskType.simpleName for each XcodeArchive task"() {
+        given: "a project with plugin applied"
+        project.plugins.apply(PLUGIN_NAME)
+
+        and: "a task of type XcodeArchive"
+        project.task([type: XcodeArchive], taskNames.first())
+        project.task([type: XcodeArchive], taskNames.last())
+
+        expect:
+        def task1 = project.tasks.findByName(expectedTaskNames.first())
+        def task2 = project.tasks.findByName(expectedTaskNames.last())
+        taskType.isInstance(task1)
+        taskType.isInstance(task2)
+
+        where:
+        taskType      | taskSuffix
+        ExportArchive | "Export"
+        ArchiveDebugSymbols | "ArchiveDSYMs"
+        taskNames = ["xcodeArchive", "xcodeArchive2"]
+        expectedTaskNames = taskNames.collect { it + taskSuffix }
     }
 }


### PR DESCRIPTION
## Description

The `ArchiveDebugSymbols` task is just a Zip task with no additonal overloads. I need to have a unique type name for the dynamic configuration. The task simply zips the `dSYM` directory inside a given `.xcarchive` as a preparation for deplyment to a symbolication/error analytics service.

I also add some new configuration that both an `ExportArchive` as well as an `ArchiveDebugSymbols` task is generated when a task of type `XcodeArchive` is added.

The generated tasks will take the `XcodeArchive` task name and append either `ArchiveDSYMS` or `Export`. A later patch will add the configuration to add these task outputs as project artifacts. So in theory never should actually call these tasks from the outside.

I adjusted some tests to take the effect of these autogenerated tasks as a given. I also added some missing tests for earlier patches.

## Changes

* ![ADD] `ArchiveDebugSymbols` task type
* ![IMPROVE] autogenerate export and archive debug symbols task

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
