### PR TITLE
Add publish artifact declarations

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/xcodebuild/XcodeBuildPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/xcodebuild/XcodeBuildPluginIntegrationSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package wooga.gradle.xcodebuild
 
 import net.wooga.test.xcode.XcodeTestProject

--- a/src/integrationTest/groovy/wooga/gradle/xcodebuild/tasks/AbstractXcodeArchiveTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/xcodebuild/tasks/AbstractXcodeArchiveTaskIntegrationSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package wooga.gradle.xcodebuild.tasks
 
 import spock.lang.Unroll

--- a/src/integrationTest/groovy/wooga/gradle/xcodebuild/tasks/AbstractXcodeTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/xcodebuild/tasks/AbstractXcodeTaskIntegrationSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package wooga.gradle.xcodebuild.tasks
 
 import spock.lang.Unroll

--- a/src/integrationTest/groovy/wooga/gradle/xcodebuild/tasks/ArchiveDebugSymbolsIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/xcodebuild/tasks/ArchiveDebugSymbolsIntegrationSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package wooga.gradle.xcodebuild.tasks
 
 import net.wooga.test.xcode.XcodeTestProject
@@ -5,6 +21,7 @@ import org.junit.ClassRule
 import spock.lang.Requires
 import spock.lang.Shared
 import wooga.gradle.xcodebuild.XcodeBuildIntegrationSpec
+import wooga.gradle.xcodebuild.XcodeBuildPlugin
 
 @Requires({ os.macOs })
 class ArchiveDebugSymbolsIntegrationSpec extends XcodeBuildIntegrationSpec {
@@ -13,29 +30,35 @@ class ArchiveDebugSymbolsIntegrationSpec extends XcodeBuildIntegrationSpec {
     @ClassRule
     XcodeTestProject xcodeProject = new XcodeTestProject()
 
+    String archiveTaskName = "xcodeArchive"
+    String testTaskName = archiveTaskName + "ArchiveDSYMs"
+
+    String workingXcodebuildTaskConfig = """
+    task ${archiveTaskName}(type: ${XcodeArchive.name}) {
+        scheme = "${xcodeProject.schemeName}"
+        baseName = "custom"
+        version = "0.1.0"
+        buildSettings {
+            codeSignIdentity ""
+            codeSigningRequired false
+            codeSigningAllowed false
+            ${System.getenv("TEST_TEAM_ID") ? "developmentTeam = '${System.getenv("TEST_TEAM_ID")}'" : ""}
+        }
+
+        buildArgument('-allowProvisioningUpdates')
+        clean = true
+        projectPath = new File("${xcodeProject.xcodeProject}")
+    }
+
+    ${testTaskName} {
+        baseName = "custom"
+        version = "0.1.0"
+    }
+    """.stripIndent()
+
     def "creates zip archive with dsym files from xcarchive file"() {
         given: "a XcodeArchive task"
-        buildFile << """
-        task xcodeArchive(type: ${XcodeArchive.name}) {
-            scheme = "${xcodeProject.schemeName}"
-            baseName = "custom"
-            version = "0.1.0"
-            buildSettings {
-                codeSignIdentity ""
-                codeSigningRequired false
-                codeSigningAllowed false
-            }
-            projectPath = new File("${xcodeProject.xcodeProject}")
-        } 
-        """.stripIndent()
-
-        and: "the generated ArchiveDsym task"
-        buildFile << """
-        xcodeArchiveArchiveDSYMs {
-            baseName = "custom"
-            version = "0.1.0"
-        }
-        """
+        buildFile << workingXcodebuildTaskConfig
 
         and: "a future dsym archive"
         def dsymArchive = new File(projectDir, "build/symbols/custom-0.1.0-dSYM.zip")
@@ -48,5 +71,41 @@ class ArchiveDebugSymbolsIntegrationSpec extends XcodeBuildIntegrationSpec {
         result.success
         result.wasExecuted("xcodeArchive")
         dsymArchive.exists()
+    }
+
+    def "is registered as publish artifact"() {
+        given: "a subproject with xcode build setup"
+        def subProjectDir = addSubproject(subProjectName)
+        def subProjectBuildFile = new File(subProjectDir, "build.gradle")
+        subProjectBuildFile << """
+            ${applyPlugin(XcodeBuildPlugin)}
+            ${workingXcodebuildTaskConfig}
+
+            version = '1.0.0'
+        """.stripIndent()
+
+        and: "the main project pulling a dependency"
+        buildFile << """
+            configurations.maybeCreate('archives')
+
+            dependencies {
+                archives project(':${subProjectName}')
+            }
+
+            task run (type: Copy) {
+                from(configurations.archives)
+                into("${projectDir}/build/outputs")
+            }
+        """.stripIndent()
+
+        when:
+        def result = runTasks("run")
+
+
+        then:
+        result.wasExecuted(":${subProjectName}:${testTaskName}")
+
+        where:
+        subProjectName = "xcodeProject"
     }
 }

--- a/src/integrationTest/groovy/wooga/gradle/xcodebuild/tasks/ExportArchiveIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/xcodebuild/tasks/ExportArchiveIntegrationSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package wooga.gradle.xcodebuild.tasks
 
 import net.wooga.test.xcode.XcodeTestProject
@@ -191,28 +207,13 @@ class ExportArchiveIntegrationSpec extends AbstractXcodeArchiveTaskIntegrationSp
         expectedValue = rawValue
     }
 
-    def "can register as publish artifact"() {
+    def "is registered as publish artifact"() {
         given: "a subproject with xcode build setup"
         def subProjectDir = addSubproject(subProjectName)
         def subProjectBuildFile = new File(subProjectDir, "build.gradle")
         subProjectBuildFile << """
-            plugins {
-                id "base"
-            }
-    
             ${applyPlugin(XcodeBuildPlugin)}
             ${workingXcodebuildTaskConfig}
-            configurations {
-                archives
-            }
-    
-            configurations['default'].extendsFrom(configurations.archives)
-    
-            project.artifacts {
-                archives(${testTaskName}.publishArtifact) {
-                    it.type = "iOS application archive"
-                }
-            }
         """.stripIndent()
 
         and: "the main project pulling a dependency"

--- a/src/main/groovy/wooga/gradle/xcodebuild/XcodeArchiveActionSpecBase.groovy
+++ b/src/main/groovy/wooga/gradle/xcodebuild/XcodeArchiveActionSpecBase.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package wooga.gradle.xcodebuild
 
 import org.gradle.api.file.Directory

--- a/src/main/groovy/wooga/gradle/xcodebuild/internal/LineBufferingOutputStream.groovy
+++ b/src/main/groovy/wooga/gradle/xcodebuild/internal/LineBufferingOutputStream.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package wooga.gradle.xcodebuild.internal
 
 import org.gradle.internal.SystemProperties

--- a/src/main/groovy/wooga/gradle/xcodebuild/internal/PropertyLookup.groovy
+++ b/src/main/groovy/wooga/gradle/xcodebuild/internal/PropertyLookup.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package wooga.gradle.xcodebuild.internal
 
 class PropertyLookup {

--- a/src/main/groovy/wooga/gradle/xcodebuild/internal/TextStream.groovy
+++ b/src/main/groovy/wooga/gradle/xcodebuild/internal/TextStream.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package wooga.gradle.xcodebuild.internal
 
 interface TextStream {

--- a/src/main/groovy/wooga/gradle/xcodebuild/tasks/AbstractXcodeArchiveTask.groovy
+++ b/src/main/groovy/wooga/gradle/xcodebuild/tasks/AbstractXcodeArchiveTask.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package wooga.gradle.xcodebuild.tasks
 
 import org.gradle.api.file.Directory


### PR DESCRIPTION
## Description

This patch adds the outputs for both `ExportArchive` and `ArchiveDebugSymbols` as publish artifacts to the `archives` configuration.

## Changes

* ![ADD] publish artifact declaration
* ![ADD] missing copyright headers

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
