### PR TITLE
Add new SighRenew task

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/fastlane/FastlaneSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/fastlane/FastlaneSpec.groovy
@@ -1,0 +1,29 @@
+package wooga.gradle.fastlane
+
+class FastlaneSpec extends IntegrationSpec {
+    File fastlaneMock
+    File fastlaneMockPath
+
+    def setupFastlaneMock() {
+        fastlaneMockPath = File.createTempDir("fastlane", "mock")
+
+        def path = System.getenv("PATH")
+        environmentVariables.clear("PATH")
+        String newPath = "${fastlaneMockPath}${File.pathSeparator}${path}"
+        environmentVariables.set("PATH", newPath)
+        assert System.getenv("PATH") == newPath
+
+
+        fastlaneMock = createFile("fastlane", fastlaneMockPath)
+        fastlaneMock.executable = true
+        fastlaneMock << """
+            #!/usr/bin/env bash
+            echo \$@
+            env
+        """.stripIndent()
+    }
+
+    def setup() {
+        setupFastlaneMock()
+    }
+}

--- a/src/integrationTest/groovy/wooga/gradle/fastlane/IntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/fastlane/IntegrationSpec.groovy
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ *
+ */
+
+package wooga.gradle.fastlane
+
+import nebula.test.functional.ExecutionResult
+import org.apache.commons.text.StringEscapeUtils
+import org.junit.Rule
+import org.junit.contrib.java.lang.system.EnvironmentVariables
+import org.junit.contrib.java.lang.system.ProvideSystemProperty
+import spock.lang.Requires
+
+@Requires({ os.macOs })
+class IntegrationSpec extends nebula.test.IntegrationSpec {
+
+    @Rule
+    ProvideSystemProperty properties = new ProvideSystemProperty("ignoreDeprecations", "true")
+
+    @Rule
+    public final EnvironmentVariables environmentVariables = new EnvironmentVariables()
+
+    def escapedPath(String path) {
+        String osName = System.getProperty("os.name").toLowerCase()
+        if (osName.contains("windows")) {
+            return StringEscapeUtils.escapeJava(path)
+        }
+        path
+    }
+
+    def setup() {
+        def gradleVersion = System.getenv("GRADLE_VERSION")
+        if (gradleVersion) {
+            this.gradleVersion = gradleVersion
+            fork = true
+        }
+    }
+
+    enum PropertyLocation {
+        none, script, property, env
+
+        String reason() {
+            switch (this) {
+                case script:
+                    return "value is provided in script"
+                case property:
+                    return "value is provided in props"
+                case env:
+                    return "value is set in env"
+                default:
+                    return "no value was configured"
+            }
+        }
+    }
+
+    String envNameFromProperty(String extensionName, String property) {
+        "${extensionName.toUpperCase()}_${property.replaceAll(/([A-Z])/, "_\$1").toUpperCase()}"
+    }
+
+
+    Boolean outputContains(ExecutionResult result, String message) {
+        result.standardOutput.contains(message) || result.standardError.contains(message)
+    }
+
+    String wrapValueBasedOnType(Object rawValue, Class type, Closure<String> fallback = null) {
+        wrapValueBasedOnType(rawValue, type.simpleName, fallback)
+    }
+
+    String wrapValueBasedOnType(Object rawValue, String type, Closure<String> fallback = null) {
+        def value
+        def rawValueEscaped = String.isInstance(rawValue) ? "'${rawValue}'" : rawValue
+        def subtypeMatches = type =~ /(?<mainType>\w+)<(?<subType>[\w<>]+)>/
+        def subType = (subtypeMatches.matches()) ? subtypeMatches.group("subType") : null
+        type = (subtypeMatches.matches()) ? subtypeMatches.group("mainType") : type
+        switch (type) {
+            case "Closure":
+                if (subType) {
+                    value = "{${wrapValueBasedOnType(rawValue, subType, fallback)}}"
+                } else {
+                    value = "{$rawValueEscaped}"
+                }
+                break
+            case "Callable":
+                value = "new java.util.concurrent.Callable<${rawValue.class.typeName}>() {@Override ${rawValue.class.typeName} call() throws Exception { $rawValueEscaped }}"
+                break
+            case "Object":
+                value = "new Object() {@Override String toString() { ${rawValueEscaped}.toString() }}"
+                break
+            case "Provider":
+                switch (subType) {
+                    case "RegularFile":
+                        value = "project.layout.file(${wrapValueBasedOnType(rawValue, "Provider<File>", fallback)})"
+                        break
+                    case "Directory":
+                        value = """
+                                project.provider({
+                                    def d = project.layout.directoryProperty()
+                                    d.set(${wrapValueBasedOnType(rawValue, "File", fallback)})
+                                    d.get()
+                                })
+                        """.trim().stripIndent()
+                        break
+                    default:
+                        value = "project.provider(${wrapValueBasedOnType(rawValue, "Closure<${subType}>", fallback)})"
+                        break
+                }
+                break
+            case "String":
+                value = "${escapedPath(rawValueEscaped.toString())}"
+                break
+            case "String[]":
+                value = "'${rawValue.collect { it }.join(",")}'.split(',')"
+                break
+            case "File":
+                value = "new File('${escapedPath(rawValue.toString())}')"
+                break
+            case "String...":
+                value = "${rawValue.collect { '"' + it + '"' }.join(", ")}"
+                break
+            case "List":
+                value = "[${rawValue.collect { '"' + it + '"' }.join(", ")}]"
+                break
+            case "Map":
+                value = "[" + rawValue.collect { k, v -> "${wrapValueBasedOnType(k, k.getClass(), fallback)} : ${wrapValueBasedOnType(v, v.getClass(), fallback)}" }.join(", ") + "]"
+                value = value == "[]" ? "[:]" : value
+                break
+            default:
+                value = (fallback) ? fallback.call(type) : rawValue
+        }
+        value
+    }
+}

--- a/src/integrationTest/groovy/wooga/gradle/fastlane/tasks/AbstractFastlaneTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/fastlane/tasks/AbstractFastlaneTaskIntegrationSpec.groovy
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wooga.gradle.fastlane.tasks
+
+import spock.lang.Unroll
+import wooga.gradle.fastlane.FastlaneSpec
+import wooga.gradle.xcodebuild.ConsoleSettings
+import wooga.gradle.xcodebuild.config.BuildSettings
+
+abstract class AbstractFastlaneTaskIntegrationSpec extends FastlaneSpec {
+
+    abstract String getTestTaskName()
+
+    abstract Class getTaskType()
+
+    abstract String getWorkingFastlaneTaskConfig()
+
+    def setup() {
+        buildFile << workingFastlaneTaskConfig
+    }
+
+    @Unroll("can set property #property with #method and type #type")
+    def "can set property #property with #method and type #type base"() {
+        given: "a task to read back the value"
+        buildFile << """
+            task("readValue") {
+                doLast {
+                    println("property: " + ${testTaskName}.${property}.get())
+                }
+            }
+        """.stripIndent()
+
+        and: "a set property"
+        buildFile << """
+            ${testTaskName}.${invocation}
+        """.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully("readValue")
+
+        then:
+        outputContains(result, "property: " + testValue.toString())
+
+        where:
+        property  | method        | rawValue               | expectedValue | type
+        "logFile" | "logFile"     | "/some/path/test1.log" | _             | "File"
+        "logFile" | "logFile"     | "/some/path/test2.log" | _             | "Provider<RegularFile>"
+        "logFile" | "logFile.set" | "/some/path/test3.log" | _             | "File"
+        "logFile" | "logFile.set" | "/some/path/test4.log" | _             | "Provider<RegularFile>"
+        "logFile" | "setLogFile"  | "/some/path/test5.log" | _             | "File"
+        "logFile" | "setLogFile"  | "/some/path/test6.log" | _             | "Provider<RegularFile>"
+
+
+        value = wrapValueBasedOnType(rawValue, type, { type ->
+            switch (type) {
+                case ConsoleSettings.class.simpleName:
+                    return "${ConsoleSettings.class.name}.fromGradleOutput(org.gradle.api.logging.configuration.ConsoleOutput.${rawValue.toString().capitalize()})"
+
+                case BuildSettings.class.simpleName:
+                    return "new ${BuildSettings.class.name}()" + rawValue.replaceAll(/(\[|\])/, '').split(',').collect({
+                        List<String> parts = it.split("=")
+                        ".put('${parts[0].trim()}', '${parts[1].trim()}')"
+                    }).join("")
+                default:
+                    return rawValue
+            }
+        })
+        invocation = (method == _) ? "${property} = ${value}" : "${method}(${value})"
+        testValue = (expectedValue == _) ? rawValue : expectedValue
+    }
+
+    @Unroll
+    def "can configure arguments with #method #message"() {
+        given: "a custom archive task"
+        buildFile << """
+            ${testTaskName} {
+                arguments(["--test", "value"])
+            }
+        """.stripIndent()
+
+        and: "a task to read back the value"
+        buildFile << """
+            task("readValue") {
+                doLast {
+                    println("property: " + ${testTaskName}.${property}.get())
+                }
+            }
+        """.stripIndent()
+
+        and: "a set property"
+        buildFile << """
+            ${testTaskName}.${method}($value)
+        """.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully("readValue")
+
+        then:
+        outputContains(result, "property: " + expectedValue.toString())
+
+        where:
+        method                    | rawValue         | type                      | append | expectedValue
+        "argument"                | "--foo"          | "String"                  | true   | ["--test", "value", "--foo"]
+        "arguments"               | ["--foo", "bar"] | "List<String>"            | true   | ["--test", "value", "--foo", "bar"]
+        "arguments"               | ["--foo", "bar"] | "String[]"                | true   | ["--test", "value", "--foo", "bar"]
+        "setAdditionalArguments"  | ["--foo", "bar"] | "List<String>"            | false  | ["--foo", "bar"]
+        "setAdditionalArguments"  | ["--foo", "bar"] | "Provider<List<String>>"  | false  | ["--foo", "bar"]
+        "additionalArguments.set" | ["--foo", "bar"] | "List<String>"            | false  | ["--foo", "bar"]
+        "additionalArguments.set" | ["--foo", "bar"] | "Provider<List<String>>>" | false  | ["--foo", "bar"]
+
+        property = "additionalArguments"
+        value = wrapValueBasedOnType(rawValue, type)
+        message = (append) ? "which appends arguments" : "which replaces arguments"
+    }
+
+    def "task writes log output"() {
+        given: "a future log file"
+        def logFile = new File(projectDir, "build/logs/${testTaskName}.log")
+        assert !logFile.exists()
+
+        and: "the logfile configured"
+        buildFile << """${testTaskName}.logFile = file("${logFile.path}")"""
+
+        when:
+        runTasks(testTaskName)
+
+        then:
+        logFile.exists()
+        !logFile.text.empty
+    }
+
+    def "prints fastlane log to console and logfile"() {
+        given: "a future log file"
+        def logFile = new File(projectDir, "build/logs/${testTaskName}.log")
+        assert !logFile.exists()
+
+        and: "the logfile configured"
+        buildFile << """${testTaskName}.logFile = file("${logFile.path}")"""
+
+        when:
+        def result = runTasks(testTaskName)
+
+        then:
+        outputContains(result, logFile.text)
+    }
+}

--- a/src/integrationTest/groovy/wooga/gradle/fastlane/tasks/SighRenewIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/fastlane/tasks/SighRenewIntegrationSpec.groovy
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wooga.gradle.fastlane.tasks
+
+import spock.lang.Issue
+import spock.lang.Requires
+import spock.lang.Unroll
+
+/**
+ * The test examples in this class are not 100% integration/functional tests.
+ *
+ * We can't run the real fastlane and connect to apple because there is no easy way to setup and maintain a test app and
+ * account with necessary credentials. We only test the invocation of fastlane and its parameters.
+ */
+@Requires({ os.macOs })
+class SighRenewIntegrationSpec extends AbstractFastlaneTaskIntegrationSpec {
+
+    String testTaskName = "sighRenew"
+    Class taskType = SighRenew
+
+    String workingFastlaneTaskConfig = """
+        task("${testTaskName}", type: ${taskType.name}) {
+            appIdentifier = 'test'
+            teamId = "fakeTeamId"
+            fileName = 'test.mobileprovisioning'
+            destinationDir = file('build')
+        }
+        """.stripIndent()
+
+    @Unroll("property #property #valueMessage sets flag #expectedCommandlineFlag")
+    def "constructs arguments"() {
+        given: "a task to read the build arguments"
+        buildFile << """
+            task("readValue") {
+                doLast {
+                    println("arguments: " + ${testTaskName}.arguments.get().join(" "))
+                }
+            }
+        """.stripIndent()
+
+        and: "a set property"
+        if (method != _) {
+            buildFile << """
+            ${testTaskName}.${method}($value)
+            """.stripIndent()
+        }
+
+        when:
+        def result = runTasksSuccessfully("readValue")
+
+        then:
+        outputContains(result, expectedCommandlineFlag)
+
+        where:
+        property                          | method                                | rawValue                   | type           || expectedCommandlineFlag
+        "appIdentifier"                   | "appIdentifier.set"                   | "com.test.app"             | "String"       || "--app_identifier com.test.app"
+        "teamId"                          | "teamId.set"                          | "test"                     | "String"       || "--team_id test"
+        "teamName"                        | "teamName.set"                        | "test"                     | "String"       || "--team_name test"
+        "provisioningName"                | "provisioningName.set"                | "test"                     | "String"       || "--provisioning_name test"
+        "username"                        | "username.set"                        | "testUser"                 | "String"       || "--username testUser"
+        "adhoc"                           | "adhoc.set"                           | true                       | "Boolean"      || "--adhoc true"
+        "adhoc"                           | "adhoc.set"                           | false                      | "Boolean"      || "--adhoc false"
+        "adhoc"                           | _                                     | _                          | "Boolean"      || "--adhoc false"
+        "readOnly"                        | "readOnly.set"                        | true                       | "Boolean"      || "--readonly true"
+        "readOnly"                        | "readOnly.set"                        | false                      | "Boolean"      || "--readonly false"
+        "readOnly"                        | _                                     | _                          | "Boolean"      || "--readonly false"
+        "ignoreProfilesWithDifferentName" | "ignoreProfilesWithDifferentName.set" | true                       | "Boolean"      || "--ignore_profiles_with_different_name true"
+        "ignoreProfilesWithDifferentName" | "ignoreProfilesWithDifferentName.set" | false                      | "Boolean"      || "--ignore_profiles_with_different_name false"
+        "ignoreProfilesWithDifferentName" | _                                     | _                          | "Boolean"      || "--ignore_profiles_with_different_name false"
+        "fileName"                        | "fileName.set"                        | "test2.mobileprovisioning" | "String"       || "--filename test2.mobileprovisioning"
+        "destinationDir"                  | "destinationDir.set"                  | "/some/path"               | "File"         || "--output_path /some/path"
+        "additionalArguments"             | "setAdditionalArguments"              | ["--verbose", "--foo bar"] | "List<String>" || "--verbose --foo bar"
+        value = wrapValueBasedOnType(rawValue, type)
+        valueMessage = (rawValue != _) ? "with value ${value}" : "without value"
+    }
+
+    @Unroll("property #property #valueMessage sets environment #expectedEnvironmentPair")
+    def "constructs process environment"() {
+        given: "a task to read the build arguments"
+        buildFile << """
+            task("readValue") {
+                doLast {
+                    println("arguments: " + ${testTaskName}.environment.get().collect {k,v -> k + '=' + v}.join("\\n"))
+                }
+            }
+        """.stripIndent()
+
+        and: "a set property"
+        if (method != _) {
+            buildFile << """
+            ${testTaskName}.${method}($value)
+            """.stripIndent()
+        }
+
+        when:
+        def result = runTasksSuccessfully("readValue")
+
+        then:
+        outputContains(result, expectedEnvironmentPair)
+
+        where:
+        property   | method         | rawValue      | type     || expectedEnvironmentPair
+        "password" | "password.set" | "secretValue" | "String" || "FASTLANE_PASSWORD=secretValue"
+        value = wrapValueBasedOnType(rawValue, type)
+        valueMessage = (rawValue != _) ? "with value ${value}" : "without value"
+    }
+
+    @Unroll("can set property #property with #method and type #type")
+    def "can set property XcodeArchive"() {
+        given: "a task to read back the value"
+        buildFile << """
+            task("readValue") {
+                doLast {
+                    println("property: " + ${testTaskName}.${property}.get())
+                }
+            }
+        """.stripIndent()
+
+        and: "a set property"
+        buildFile << """
+            ${testTaskName}.${method}($value)
+        """.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully("readValue")
+
+        then:
+        outputContains(result, "property: " + expectedValue.toString())
+
+        where:
+        property                          | method                                | rawValue        | type
+        "appIdentifier"                   | "appIdentifier"                       | "com.test.app1" | "String"
+        "appIdentifier"                   | "appIdentifier"                       | "com.test.app2" | "Provider<String>"
+        "appIdentifier"                   | "appIdentifier.set"                   | "com.test.app1" | "String"
+        "appIdentifier"                   | "appIdentifier.set"                   | "com.test.app2" | "Provider<String>"
+        "appIdentifier"                   | "setAppIdentifier"                    | "com.test.app3" | "String"
+        "appIdentifier"                   | "setAppIdentifier"                    | "com.test.app4" | "Provider<String>"
+
+        "teamId"                          | "teamId"                              | "1234561"       | "String"
+        "teamId"                          | "teamId"                              | "1234562"       | "Provider<String>"
+        "teamId"                          | "teamId.set"                          | "1234561"       | "String"
+        "teamId"                          | "teamId.set"                          | "1234562"       | "Provider<String>"
+        "teamId"                          | "setTeamId"                           | "1234563"       | "String"
+        "teamId"                          | "setTeamId"                           | "1234564"       | "Provider<String>"
+
+        "teamName"                        | "teamName"                            | "someTeam1"     | "String"
+        "teamName"                        | "teamName"                            | "someTeam2"     | "Provider<String>"
+        "teamName"                        | "teamName.set"                        | "someTeam3"     | "String"
+        "teamName"                        | "teamName.set"                        | "someTeam4"     | "Provider<String>"
+        "teamName"                        | "setTeamName"                         | "someTeam5"     | "String"
+        "teamName"                        | "setTeamName"                         | "someTeam6"     | "Provider<String>"
+
+        "username"                        | "username"                            | "someName1"     | "String"
+        "username"                        | "username"                            | "someName2"     | "Provider<String>"
+        "username"                        | "username.set"                        | "someName3"     | "String"
+        "username"                        | "username.set"                        | "someName4"     | "Provider<String>"
+        "username"                        | "setUsername"                         | "someName5"     | "String"
+        "username"                        | "setUsername"                         | "someName6"     | "Provider<String>"
+
+        "password"                        | "password"                            | "1234561"       | "String"
+        "password"                        | "password"                            | "1234562"       | "Provider<String>"
+        "password"                        | "password.set"                        | "1234561"       | "String"
+        "password"                        | "password.set"                        | "1234562"       | "Provider<String>"
+        "password"                        | "setPassword"                         | "1234563"       | "String"
+        "password"                        | "setPassword"                         | "1234564"       | "Provider<String>"
+
+        "fileName"                        | "fileName"                            | "name1"         | "String"
+        "fileName"                        | "fileName"                            | "name2"         | "Provider<String>"
+        "fileName"                        | "fileName.set"                        | "name3"         | "String"
+        "fileName"                        | "fileName.set"                        | "name4"         | "Provider<String>"
+        "fileName"                        | "setFileName"                         | "name5"         | "String"
+        "fileName"                        | "setFileName"                         | "name6"         | "Provider<String>"
+
+        "provisioningName"                | "provisioningName"                    | "name1"         | "String"
+        "provisioningName"                | "provisioningName"                    | "name2"         | "Provider<String>"
+        "provisioningName"                | "provisioningName.set"                | "name3"         | "String"
+        "provisioningName"                | "provisioningName.set"                | "name4"         | "Provider<String>"
+        "provisioningName"                | "setProvisioningName"                 | "name5"         | "String"
+        "provisioningName"                | "setProvisioningName"                 | "name6"         | "Provider<String>"
+
+        "adhoc"                           | "adhoc"                               | true            | "Boolean"
+        "adhoc"                           | "adhoc"                               | false           | "Boolean"
+        "adhoc"                           | "adhoc"                               | true            | "Provider<Boolean>"
+        "adhoc"                           | "adhoc"                               | false           | "Provider<Boolean>"
+        "adhoc"                           | "adhoc.set"                           | true            | "Boolean"
+        "adhoc"                           | "adhoc.set"                           | false           | "Boolean"
+        "adhoc"                           | "adhoc.set"                           | true            | "Provider<Boolean>"
+        "adhoc"                           | "adhoc.set"                           | false           | "Provider<Boolean>"
+        "adhoc"                           | "setAdhoc"                            | true            | "Boolean"
+        "adhoc"                           | "setAdhoc"                            | false           | "Boolean"
+        "adhoc"                           | "setAdhoc"                            | true            | "Provider<Boolean>"
+        "adhoc"                           | "setAdhoc"                            | false           | "Provider<Boolean>"
+
+        "readOnly"                        | "readOnly"                            | true            | "Boolean"
+        "readOnly"                        | "readOnly"                            | false           | "Boolean"
+        "readOnly"                        | "readOnly"                            | true            | "Provider<Boolean>"
+        "readOnly"                        | "readOnly"                            | false           | "Provider<Boolean>"
+        "readOnly"                        | "readOnly.set"                        | true            | "Boolean"
+        "readOnly"                        | "readOnly.set"                        | false           | "Boolean"
+        "readOnly"                        | "readOnly.set"                        | true            | "Provider<Boolean>"
+        "readOnly"                        | "readOnly.set"                        | false           | "Provider<Boolean>"
+        "readOnly"                        | "setReadOnly"                         | true            | "Boolean"
+        "readOnly"                        | "setReadOnly"                         | false           | "Boolean"
+        "readOnly"                        | "setReadOnly"                         | true            | "Provider<Boolean>"
+        "readOnly"                        | "setReadOnly"                         | false           | "Provider<Boolean>"
+
+        "ignoreProfilesWithDifferentName" | "ignoreProfilesWithDifferentName"     | true            | "Boolean"
+        "ignoreProfilesWithDifferentName" | "ignoreProfilesWithDifferentName"     | false           | "Boolean"
+        "ignoreProfilesWithDifferentName" | "ignoreProfilesWithDifferentName"     | true            | "Provider<Boolean>"
+        "ignoreProfilesWithDifferentName" | "ignoreProfilesWithDifferentName"     | false           | "Provider<Boolean>"
+        "ignoreProfilesWithDifferentName" | "ignoreProfilesWithDifferentName.set" | true            | "Boolean"
+        "ignoreProfilesWithDifferentName" | "ignoreProfilesWithDifferentName.set" | false           | "Boolean"
+        "ignoreProfilesWithDifferentName" | "ignoreProfilesWithDifferentName.set" | true            | "Provider<Boolean>"
+        "ignoreProfilesWithDifferentName" | "ignoreProfilesWithDifferentName.set" | false           | "Provider<Boolean>"
+        "ignoreProfilesWithDifferentName" | "setIgnoreProfilesWithDifferentName"  | true            | "Boolean"
+        "ignoreProfilesWithDifferentName" | "setIgnoreProfilesWithDifferentName"  | false           | "Boolean"
+        "ignoreProfilesWithDifferentName" | "setIgnoreProfilesWithDifferentName"  | true            | "Provider<Boolean>"
+        "ignoreProfilesWithDifferentName" | "setIgnoreProfilesWithDifferentName"  | false           | "Provider<Boolean>"
+
+        "destinationDir"                  | "destinationDir"                      | "/some/path/1"  | "File"
+        "destinationDir"                  | "destinationDir"                      | "/some/path/2"  | "Provider<Directory>"
+        "destinationDir"                  | "destinationDir.set"                  | "/some/path/3"  | "File"
+        "destinationDir"                  | "destinationDir.set"                  | "/some/path/4"  | "Provider<Directory>"
+        "destinationDir"                  | "setDestinationDir"                   | "/some/path/5"  | "File"
+        "destinationDir"                  | "setDestinationDir"                   | "/some/path/6"  | "Provider<Directory>"
+
+        value = wrapValueBasedOnType(rawValue, type)
+        expectedValue = rawValue
+    }
+
+    @Issue("https://github.com/wooga/atlas-build-unity/issues/38")
+    def "task is never up-to-date"() {
+        given: "call import tasks once"
+        def r = runTasks(testTaskName)
+
+        when: "no parameter changes"
+        def result = runTasksSuccessfully(testTaskName)
+
+        then:
+        !result.wasUpToDate(testTaskName)
+    }
+}

--- a/src/main/groovy/wooga/gradle/fastlane/FastlaneActionSpec.groovy
+++ b/src/main/groovy/wooga/gradle/fastlane/FastlaneActionSpec.groovy
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wooga.gradle.fastlane
+
+import org.gradle.api.file.RegularFile
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Provider
+
+interface FastlaneActionSpec<T extends FastlaneActionSpec> {
+    Provider<List<String>> getArguments()
+
+    Provider<Map<String, String>> getEnvironment()
+
+    RegularFileProperty getLogFile()
+
+    void setLogFile(File value)
+    void setLogFile(Provider<RegularFile> value)
+
+    T logFile(File value)
+    T logFile(Provider<RegularFile> value)
+
+    void setAdditionalArguments(Iterable<String> value)
+    void setAdditionalArguments(Provider<? extends Iterable<String>> value)
+
+    T argument(String argument)
+    T arguments(String... arguments)
+    T arguments(Iterable<String> arguments)
+}

--- a/src/main/groovy/wooga/gradle/fastlane/internal/FastlaneAction.groovy
+++ b/src/main/groovy/wooga/gradle/fastlane/internal/FastlaneAction.groovy
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wooga.gradle.fastlane.internal
+
+
+import org.gradle.api.Action
+import org.gradle.api.Project
+import org.gradle.process.ExecResult
+import org.gradle.process.ExecSpec
+import wooga.gradle.build.unity.internal.ExecUtil
+import wooga.gradle.xcodebuild.internal.ForkTextStream
+import wooga.gradle.xcodebuild.internal.LineBufferingOutputStream
+import wooga.gradle.xcodebuild.internal.TextStream
+
+class FastlaneAction {
+
+    final Project project
+    final List<String> arguments
+    final Map<String, String> environment
+    final File logFile
+
+    FastlaneAction(Project project, List<String> arguments, Map<String, String> environment, File logFile) {
+        this.project = project
+        this.arguments = arguments
+        this.environment = environment
+        this.logFile = logFile
+    }
+
+    ExecResult exec() {
+        TextStream handler = new ForkTextStream()
+
+        def outStream = new LineBufferingOutputStream(handler)
+        def logWriter = System.out.newPrintWriter()
+        if (logFile) {
+            logFile.parentFile.mkdirs()
+            handler.addWriter(logFile.newPrintWriter())
+        }
+
+        handler.addWriter(logWriter)
+
+
+        def executablePath = ExecUtil.getExecutable("fastlane")
+        def env = environment
+
+        project.exec(new Action<ExecSpec>() {
+            @Override
+            void execute(ExecSpec exec) {
+                exec.with {
+                    executable executablePath
+                    args = arguments
+                    environment(env)
+                    standardOutput = outStream
+                }
+            }
+        })
+    }
+}

--- a/src/main/groovy/wooga/gradle/fastlane/tasks/AbstractFastlaneTask.groovy
+++ b/src/main/groovy/wooga/gradle/fastlane/tasks/AbstractFastlaneTask.groovy
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wooga.gradle.fastlane.tasks
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFile
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+import wooga.gradle.fastlane.FastlaneActionSpec
+import wooga.gradle.fastlane.internal.FastlaneAction
+
+abstract class AbstractFastlaneTask extends DefaultTask implements FastlaneActionSpec {
+
+    @Internal
+    final RegularFileProperty logFile
+
+    @Override
+    void setLogFile(File value) {
+        logFile.set(value)
+    }
+
+    @Override
+    void setLogFile(Provider<RegularFile> value) {
+        logFile.set(value)
+    }
+
+    @Override
+    AbstractFastlaneTask logFile(File value) {
+        setLogFile(value)
+        this
+    }
+
+    @Override
+    AbstractFastlaneTask logFile(Provider<RegularFile> value) {
+        setLogFile(value)
+        this
+    }
+
+    final ListProperty<String> additionalArguments
+
+    @Override
+    void setAdditionalArguments(Iterable<String> value) {
+        additionalArguments.set(value)
+    }
+
+    @Override
+    void setAdditionalArguments(Provider<? extends Iterable<String>> value) {
+        additionalArguments.set(value)
+    }
+
+    @Override
+    AbstractFastlaneTask argument(String argument) {
+        additionalArguments.add(argument)
+        return this
+    }
+
+    @Override
+    AbstractFastlaneTask arguments(String[] arguments) {
+        additionalArguments.addAll(project.provider({ arguments.toList() }))
+        return this
+    }
+
+    @Override
+    AbstractFastlaneTask arguments(Iterable arguments) {
+        additionalArguments.addAll(project.provider({ arguments }))
+        return this
+    }
+
+    AbstractFastlaneTask() {
+        additionalArguments = project.objects.listProperty(String)
+        logFile = project.layout.fileProperty()
+    }
+
+    @TaskAction
+    protected void exec() {
+        def action = new FastlaneAction(project, arguments.get(), environment.get(), logFile.getAsFile().getOrNull())
+        action.exec()
+    }
+}

--- a/src/main/groovy/wooga/gradle/fastlane/tasks/SighRenew.groovy
+++ b/src/main/groovy/wooga/gradle/fastlane/tasks/SighRenew.groovy
@@ -1,0 +1,338 @@
+/*
+ * Copyright 2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wooga.gradle.fastlane.tasks
+
+import org.gradle.api.Task
+import org.gradle.api.file.Directory
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFile
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.specs.Spec
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputFile
+
+class SighRenew extends AbstractFastlaneTask {
+
+    final Property<String> appIdentifier
+
+    void setAppIdentifier(String value) {
+        appIdentifier.set(value)
+    }
+
+    void setAppIdentifier(Provider<String> value) {
+        appIdentifier.set(value)
+    }
+
+    SighRenew appIdentifier(String value) {
+        setAppIdentifier(value)
+        this
+    }
+
+    SighRenew appIdentifier(Provider<String> value) {
+        setAppIdentifier(value)
+        this
+    }
+
+    final Property<String> teamId
+
+    void setTeamId(String value) {
+        teamId.set(value)
+    }
+
+    void setTeamId(Provider<String> value) {
+        teamId.set(value)
+    }
+
+    SighRenew teamId(String value) {
+        setTeamId(value)
+        this
+    }
+
+    SighRenew teamId(Provider<String> value) {
+        setTeamId(value)
+        this
+    }
+
+    final Property<String> teamName
+
+    void setTeamName(String value) {
+        teamName.set(value)
+    }
+
+    void setTeamName(Provider<String> value) {
+        teamName.set(value)
+    }
+
+    SighRenew teamName(String value) {
+        setTeamName(value)
+        this
+    }
+
+    SighRenew teamName(Provider<String> value) {
+        setTeamName(value)
+        this
+    }
+
+    final Property<String> username
+
+    void setUsername(String value) {
+        username.set(value)
+    }
+
+    void setUsername(Provider<String> value) {
+        username.set(value)
+    }
+
+    SighRenew username(String value) {
+        setUsername(value)
+        this
+    }
+
+    SighRenew username(Provider<String> value) {
+        setUsername(value)
+        this
+    }
+
+    final Property<String> password
+
+    void setPassword(String value) {
+        password.set(value)
+    }
+
+    void setPassword(Provider<String> value) {
+        password.set(value)
+    }
+
+    SighRenew password(String value) {
+        setPassword(value)
+        this
+    }
+
+    SighRenew password(Provider<String> value) {
+        setPassword(value)
+        this
+    }
+
+    final Property<String> fileName
+
+    void setFileName(String value) {
+        fileName.set(value)
+    }
+
+    void setFileName(Provider<String> value) {
+        fileName.set(value)
+    }
+
+    SighRenew fileName(String value) {
+        setFileName(value)
+        this
+    }
+
+    SighRenew fileName(Provider<String> value) {
+        setFileName(value)
+        this
+    }
+
+    final Property<String> provisioningName
+
+
+    void setProvisioningName(String value) {
+        provisioningName.set(value)
+    }
+
+    void setProvisioningName(Provider<String> value) {
+        provisioningName.set(value)
+    }
+
+    SighRenew provisioningName(String value) {
+        setProvisioningName(value)
+        this
+    }
+
+    SighRenew provisioningName(Provider<String> value) {
+        setProvisioningName(value)
+        this
+    }
+
+    final Property<Boolean> adhoc
+
+    void setAdhoc(Boolean value) {
+        adhoc.set(value)
+    }
+
+    void setAdhoc(Provider<Boolean> value) {
+        adhoc.set(value)
+    }
+
+    SighRenew adhoc(Boolean value) {
+        setAdhoc(value)
+        this
+    }
+
+    SighRenew adhoc(Provider<Boolean> value) {
+        setAdhoc(value)
+        this
+    }
+
+    final DirectoryProperty destinationDir
+
+    void setDestinationDir(File value) {
+        destinationDir.set(value)
+    }
+
+    void setDestinationDir(Provider<Directory> value) {
+        destinationDir.set(value)
+    }
+
+    SighRenew destinationDir(File value) {
+        setDestinationDir(value)
+        this
+    }
+
+    SighRenew destinationDir(Provider<Directory> value) {
+        setDestinationDir(value)
+        this
+    }
+
+    final Property<Boolean> readOnly
+
+    void setReadOnly(Boolean value) {
+        readOnly.set(value)
+    }
+
+    void setReadOnly(Provider<Boolean> value) {
+        readOnly.set(value)
+    }
+
+    SighRenew readOnly(Boolean value) {
+        setReadOnly(value)
+        this
+    }
+
+    SighRenew readOnly(Provider<Boolean> value) {
+        setReadOnly(value)
+        this
+    }
+
+    final Property<Boolean> ignoreProfilesWithDifferentName
+
+    void setIgnoreProfilesWithDifferentName(Boolean value) {
+        ignoreProfilesWithDifferentName.set(value)
+    }
+
+    void setIgnoreProfilesWithDifferentName(Provider<Boolean> value) {
+        ignoreProfilesWithDifferentName.set(value)
+    }
+
+    SighRenew ignoreProfilesWithDifferentName(Boolean value) {
+        setIgnoreProfilesWithDifferentName(value)
+        this
+    }
+
+    SighRenew ignoreProfilesWithDifferentName(Provider<Boolean> value) {
+        setIgnoreProfilesWithDifferentName(value)
+        this
+    }
+
+    @OutputFile
+    final Provider<RegularFile> mobileProvisioningProfile
+
+    @Input
+    final Provider<List<String>> arguments
+
+    @Input
+    final Provider<Map<String, String>> environment
+
+    SighRenew() {
+        super()
+        appIdentifier = project.objects.property(String)
+        teamId = project.objects.property(String)
+        teamName = project.objects.property(String)
+        username = project.objects.property(String)
+        password = project.objects.property(String)
+        fileName = project.objects.property(String)
+        provisioningName = project.objects.property(String)
+        adhoc = project.objects.property(Boolean)
+        readOnly = project.objects.property(Boolean)
+        ignoreProfilesWithDifferentName = project.objects.property(Boolean)
+        destinationDir = project.layout.directoryProperty()
+        mobileProvisioningProfile = destinationDir.file(fileName)
+
+        environment = project.provider({
+            Map<String, String> environment = [:]
+
+            if (password.isPresent()) {
+                environment['FASTLANE_PASSWORD'] = password.get()
+            }
+
+            environment
+        })
+
+        outputs.upToDateWhen(new Spec<Task>() {
+            @Override
+            boolean isSatisfiedBy(Task task) {
+                false
+            }
+        })
+
+        arguments = project.provider({
+            List<String> arguments = new ArrayList<String>()
+
+            arguments << "sigh" << "renew"
+
+            if (username.present) {
+                arguments << "--username" << username.get()
+            }
+
+            if (teamId.present) {
+                arguments << "--team_id" << teamId.get()
+            }
+
+            if (teamName.present) {
+                arguments << "--team_name" << teamName.get()
+            }
+
+            arguments << "--app_identifier" << appIdentifier.get()
+
+            if (provisioningName.present) {
+                arguments << "--provisioning_name" << provisioningName.get()
+            }
+
+            arguments << "--adhoc" << (adhoc.present && adhoc.get()).toString()
+            arguments << "--readonly" << (readOnly.present && readOnly.get()).toString()
+            arguments << "--ignore_profiles_with_different_name" << (ignoreProfilesWithDifferentName.present && ignoreProfilesWithDifferentName.get()).toString()
+            arguments << "--filename" << fileName.get()
+            arguments << "--output_path" << destinationDir.get().asFile.path
+
+            if (additionalArguments.present) {
+                additionalArguments.get().each {
+                    arguments << it
+                }
+            }
+
+            arguments
+        })
+
+        onlyIf(new Spec<SighRenew>() {
+            @Override
+            boolean isSatisfiedBy(SighRenew task) {
+                (task.teamId.present || task.teamName.present) && task.appIdentifier.present
+            }
+        })
+    }
+}


### PR DESCRIPTION
## Description

This patch adds a new task type `SighRenew` which will replace `ImportProvisioningProfile` in the `net.wooga.build-unity-ios` plugin. I created the same setup as for the new xcodebuild tasks. I did not create a new gradle plugin setup for the fastlane tasks as I don't know yet if it actually makes sense or not. The task is not yet fully integration tested since it is pretty much impossible to create and maintain the testsetup on the apple developer portal in order to test all functionalities.

## Changes

* ![ADD] `SighRenew` task

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
