### PR TITLE
Add PilotUpload task

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/fastlane/tasks/PilotUploadIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/fastlane/tasks/PilotUploadIntegrationSpec.groovy
@@ -1,0 +1,254 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wooga.gradle.fastlane.tasks
+
+import spock.lang.Requires
+import spock.lang.Unroll
+
+/**
+ * The test examples in this class are not 100% integration/functional tests.
+ *
+ * We can't run the real fastlane and connect to apple because there is no easy way to setup and maintain a test app and
+ * account with necessary credentials. We only test the invocation of fastlane and its parameters.
+ */
+@Requires({ os.macOs })
+class PilotUploadIntegrationSpec extends AbstractFastlaneTaskIntegrationSpec {
+
+    String testTaskName = "pilotUpload"
+
+    Class taskType = PilotUpload
+
+    def ipaFile = File.createTempFile("mockIpa", ".ipa")
+
+    String workingFastlaneTaskConfig = """
+        task("${testTaskName}", type: ${taskType.name}) {
+            ipa = file("${ipaFile.path}")
+        }
+        """.stripIndent()
+
+    @Unroll("property #property #valueMessage sets flag #expectedCommandlineFlag")
+    def "constructs arguments"() {
+        given: "a task to read the build arguments"
+        buildFile << """
+            task("readValue") {
+                doLast {
+                    println("arguments: " + ${testTaskName}.arguments.get().join(" "))
+                }
+            }
+        """.stripIndent()
+
+        and: "a set property"
+        if (method != _) {
+            buildFile << """
+            ${testTaskName}.${method}($value)
+            """.stripIndent()
+        }
+
+        when:
+        def result = runTasksSuccessfully("readValue")
+
+        then:
+        outputContains(result, expectedCommandlineFlag)
+
+        where:
+        property                        | method                              | rawValue                   | type           || expectedCommandlineFlag
+        "appIdentifier"                 | "appIdentifier.set"                 | "com.test.app"             | "String"       || "--app_identifier com.test.app"
+        "teamId"                        | "teamId.set"                        | "test"                     | "String"       || "--team_id test"
+        "devPortalTeamId"               | "devPortalTeamId.set"               | "test"                     | "String"       || "--dev_portal_team_id test"
+        "teamName"                      | "teamName.set"                      | "test"                     | "String"       || "--team_name test"
+        "username"                      | "username.set"                      | "testUser"                 | "String"       || "--username testUser"
+        "itcProvider"                   | "itcProvider.set"                   | "iphone"                   | "String"       || "--itc_provider iphone"
+        "skipSubmission"                | "skipSubmission.set"                | true                       | "Boolean"      || "--skip_submission true"
+        "skipSubmission"                | "skipSubmission.set"                | false                      | "Boolean"      || "--skip_submission false"
+        "skipSubmission"                | _                                   | _                          | "Boolean"      || "--skip_submission false"
+        "skipWaitingForBuildProcessing" | "skipWaitingForBuildProcessing.set" | true                       | "Boolean"      || "--skip_waiting_for_build_processing true"
+        "skipWaitingForBuildProcessing" | "skipWaitingForBuildProcessing.set" | false                      | "Boolean"      || "--skip_waiting_for_build_processing false"
+        "skipWaitingForBuildProcessing" | _                                   | _                          | "Boolean"      || "--skip_waiting_for_build_processing false"
+        "ipa"                           | "ipa.set"                           | "/path/to/test2.ipa"       | "File"         || "--ipa /path/to/test2.ipa"
+        "additionalArguments"           | "setAdditionalArguments"            | ["--verbose", "--foo bar"] | "List<String>" || "--verbose --foo bar"
+        value = wrapValueBasedOnType(rawValue, type)
+        valueMessage = (rawValue != _) ? "with value ${value}" : "without value"
+    }
+
+    @Unroll("property #property #valueMessage sets environment #expectedEnvironmentPair")
+    def "constructs process environment"() {
+        given: "a task to read the build arguments"
+        buildFile << """
+            task("readValue") {
+                doLast {
+                    println("arguments: " + ${testTaskName}.environment.get().collect {k,v -> k + '=' + v}.join("\\n"))
+                }
+            }
+        """.stripIndent()
+
+        and: "a set property"
+        if (method != _) {
+            buildFile << """
+            ${testTaskName}.${method}($value)
+            """.stripIndent()
+        }
+
+        when:
+        def result = runTasksSuccessfully("readValue")
+
+        then:
+        outputContains(result, expectedEnvironmentPair)
+
+        where:
+        property   | method         | rawValue      | type     || expectedEnvironmentPair
+        "password" | "password.set" | "secretValue" | "String" || "FASTLANE_PASSWORD=secretValue"
+        value = wrapValueBasedOnType(rawValue, type)
+        valueMessage = (rawValue != _) ? "with value ${value}" : "without value"
+    }
+
+    @Unroll("can set property #property with #method and type #type")
+    def "can set property SighRenew"() {
+        given: "a task to read back the value"
+        buildFile << """
+            task("readValue") {
+                doLast {
+                    println("property: " + ${testTaskName}.${property}.get())
+                }
+            }
+        """.stripIndent()
+
+        and: "a set property"
+        buildFile << """
+            ${testTaskName}.${method}($value)
+        """.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully("readValue")
+
+        then:
+        outputContains(result, "property: " + expectedValue.toString())
+
+        where:
+        property                        | method                              | rawValue             | type
+        "appIdentifier"                 | "appIdentifier"                     | "com.test.app1"      | "String"
+        "appIdentifier"                 | "appIdentifier"                     | "com.test.app2"      | "Provider<String>"
+        "appIdentifier"                 | "appIdentifier.set"                 | "com.test.app1"      | "String"
+        "appIdentifier"                 | "appIdentifier.set"                 | "com.test.app2"      | "Provider<String>"
+        "appIdentifier"                 | "setAppIdentifier"                  | "com.test.app3"      | "String"
+        "appIdentifier"                 | "setAppIdentifier"                  | "com.test.app4"      | "Provider<String>"
+
+        "teamId"                        | "teamId"                            | "1234561"            | "String"
+        "teamId"                        | "teamId"                            | "1234562"            | "Provider<String>"
+        "teamId"                        | "teamId.set"                        | "1234561"            | "String"
+        "teamId"                        | "teamId.set"                        | "1234562"            | "Provider<String>"
+        "teamId"                        | "setTeamId"                         | "1234563"            | "String"
+        "teamId"                        | "setTeamId"                         | "1234564"            | "Provider<String>"
+
+        "devPortalTeamId"               | "devPortalTeamId"                   | "1234561"            | "String"
+        "devPortalTeamId"               | "devPortalTeamId"                   | "1234562"            | "Provider<String>"
+        "devPortalTeamId"               | "devPortalTeamId.set"               | "1234561"            | "String"
+        "devPortalTeamId"               | "devPortalTeamId.set"               | "1234562"            | "Provider<String>"
+        "devPortalTeamId"               | "setDevPortalTeamId"                | "1234563"            | "String"
+        "devPortalTeamId"               | "setDevPortalTeamId"                | "1234564"            | "Provider<String>"
+
+        "teamName"                      | "teamName"                          | "someTeam1"          | "String"
+        "teamName"                      | "teamName"                          | "someTeam2"          | "Provider<String>"
+        "teamName"                      | "teamName.set"                      | "someTeam3"          | "String"
+        "teamName"                      | "teamName.set"                      | "someTeam4"          | "Provider<String>"
+        "teamName"                      | "setTeamName"                       | "someTeam5"          | "String"
+        "teamName"                      | "setTeamName"                       | "someTeam6"          | "Provider<String>"
+
+        "username"                      | "username"                          | "someName1"          | "String"
+        "username"                      | "username"                          | "someName2"          | "Provider<String>"
+        "username"                      | "username.set"                      | "someName3"          | "String"
+        "username"                      | "username.set"                      | "someName4"          | "Provider<String>"
+        "username"                      | "setUsername"                       | "someName5"          | "String"
+        "username"                      | "setUsername"                       | "someName6"          | "Provider<String>"
+
+        "password"                      | "password"                          | "1234561"            | "String"
+        "password"                      | "password"                          | "1234562"            | "Provider<String>"
+        "password"                      | "password.set"                      | "1234561"            | "String"
+        "password"                      | "password.set"                      | "1234562"            | "Provider<String>"
+        "password"                      | "setPassword"                       | "1234563"            | "String"
+        "password"                      | "setPassword"                       | "1234564"            | "Provider<String>"
+
+        "itcProvider"                   | "itcProvider"                       | "test1"              | "String"
+        "itcProvider"                   | "itcProvider"                       | "test2"              | "Provider<String>"
+        "itcProvider"                   | "itcProvider.set"                   | "test1"              | "String"
+        "itcProvider"                   | "itcProvider.set"                   | "test2"              | "Provider<String>"
+        "itcProvider"                   | "setItcProvider"                    | "test3"              | "String"
+        "itcProvider"                   | "setItcProvider"                    | "test4"              | "Provider<String>"
+
+        "ipa"                           | "ipa"                               | "/path/to/test1.ipa" | "File"
+        "ipa"                           | "ipa"                               | "/path/to/test2.ipa" | "Provider<RegularFile>"
+        "ipa"                           | "ipa.set"                           | "/path/to/test3.ipa" | "File"
+        "ipa"                           | "ipa.set"                           | "/path/to/test4.ipa" | "Provider<RegularFile>"
+        "ipa"                           | "setIpa"                            | "/path/to/test5.ipa" | "File"
+        "ipa"                           | "setIpa"                            | "/path/to/test6.ipa" | "Provider<RegularFile>"
+
+        "skipSubmission"                | "skipSubmission"                    | true                 | "Boolean"
+        "skipSubmission"                | "skipSubmission"                    | false                | "Boolean"
+        "skipSubmission"                | "skipSubmission"                    | true                 | "Provider<Boolean>"
+        "skipSubmission"                | "skipSubmission"                    | false                | "Provider<Boolean>"
+        "skipSubmission"                | "skipSubmission.set"                | true                 | "Boolean"
+        "skipSubmission"                | "skipSubmission.set"                | false                | "Boolean"
+        "skipSubmission"                | "skipSubmission.set"                | true                 | "Provider<Boolean>"
+        "skipSubmission"                | "skipSubmission.set"                | false                | "Provider<Boolean>"
+        "skipSubmission"                | "setSkipSubmission"                 | true                 | "Boolean"
+        "skipSubmission"                | "setSkipSubmission"                 | false                | "Boolean"
+        "skipSubmission"                | "setSkipSubmission"                 | true                 | "Provider<Boolean>"
+        "skipSubmission"                | "setSkipSubmission"                 | false                | "Provider<Boolean>"
+
+        "skipWaitingForBuildProcessing" | "skipWaitingForBuildProcessing"     | true                 | "Boolean"
+        "skipWaitingForBuildProcessing" | "skipWaitingForBuildProcessing"     | false                | "Boolean"
+        "skipWaitingForBuildProcessing" | "skipWaitingForBuildProcessing"     | true                 | "Provider<Boolean>"
+        "skipWaitingForBuildProcessing" | "skipWaitingForBuildProcessing"     | false                | "Provider<Boolean>"
+        "skipWaitingForBuildProcessing" | "skipWaitingForBuildProcessing.set" | true                 | "Boolean"
+        "skipWaitingForBuildProcessing" | "skipWaitingForBuildProcessing.set" | false                | "Boolean"
+        "skipWaitingForBuildProcessing" | "skipWaitingForBuildProcessing.set" | true                 | "Provider<Boolean>"
+        "skipWaitingForBuildProcessing" | "skipWaitingForBuildProcessing.set" | false                | "Provider<Boolean>"
+        "skipWaitingForBuildProcessing" | "setSkipWaitingForBuildProcessing"  | true                 | "Boolean"
+        "skipWaitingForBuildProcessing" | "setSkipWaitingForBuildProcessing"  | false                | "Boolean"
+        "skipWaitingForBuildProcessing" | "setSkipWaitingForBuildProcessing"  | true                 | "Provider<Boolean>"
+        "skipWaitingForBuildProcessing" | "setSkipWaitingForBuildProcessing"  | false                | "Provider<Boolean>"
+
+        value = wrapValueBasedOnType(rawValue, type)
+        expectedValue = rawValue
+    }
+
+    def "task is never up-to-date"() {
+        given: "call tasks once"
+        def r = runTasks(testTaskName)
+
+        when: "no parameter changes"
+        def result = runTasksSuccessfully(testTaskName)
+
+        then:
+        !result.wasUpToDate(testTaskName)
+    }
+
+    def "task skips with no-source when ipa is not set"() {
+        given: "call tasks once"
+        def result = runTasks(testTaskName)
+        assert !outputContains(result, "Task :${testTaskName} NO-SOURCE")
+
+        when: "the task with ipa param set to null"
+        buildFile << """
+        ${testTaskName}.ipa = null
+        """.stripIndent()
+
+        result = runTasksSuccessfully(testTaskName)
+
+        then:
+        outputContains(result, "Task :${testTaskName} NO-SOURCE")
+    }
+}

--- a/src/integrationTest/groovy/wooga/gradle/fastlane/tasks/SighRenewIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/fastlane/tasks/SighRenewIntegrationSpec.groovy
@@ -120,7 +120,7 @@ class SighRenewIntegrationSpec extends AbstractFastlaneTaskIntegrationSpec {
     }
 
     @Unroll("can set property #property with #method and type #type")
-    def "can set property XcodeArchive"() {
+    def "can set property SighRenew"() {
         given: "a task to read back the value"
         buildFile << """
             task("readValue") {

--- a/src/main/groovy/wooga/gradle/fastlane/tasks/PilotUpload.groovy
+++ b/src/main/groovy/wooga/gradle/fastlane/tasks/PilotUpload.groovy
@@ -1,0 +1,318 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wooga.gradle.fastlane.tasks
+
+import org.gradle.api.Task
+import org.gradle.api.file.FileCollection
+import org.gradle.api.file.RegularFile
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.specs.Spec
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.SkipWhenEmpty
+
+class PilotUpload extends AbstractFastlaneTask {
+
+    @SkipWhenEmpty
+    @InputFiles
+    protected FileCollection getInputFiles() {
+        if (ipa.present) {
+            return project.files(ipa)
+        }
+        project.files()
+    }
+
+    final RegularFileProperty ipa
+
+    void setIpa(File value) {
+        ipa.set(value)
+    }
+
+    void setIpa(Provider<RegularFile> value) {
+        ipa.set(value)
+    }
+
+    PilotUpload ipa(File value) {
+        setIpa(value)
+        this
+    }
+
+    PilotUpload ipa(Provider<RegularFile> value) {
+        setIpa(value)
+        this
+    }
+
+    final Property<String> appIdentifier
+
+    void setAppIdentifier(String value) {
+        appIdentifier.set(value)
+    }
+
+    void setAppIdentifier(Provider<String> value) {
+        appIdentifier.set(value)
+    }
+
+    PilotUpload appIdentifier(String value) {
+        setAppIdentifier(value)
+        this
+    }
+
+    PilotUpload appIdentifier(Provider<String> value) {
+        setAppIdentifier(value)
+        this
+    }
+
+    final Property<String> teamId
+
+    void setTeamId(String value) {
+        teamId.set(value)
+    }
+
+    void setTeamId(Provider<String> value) {
+        teamId.set(value)
+    }
+
+    PilotUpload teamId(String value) {
+        setTeamId(value)
+        this
+    }
+
+    PilotUpload teamId(Provider<String> value) {
+        setTeamId(value)
+        this
+    }
+
+    final Property<String> teamName
+
+    void setTeamName(String value) {
+        teamName.set(value)
+    }
+
+    void setTeamName(Provider<String> value) {
+        teamName.set(value)
+    }
+
+    PilotUpload teamName(String value) {
+        setTeamName(value)
+        this
+    }
+
+    PilotUpload teamName(Provider<String> value) {
+        setTeamName(value)
+        this
+    }
+
+    final Property<String> username
+
+    void setUsername(String value) {
+        username.set(value)
+    }
+
+    void setUsername(Provider<String> value) {
+        username.set(value)
+    }
+
+    PilotUpload username(String value) {
+        setUsername(value)
+        this
+    }
+
+    PilotUpload username(Provider<String> value) {
+        setUsername(value)
+        this
+    }
+
+    final Property<String> password
+
+    void setPassword(String value) {
+        password.set(value)
+    }
+
+    void setPassword(Provider<String> value) {
+        password.set(value)
+    }
+
+    PilotUpload password(String value) {
+        setPassword(value)
+        this
+    }
+
+    PilotUpload password(Provider<String> value) {
+        setPassword(value)
+        this
+    }
+
+    final Property<String> devPortalTeamId
+
+    void setDevPortalTeamId(String value) {
+        devPortalTeamId.set(value)
+    }
+
+    void setDevPortalTeamId(Provider<String> value) {
+        devPortalTeamId.set(value)
+    }
+
+    PilotUpload devPortalTeamId(String value) {
+        setDevPortalTeamId(value)
+        this
+    }
+
+    PilotUpload devPortalTeamId(Provider<String> value) {
+        setDevPortalTeamId(value)
+        this
+    }
+
+    final Property<String> itcProvider
+
+    void setItcProvider(String value) {
+        itcProvider.set(value)
+    }
+
+    void setItcProvider(Provider<String> value) {
+        itcProvider.set(value)
+    }
+
+    PilotUpload itcProvider(String value) {
+        setItcProvider(value)
+        this
+    }
+
+    PilotUpload itcProvider(Provider<String> value) {
+        setItcProvider(value)
+        this
+    }
+
+    final Property<Boolean> skipSubmission
+
+    void setSkipSubmission(Boolean value) {
+        skipSubmission.set(value)
+    }
+
+    void setSkipSubmission(Provider<Boolean> value) {
+        skipSubmission.set(value)
+    }
+
+    PilotUpload skipSubmission(Boolean value) {
+        setSkipSubmission(value)
+        this
+    }
+
+    PilotUpload skipSubmission(Provider<Boolean> value) {
+        setSkipSubmission(value)
+        this
+    }
+
+    final Property<Boolean> skipWaitingForBuildProcessing
+
+    void setSkipWaitingForBuildProcessing(Boolean value) {
+        skipWaitingForBuildProcessing.set(value)
+    }
+
+    void setSkipWaitingForBuildProcessing(Provider<Boolean> value) {
+        skipWaitingForBuildProcessing.set(value)
+    }
+
+    PilotUpload skipWaitingForBuildProcessing(Boolean value) {
+        setSkipWaitingForBuildProcessing(value)
+        this
+    }
+
+    PilotUpload skipWaitingForBuildProcessing(Provider<Boolean> value) {
+        setSkipWaitingForBuildProcessing(value)
+        this
+    }
+
+    @Input
+    final Provider<List<String>> arguments
+
+    @Input
+    final Provider<Map<String, String>> environment
+
+    PilotUpload() {
+        ipa = project.layout.fileProperty()
+        appIdentifier = project.objects.property(String)
+        teamId = project.objects.property(String)
+        devPortalTeamId = project.objects.property(String)
+        teamName = project.objects.property(String)
+        username = project.objects.property(String)
+        password = project.objects.property(String)
+        itcProvider = project.objects.property(String)
+        skipSubmission = project.objects.property(Boolean)
+        skipWaitingForBuildProcessing = project.objects.property(Boolean)
+
+        outputs.upToDateWhen(new Spec<Task>() {
+            @Override
+            boolean isSatisfiedBy(Task task) {
+                false
+            }
+        })
+
+        environment = project.provider({
+            Map<String, String> environment = [:]
+
+            if (password.isPresent()) {
+                environment['FASTLANE_PASSWORD'] = password.get()
+            }
+
+            environment
+        })
+
+        arguments = project.provider({
+            List<String> arguments = new ArrayList<String>()
+
+            arguments << "pilot" << "upload"
+
+            if (username.present) {
+                arguments << "--username" << username.get()
+            }
+
+            if (teamId.present) {
+                arguments << "--team_id" << teamId.get()
+            }
+
+            if (teamName.present) {
+                arguments << "--team_name" << teamName.get()
+            }
+
+            if (devPortalTeamId.present) {
+                arguments << "--dev_portal_team_id" << devPortalTeamId.get()
+            }
+
+            if (appIdentifier.present) {
+                arguments << "--app_identifier" << appIdentifier.get()
+            }
+
+            if (itcProvider.present) {
+                arguments << "--itc_provider" << itcProvider.get()
+            }
+
+            arguments << "--skip_submission" << (skipSubmission.present && skipSubmission.get()).toString()
+            arguments << "--skip_waiting_for_build_processing" << (skipWaitingForBuildProcessing.present && skipWaitingForBuildProcessing.get()).toString()
+            arguments << "--ipa" << ipa.get().asFile.path
+
+            if (additionalArguments.present) {
+                additionalArguments.get().each {
+                    arguments << it
+                }
+            }
+
+            arguments
+        })
+    }
+}


### PR DESCRIPTION
## Description

This is the second patch which will soon replace the old `fastlane` based task from `net.wooga.build-unity-ios`. The new task type `PilotUpdate` will soon replace the old `PublishTestFlight` implementation. This new task has nearly the same interface. It uses like all oter new types the Provider API to get rid of convention mapping as much as possible. The implementation uses a lot of the underlying abstract base class `AbstractFastlaneTask` which was introduced in the last patch (#86). This makes this change rather small. It supports logfile creation and the ability to add additional arguments in case fastlane adds more commandline arguments or we need to use a few of the ones I did not yet implement because of a good reason to have them in.

## Changes

* ![ADD] `PilotUpload` task type


[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
