### PR TITLE
Add fastlane gradle plugin

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/fastlane/FastlaneIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/fastlane/FastlaneIntegrationSpec.groovy
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wooga.gradle.fastlane
+
+abstract class FastlaneIntegrationSpec extends FastlaneSpec {
+    def setup() {
+        buildFile << """
+          group = 'test'
+          ${applyPlugin(FastlanePlugin)}
+       """.stripIndent()
+    }
+}

--- a/src/integrationTest/groovy/wooga/gradle/fastlane/FastlanePluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/fastlane/FastlanePluginIntegrationSpec.groovy
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wooga.gradle.fastlane
+
+import spock.lang.Unroll
+import wooga.gradle.fastlane.tasks.PilotUpload
+import wooga.gradle.fastlane.tasks.SighRenew
+
+class FastlanePluginIntegrationSpec extends FastlaneIntegrationSpec {
+
+    @Unroll()
+    def "extension property :#property returns '#testValue' if #reason"() {
+        given:
+        buildFile << """
+            task(custom) {
+                doLast {
+                    def value = ${extensionName}.${property}.getOrNull()
+                    println("${extensionName}.${property}: " + value)
+                }
+            }
+        """
+
+        and: "a gradle.properties"
+        def propertiesFile = createFile("gradle.properties")
+
+        switch (location) {
+            case PropertyLocation.script:
+                buildFile << "${extensionName}.${invocation}"
+                break
+            case PropertyLocation.property:
+                propertiesFile << "${extensionName}.${property} = ${escapedValue}"
+                break
+            case PropertyLocation.env:
+                environmentVariables.set(envNameFromProperty(extensionName, property), "${value}")
+                break
+            default:
+                break
+        }
+
+        and: "the test value with replace placeholders"
+        if (testValue instanceof String) {
+            testValue = testValue.replaceAll("#projectDir#", escapedPath(projectDir.path))
+        }
+
+        when: ""
+        def result = runTasksSuccessfully("custom")
+
+        then:
+        result.standardOutput.contains("${extensionName}.${property}: ${testValue}")
+
+        where:
+        property   | method         | rawValue        | expectedValue | type               | location                  | additionalInfo
+        "username" | _              | "someUser1"     | _             | _                  | PropertyLocation.env      | ""
+        "username" | _              | "someUser2"     | _             | _                  | PropertyLocation.property | ""
+        "username" | _              | "someUser3"     | _             | "String"           | PropertyLocation.script   | ""
+        "username" | _              | "someUser4"     | _             | "Provider<String>" | PropertyLocation.script   | ""
+        "username" | "username.set" | "someUser5"     | _             | "String"           | PropertyLocation.script   | ""
+        "username" | "username.set" | "someUser6"     | _             | "Provider<String>" | PropertyLocation.script   | ""
+        "username" | "username"     | "someUser7"     | _             | "String"           | PropertyLocation.script   | ""
+        "username" | "username"     | "someUser8"     | _             | "Provider<String>" | PropertyLocation.script   | ""
+        "username" | _              | _               | null          | _                  | PropertyLocation.none     | ""
+
+
+        "password" | _              | "somePassword1" | _             | _                  | PropertyLocation.env      | ""
+        "password" | _              | "somePassword2" | _             | _                  | PropertyLocation.property | ""
+        "password" | _              | "somePassword3" | _             | "String"           | PropertyLocation.script   | ""
+        "password" | _              | "somePassword4" | _             | "Provider<String>" | PropertyLocation.script   | ""
+        "password" | "password.set" | "somePassword5" | _             | "String"           | PropertyLocation.script   | ""
+        "password" | "password.set" | "somePassword6" | _             | "Provider<String>" | PropertyLocation.script   | ""
+        "password" | "password"     | "somePassword7" | _             | "String"           | PropertyLocation.script   | ""
+        "password" | "password"     | "somePassword8" | _             | "Provider<String>" | PropertyLocation.script   | ""
+        "password" | _              | _               | null          | _                  | PropertyLocation.none     | ""
+
+        extensionName = "fastlane"
+        value = (type != _) ? wrapValueBasedOnType(rawValue, type) : rawValue
+        providedValue = (location == PropertyLocation.script) ? type : value
+        testValue = (expectedValue == _) ? rawValue : expectedValue
+        reason = location.reason() + ((location == PropertyLocation.none) ? "" : "  with '$providedValue' ") + additionalInfo
+        escapedValue = (value instanceof String) ? escapedPath(value) : value
+        invocation = (method != _) ? "${method}(${escapedValue})" : "${property} = ${escapedValue}"
+    }
+
+    @Unroll("property #property of type #tasktype.simpleName is bound to property #extensionProperty of extension #extensionName")
+    def "task property is connected with extension"() {
+        given:
+        buildFile << """
+            task ${taskName}(type: ${tasktype.name})
+
+            task(custom) {
+                doLast {
+                    def value = ${taskName}.${property}${providerInvocation}
+                    println("${taskName}.${property}: " + value)
+                }
+            }
+            
+            ${extensionName}.${invocation}
+        """.stripIndent()
+
+        and: "the test value with replace placeholders"
+        if (testValue instanceof String) {
+            testValue = testValue.replaceAll("#projectDir#", escapedPath(projectDir.path))
+            testValue = testValue.replaceAll("#taskName#", taskName)
+        }
+
+        when: ""
+        def result = runTasksSuccessfully("custom")
+
+        then:
+        result.standardOutput.contains("${taskName}.${property}: ${testValue}")
+
+        where:
+        property   | extensionProperty | tasktype    | rawValue    | expectedValue | type     | useProviderApi
+        "username" | "username"        | SighRenew   | "userName1" | _             | "String" | true
+        "username" | "username"        | PilotUpload | "userName2" | _             | "String" | true
+
+        "password" | "password"        | SighRenew   | "password1" | _             | "String" | true
+        "password" | "password"        | PilotUpload | "password2" | _             | "String" | true
+
+        extensionName = "fastlane"
+        taskName = "fastlaneTask"
+        value = (type != _) ? wrapValueBasedOnType(rawValue, type) : rawValue
+        testValue = (expectedValue == _) ? rawValue : expectedValue
+        escapedValue = (value instanceof String) ? escapedPath(value) : value
+        invocation = "${extensionProperty}.set(${escapedValue})"
+        providerInvocation = (useProviderApi) ? ".getOrNull()" : ""
+    }
+}

--- a/src/integrationTest/groovy/wooga/gradle/fastlane/IntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/fastlane/IntegrationSpec.groovy
@@ -49,6 +49,8 @@ class IntegrationSpec extends nebula.test.IntegrationSpec {
             this.gradleVersion = gradleVersion
             fork = true
         }
+
+        environmentVariables.clear("FASTLANE_USERNAME", "FASTLANE_PASSWORD")
     }
 
     enum PropertyLocation {

--- a/src/integrationTest/groovy/wooga/gradle/fastlane/tasks/AbstractFastlaneTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/fastlane/tasks/AbstractFastlaneTaskIntegrationSpec.groovy
@@ -17,11 +17,11 @@
 package wooga.gradle.fastlane.tasks
 
 import spock.lang.Unroll
-import wooga.gradle.fastlane.FastlaneSpec
+import wooga.gradle.fastlane.FastlaneIntegrationSpec
 import wooga.gradle.xcodebuild.ConsoleSettings
 import wooga.gradle.xcodebuild.config.BuildSettings
 
-abstract class AbstractFastlaneTaskIntegrationSpec extends FastlaneSpec {
+abstract class AbstractFastlaneTaskIntegrationSpec extends FastlaneIntegrationSpec {
 
     abstract String getTestTaskName()
 

--- a/src/integrationTest/groovy/wooga/gradle/fastlane/tasks/PilotUploadIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/fastlane/tasks/PilotUploadIntegrationSpec.groovy
@@ -1,0 +1,254 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wooga.gradle.fastlane.tasks
+
+import spock.lang.Requires
+import spock.lang.Unroll
+
+/**
+ * The test examples in this class are not 100% integration/functional tests.
+ *
+ * We can't run the real fastlane and connect to apple because there is no easy way to setup and maintain a test app and
+ * account with necessary credentials. We only test the invocation of fastlane and its parameters.
+ */
+@Requires({ os.macOs })
+class PilotUploadIntegrationSpec extends AbstractFastlaneTaskIntegrationSpec {
+
+    String testTaskName = "pilotUpload"
+
+    Class taskType = PilotUpload
+
+    def ipaFile = File.createTempFile("mockIpa", ".ipa")
+
+    String workingFastlaneTaskConfig = """
+        task("${testTaskName}", type: ${taskType.name}) {
+            ipa = file("${ipaFile.path}")
+        }
+        """.stripIndent()
+
+    @Unroll("property #property #valueMessage sets flag #expectedCommandlineFlag")
+    def "constructs arguments"() {
+        given: "a task to read the build arguments"
+        buildFile << """
+            task("readValue") {
+                doLast {
+                    println("arguments: " + ${testTaskName}.arguments.get().join(" "))
+                }
+            }
+        """.stripIndent()
+
+        and: "a set property"
+        if (method != _) {
+            buildFile << """
+            ${testTaskName}.${method}($value)
+            """.stripIndent()
+        }
+
+        when:
+        def result = runTasksSuccessfully("readValue")
+
+        then:
+        outputContains(result, expectedCommandlineFlag)
+
+        where:
+        property                        | method                              | rawValue                   | type           || expectedCommandlineFlag
+        "appIdentifier"                 | "appIdentifier.set"                 | "com.test.app"             | "String"       || "--app_identifier com.test.app"
+        "teamId"                        | "teamId.set"                        | "test"                     | "String"       || "--team_id test"
+        "devPortalTeamId"               | "devPortalTeamId.set"               | "test"                     | "String"       || "--dev_portal_team_id test"
+        "teamName"                      | "teamName.set"                      | "test"                     | "String"       || "--team_name test"
+        "username"                      | "username.set"                      | "testUser"                 | "String"       || "--username testUser"
+        "itcProvider"                   | "itcProvider.set"                   | "iphone"                   | "String"       || "--itc_provider iphone"
+        "skipSubmission"                | "skipSubmission.set"                | true                       | "Boolean"      || "--skip_submission true"
+        "skipSubmission"                | "skipSubmission.set"                | false                      | "Boolean"      || "--skip_submission false"
+        "skipSubmission"                | _                                   | _                          | "Boolean"      || "--skip_submission false"
+        "skipWaitingForBuildProcessing" | "skipWaitingForBuildProcessing.set" | true                       | "Boolean"      || "--skip_waiting_for_build_processing true"
+        "skipWaitingForBuildProcessing" | "skipWaitingForBuildProcessing.set" | false                      | "Boolean"      || "--skip_waiting_for_build_processing false"
+        "skipWaitingForBuildProcessing" | _                                   | _                          | "Boolean"      || "--skip_waiting_for_build_processing false"
+        "ipa"                           | "ipa.set"                           | "/path/to/test2.ipa"       | "File"         || "--ipa /path/to/test2.ipa"
+        "additionalArguments"           | "setAdditionalArguments"            | ["--verbose", "--foo bar"] | "List<String>" || "--verbose --foo bar"
+        value = wrapValueBasedOnType(rawValue, type)
+        valueMessage = (rawValue != _) ? "with value ${value}" : "without value"
+    }
+
+    @Unroll("property #property #valueMessage sets environment #expectedEnvironmentPair")
+    def "constructs process environment"() {
+        given: "a task to read the build arguments"
+        buildFile << """
+            task("readValue") {
+                doLast {
+                    println("arguments: " + ${testTaskName}.environment.get().collect {k,v -> k + '=' + v}.join("\\n"))
+                }
+            }
+        """.stripIndent()
+
+        and: "a set property"
+        if (method != _) {
+            buildFile << """
+            ${testTaskName}.${method}($value)
+            """.stripIndent()
+        }
+
+        when:
+        def result = runTasksSuccessfully("readValue")
+
+        then:
+        outputContains(result, expectedEnvironmentPair)
+
+        where:
+        property   | method         | rawValue      | type     || expectedEnvironmentPair
+        "password" | "password.set" | "secretValue" | "String" || "FASTLANE_PASSWORD=secretValue"
+        value = wrapValueBasedOnType(rawValue, type)
+        valueMessage = (rawValue != _) ? "with value ${value}" : "without value"
+    }
+
+    @Unroll("can set property #property with #method and type #type")
+    def "can set property SighRenew"() {
+        given: "a task to read back the value"
+        buildFile << """
+            task("readValue") {
+                doLast {
+                    println("property: " + ${testTaskName}.${property}.get())
+                }
+            }
+        """.stripIndent()
+
+        and: "a set property"
+        buildFile << """
+            ${testTaskName}.${method}($value)
+        """.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully("readValue")
+
+        then:
+        outputContains(result, "property: " + expectedValue.toString())
+
+        where:
+        property                        | method                              | rawValue             | type
+        "appIdentifier"                 | "appIdentifier"                     | "com.test.app1"      | "String"
+        "appIdentifier"                 | "appIdentifier"                     | "com.test.app2"      | "Provider<String>"
+        "appIdentifier"                 | "appIdentifier.set"                 | "com.test.app1"      | "String"
+        "appIdentifier"                 | "appIdentifier.set"                 | "com.test.app2"      | "Provider<String>"
+        "appIdentifier"                 | "setAppIdentifier"                  | "com.test.app3"      | "String"
+        "appIdentifier"                 | "setAppIdentifier"                  | "com.test.app4"      | "Provider<String>"
+
+        "teamId"                        | "teamId"                            | "1234561"            | "String"
+        "teamId"                        | "teamId"                            | "1234562"            | "Provider<String>"
+        "teamId"                        | "teamId.set"                        | "1234561"            | "String"
+        "teamId"                        | "teamId.set"                        | "1234562"            | "Provider<String>"
+        "teamId"                        | "setTeamId"                         | "1234563"            | "String"
+        "teamId"                        | "setTeamId"                         | "1234564"            | "Provider<String>"
+
+        "devPortalTeamId"               | "devPortalTeamId"                   | "1234561"            | "String"
+        "devPortalTeamId"               | "devPortalTeamId"                   | "1234562"            | "Provider<String>"
+        "devPortalTeamId"               | "devPortalTeamId.set"               | "1234561"            | "String"
+        "devPortalTeamId"               | "devPortalTeamId.set"               | "1234562"            | "Provider<String>"
+        "devPortalTeamId"               | "setDevPortalTeamId"                | "1234563"            | "String"
+        "devPortalTeamId"               | "setDevPortalTeamId"                | "1234564"            | "Provider<String>"
+
+        "teamName"                      | "teamName"                          | "someTeam1"          | "String"
+        "teamName"                      | "teamName"                          | "someTeam2"          | "Provider<String>"
+        "teamName"                      | "teamName.set"                      | "someTeam3"          | "String"
+        "teamName"                      | "teamName.set"                      | "someTeam4"          | "Provider<String>"
+        "teamName"                      | "setTeamName"                       | "someTeam5"          | "String"
+        "teamName"                      | "setTeamName"                       | "someTeam6"          | "Provider<String>"
+
+        "username"                      | "username"                          | "someName1"          | "String"
+        "username"                      | "username"                          | "someName2"          | "Provider<String>"
+        "username"                      | "username.set"                      | "someName3"          | "String"
+        "username"                      | "username.set"                      | "someName4"          | "Provider<String>"
+        "username"                      | "setUsername"                       | "someName5"          | "String"
+        "username"                      | "setUsername"                       | "someName6"          | "Provider<String>"
+
+        "password"                      | "password"                          | "1234561"            | "String"
+        "password"                      | "password"                          | "1234562"            | "Provider<String>"
+        "password"                      | "password.set"                      | "1234561"            | "String"
+        "password"                      | "password.set"                      | "1234562"            | "Provider<String>"
+        "password"                      | "setPassword"                       | "1234563"            | "String"
+        "password"                      | "setPassword"                       | "1234564"            | "Provider<String>"
+
+        "itcProvider"                   | "itcProvider"                       | "test1"              | "String"
+        "itcProvider"                   | "itcProvider"                       | "test2"              | "Provider<String>"
+        "itcProvider"                   | "itcProvider.set"                   | "test1"              | "String"
+        "itcProvider"                   | "itcProvider.set"                   | "test2"              | "Provider<String>"
+        "itcProvider"                   | "setItcProvider"                    | "test3"              | "String"
+        "itcProvider"                   | "setItcProvider"                    | "test4"              | "Provider<String>"
+
+        "ipa"                           | "ipa"                               | "/path/to/test1.ipa" | "File"
+        "ipa"                           | "ipa"                               | "/path/to/test2.ipa" | "Provider<RegularFile>"
+        "ipa"                           | "ipa.set"                           | "/path/to/test3.ipa" | "File"
+        "ipa"                           | "ipa.set"                           | "/path/to/test4.ipa" | "Provider<RegularFile>"
+        "ipa"                           | "setIpa"                            | "/path/to/test5.ipa" | "File"
+        "ipa"                           | "setIpa"                            | "/path/to/test6.ipa" | "Provider<RegularFile>"
+
+        "skipSubmission"                | "skipSubmission"                    | true                 | "Boolean"
+        "skipSubmission"                | "skipSubmission"                    | false                | "Boolean"
+        "skipSubmission"                | "skipSubmission"                    | true                 | "Provider<Boolean>"
+        "skipSubmission"                | "skipSubmission"                    | false                | "Provider<Boolean>"
+        "skipSubmission"                | "skipSubmission.set"                | true                 | "Boolean"
+        "skipSubmission"                | "skipSubmission.set"                | false                | "Boolean"
+        "skipSubmission"                | "skipSubmission.set"                | true                 | "Provider<Boolean>"
+        "skipSubmission"                | "skipSubmission.set"                | false                | "Provider<Boolean>"
+        "skipSubmission"                | "setSkipSubmission"                 | true                 | "Boolean"
+        "skipSubmission"                | "setSkipSubmission"                 | false                | "Boolean"
+        "skipSubmission"                | "setSkipSubmission"                 | true                 | "Provider<Boolean>"
+        "skipSubmission"                | "setSkipSubmission"                 | false                | "Provider<Boolean>"
+
+        "skipWaitingForBuildProcessing" | "skipWaitingForBuildProcessing"     | true                 | "Boolean"
+        "skipWaitingForBuildProcessing" | "skipWaitingForBuildProcessing"     | false                | "Boolean"
+        "skipWaitingForBuildProcessing" | "skipWaitingForBuildProcessing"     | true                 | "Provider<Boolean>"
+        "skipWaitingForBuildProcessing" | "skipWaitingForBuildProcessing"     | false                | "Provider<Boolean>"
+        "skipWaitingForBuildProcessing" | "skipWaitingForBuildProcessing.set" | true                 | "Boolean"
+        "skipWaitingForBuildProcessing" | "skipWaitingForBuildProcessing.set" | false                | "Boolean"
+        "skipWaitingForBuildProcessing" | "skipWaitingForBuildProcessing.set" | true                 | "Provider<Boolean>"
+        "skipWaitingForBuildProcessing" | "skipWaitingForBuildProcessing.set" | false                | "Provider<Boolean>"
+        "skipWaitingForBuildProcessing" | "setSkipWaitingForBuildProcessing"  | true                 | "Boolean"
+        "skipWaitingForBuildProcessing" | "setSkipWaitingForBuildProcessing"  | false                | "Boolean"
+        "skipWaitingForBuildProcessing" | "setSkipWaitingForBuildProcessing"  | true                 | "Provider<Boolean>"
+        "skipWaitingForBuildProcessing" | "setSkipWaitingForBuildProcessing"  | false                | "Provider<Boolean>"
+
+        value = wrapValueBasedOnType(rawValue, type)
+        expectedValue = rawValue
+    }
+
+    def "task is never up-to-date"() {
+        given: "call tasks once"
+        def r = runTasks(testTaskName)
+
+        when: "no parameter changes"
+        def result = runTasksSuccessfully(testTaskName)
+
+        then:
+        !result.wasUpToDate(testTaskName)
+    }
+
+    def "task skips with no-source when ipa is not set"() {
+        given: "call tasks once"
+        def result = runTasks(testTaskName)
+        assert !outputContains(result, "Task :${testTaskName} NO-SOURCE")
+
+        when: "the task with ipa param set to null"
+        buildFile << """
+        ${testTaskName}.ipa = null
+        """.stripIndent()
+
+        result = runTasksSuccessfully(testTaskName)
+
+        then:
+        outputContains(result, "Task :${testTaskName} NO-SOURCE")
+    }
+}

--- a/src/integrationTest/groovy/wooga/gradle/fastlane/tasks/SighRenewIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/fastlane/tasks/SighRenewIntegrationSpec.groovy
@@ -120,7 +120,7 @@ class SighRenewIntegrationSpec extends AbstractFastlaneTaskIntegrationSpec {
     }
 
     @Unroll("can set property #property with #method and type #type")
-    def "can set property XcodeArchive"() {
+    def "can set property SighRenew"() {
         given: "a task to read back the value"
         buildFile << """
             task("readValue") {

--- a/src/main/groovy/wooga/gradle/fastlane/FastlanePlugin.groovy
+++ b/src/main/groovy/wooga/gradle/fastlane/FastlanePlugin.groovy
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wooga.gradle.fastlane
+
+import org.gradle.api.Action
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.plugins.BasePlugin
+import org.gradle.api.provider.Provider
+import wooga.gradle.fastlane.internal.DefaultFastlanePluginExtension
+import wooga.gradle.fastlane.tasks.PilotUpload
+import wooga.gradle.fastlane.tasks.SighRenew
+import wooga.gradle.fastlane.internal.PropertyLookup
+
+import static wooga.gradle.fastlane.FastlanePluginConsts.*
+
+class FastlanePlugin implements Plugin<Project> {
+    static final String EXTENSION_NAME = "fastlane"
+    static final String FASTLANE_GROUP = "fastlane"
+
+    private Project project
+
+    @Override
+    void apply(Project project) {
+        this.project = project
+
+        def extension = project.extensions.create(FastlanePluginExtension, EXTENSION_NAME, DefaultFastlanePluginExtension, project)
+
+        extension.username.set(lookupValueInEnvAndPropertiesProvider(USERNAME_LOOKUP))
+        extension.password.set(lookupValueInEnvAndPropertiesProvider(PASSWORD_LOOKUP))
+
+        project.tasks.withType(SighRenew, new Action<SighRenew>() {
+            @Override
+            void execute(SighRenew task) {
+                task.group = FASTLANE_GROUP
+                task.description = "runs fastlane sigh renew"
+
+                task.username.set(extension.username)
+                task.password.set(extension.password)
+            }
+        })
+
+        project.tasks.withType(PilotUpload, new Action<PilotUpload>() {
+            @Override
+            void execute(PilotUpload task) {
+                task.group = BasePlugin.UPLOAD_GROUP
+                task.description = "runs fastlane pilot upload"
+
+                task.username.set(extension.username)
+                task.password.set(extension.password)
+            }
+        })
+    }
+
+    private Provider<String> lookupValueInEnvAndPropertiesProvider(PropertyLookup lookup) {
+        lookupValueInEnvAndPropertiesProvider(lookup.env, lookup.property, lookup.defaultValue)
+    }
+
+    private Provider<String> lookupValueInEnvAndPropertiesProvider(String env, String property, String defaultValue = null) {
+        project.provider({
+            lookupValueInEnvAndProperties(env, property, defaultValue)
+        })
+    }
+
+    protected String lookupValueInEnvAndProperties(String env, String property, String defaultValue = null) {
+        System.getenv().get(env) ?:
+                project.properties.getOrDefault(property, defaultValue)
+    }
+}

--- a/src/main/groovy/wooga/gradle/fastlane/FastlanePluginConsts.groovy
+++ b/src/main/groovy/wooga/gradle/fastlane/FastlanePluginConsts.groovy
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wooga.gradle.fastlane
+
+import wooga.gradle.fastlane.internal.PropertyLookup
+
+class FastlanePluginConsts {
+
+    static final PropertyLookup USERNAME_LOOKUP = new PropertyLookup("FASTLANE_USERNAME", "fastlane.username", null)
+    static final PropertyLookup PASSWORD_LOOKUP = new PropertyLookup("FASTLANE_PASSWORD", "fastlane.password", null)
+}

--- a/src/main/groovy/wooga/gradle/fastlane/FastlanePluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/fastlane/FastlanePluginExtension.groovy
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wooga.gradle.fastlane
+
+
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+
+interface FastlanePluginExtension<T extends FastlanePluginExtension> {
+    Property<String> getUsername()
+
+    void setUsername(String value)
+    void setUsername(Provider<String> value)
+
+    T username(String value)
+    T username(Provider<String> value)
+
+    Property<String> getPassword()
+
+    void setPassword(String value)
+    void setPassword(Provider<String> value)
+
+    T password(String value)
+    T password(Provider<String> value)
+}

--- a/src/main/groovy/wooga/gradle/fastlane/internal/DefaultFastlanePluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/fastlane/internal/DefaultFastlanePluginExtension.groovy
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wooga.gradle.fastlane.internal
+
+
+import org.gradle.api.Project
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import wooga.gradle.fastlane.FastlanePluginExtension
+
+class DefaultFastlanePluginExtension implements FastlanePluginExtension {
+
+    private final Project project
+
+    DefaultFastlanePluginExtension(Project project) {
+        this.project = project
+
+        username = project.objects.property(String)
+        password = project.objects.property(String)
+    }
+
+    final Property<String> username
+
+    @Override
+    void setUsername(String value) {
+        username.set(value)
+    }
+
+    @Override
+    void setUsername(Provider<String> value) {
+        username.set(value)
+    }
+
+    @Override
+    FastlanePluginExtension username(String value) {
+        setUsername(value)
+        this
+    }
+
+    @Override
+    FastlanePluginExtension username(Provider<String> value) {
+        setUsername(value)
+        this
+    }
+
+    final Property<String> password
+
+    @Override
+    void setPassword(String value) {
+        password.set(value)
+    }
+
+    @Override
+    void setPassword(Provider<String> value) {
+        password.set(value)
+    }
+
+    @Override
+    FastlanePluginExtension password(String value) {
+        setPassword(value)
+        this
+    }
+
+    @Override
+    FastlanePluginExtension password(Provider<String> value) {
+        setPassword(value)
+        this
+    }
+
+}

--- a/src/main/groovy/wooga/gradle/fastlane/internal/PropertyLookup.groovy
+++ b/src/main/groovy/wooga/gradle/fastlane/internal/PropertyLookup.groovy
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wooga.gradle.fastlane.internal
+
+class PropertyLookup {
+    final String env
+    final String property
+    final String defaultValue
+
+    PropertyLookup(String env, String property, String defaultValue) {
+        this.env = env
+        this.property = property
+        this.defaultValue = defaultValue
+    }
+}

--- a/src/main/groovy/wooga/gradle/fastlane/tasks/PilotUpload.groovy
+++ b/src/main/groovy/wooga/gradle/fastlane/tasks/PilotUpload.groovy
@@ -1,0 +1,318 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wooga.gradle.fastlane.tasks
+
+import org.gradle.api.Task
+import org.gradle.api.file.FileCollection
+import org.gradle.api.file.RegularFile
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.specs.Spec
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.SkipWhenEmpty
+
+class PilotUpload extends AbstractFastlaneTask {
+
+    @SkipWhenEmpty
+    @InputFiles
+    protected FileCollection getInputFiles() {
+        if (ipa.present) {
+            return project.files(ipa)
+        }
+        project.files()
+    }
+
+    final RegularFileProperty ipa
+
+    void setIpa(File value) {
+        ipa.set(value)
+    }
+
+    void setIpa(Provider<RegularFile> value) {
+        ipa.set(value)
+    }
+
+    PilotUpload ipa(File value) {
+        setIpa(value)
+        this
+    }
+
+    PilotUpload ipa(Provider<RegularFile> value) {
+        setIpa(value)
+        this
+    }
+
+    final Property<String> appIdentifier
+
+    void setAppIdentifier(String value) {
+        appIdentifier.set(value)
+    }
+
+    void setAppIdentifier(Provider<String> value) {
+        appIdentifier.set(value)
+    }
+
+    PilotUpload appIdentifier(String value) {
+        setAppIdentifier(value)
+        this
+    }
+
+    PilotUpload appIdentifier(Provider<String> value) {
+        setAppIdentifier(value)
+        this
+    }
+
+    final Property<String> teamId
+
+    void setTeamId(String value) {
+        teamId.set(value)
+    }
+
+    void setTeamId(Provider<String> value) {
+        teamId.set(value)
+    }
+
+    PilotUpload teamId(String value) {
+        setTeamId(value)
+        this
+    }
+
+    PilotUpload teamId(Provider<String> value) {
+        setTeamId(value)
+        this
+    }
+
+    final Property<String> teamName
+
+    void setTeamName(String value) {
+        teamName.set(value)
+    }
+
+    void setTeamName(Provider<String> value) {
+        teamName.set(value)
+    }
+
+    PilotUpload teamName(String value) {
+        setTeamName(value)
+        this
+    }
+
+    PilotUpload teamName(Provider<String> value) {
+        setTeamName(value)
+        this
+    }
+
+    final Property<String> username
+
+    void setUsername(String value) {
+        username.set(value)
+    }
+
+    void setUsername(Provider<String> value) {
+        username.set(value)
+    }
+
+    PilotUpload username(String value) {
+        setUsername(value)
+        this
+    }
+
+    PilotUpload username(Provider<String> value) {
+        setUsername(value)
+        this
+    }
+
+    final Property<String> password
+
+    void setPassword(String value) {
+        password.set(value)
+    }
+
+    void setPassword(Provider<String> value) {
+        password.set(value)
+    }
+
+    PilotUpload password(String value) {
+        setPassword(value)
+        this
+    }
+
+    PilotUpload password(Provider<String> value) {
+        setPassword(value)
+        this
+    }
+
+    final Property<String> devPortalTeamId
+
+    void setDevPortalTeamId(String value) {
+        devPortalTeamId.set(value)
+    }
+
+    void setDevPortalTeamId(Provider<String> value) {
+        devPortalTeamId.set(value)
+    }
+
+    PilotUpload devPortalTeamId(String value) {
+        setDevPortalTeamId(value)
+        this
+    }
+
+    PilotUpload devPortalTeamId(Provider<String> value) {
+        setDevPortalTeamId(value)
+        this
+    }
+
+    final Property<String> itcProvider
+
+    void setItcProvider(String value) {
+        itcProvider.set(value)
+    }
+
+    void setItcProvider(Provider<String> value) {
+        itcProvider.set(value)
+    }
+
+    PilotUpload itcProvider(String value) {
+        setItcProvider(value)
+        this
+    }
+
+    PilotUpload itcProvider(Provider<String> value) {
+        setItcProvider(value)
+        this
+    }
+
+    final Property<Boolean> skipSubmission
+
+    void setSkipSubmission(Boolean value) {
+        skipSubmission.set(value)
+    }
+
+    void setSkipSubmission(Provider<Boolean> value) {
+        skipSubmission.set(value)
+    }
+
+    PilotUpload skipSubmission(Boolean value) {
+        setSkipSubmission(value)
+        this
+    }
+
+    PilotUpload skipSubmission(Provider<Boolean> value) {
+        setSkipSubmission(value)
+        this
+    }
+
+    final Property<Boolean> skipWaitingForBuildProcessing
+
+    void setSkipWaitingForBuildProcessing(Boolean value) {
+        skipWaitingForBuildProcessing.set(value)
+    }
+
+    void setSkipWaitingForBuildProcessing(Provider<Boolean> value) {
+        skipWaitingForBuildProcessing.set(value)
+    }
+
+    PilotUpload skipWaitingForBuildProcessing(Boolean value) {
+        setSkipWaitingForBuildProcessing(value)
+        this
+    }
+
+    PilotUpload skipWaitingForBuildProcessing(Provider<Boolean> value) {
+        setSkipWaitingForBuildProcessing(value)
+        this
+    }
+
+    @Input
+    final Provider<List<String>> arguments
+
+    @Input
+    final Provider<Map<String, String>> environment
+
+    PilotUpload() {
+        ipa = project.layout.fileProperty()
+        appIdentifier = project.objects.property(String)
+        teamId = project.objects.property(String)
+        devPortalTeamId = project.objects.property(String)
+        teamName = project.objects.property(String)
+        username = project.objects.property(String)
+        password = project.objects.property(String)
+        itcProvider = project.objects.property(String)
+        skipSubmission = project.objects.property(Boolean)
+        skipWaitingForBuildProcessing = project.objects.property(Boolean)
+
+        outputs.upToDateWhen(new Spec<Task>() {
+            @Override
+            boolean isSatisfiedBy(Task task) {
+                false
+            }
+        })
+
+        environment = project.provider({
+            Map<String, String> environment = [:]
+
+            if (password.isPresent()) {
+                environment['FASTLANE_PASSWORD'] = password.get()
+            }
+
+            environment
+        })
+
+        arguments = project.provider({
+            List<String> arguments = new ArrayList<String>()
+
+            arguments << "pilot" << "upload"
+
+            if (username.present) {
+                arguments << "--username" << username.get()
+            }
+
+            if (teamId.present) {
+                arguments << "--team_id" << teamId.get()
+            }
+
+            if (teamName.present) {
+                arguments << "--team_name" << teamName.get()
+            }
+
+            if (devPortalTeamId.present) {
+                arguments << "--dev_portal_team_id" << devPortalTeamId.get()
+            }
+
+            if (appIdentifier.present) {
+                arguments << "--app_identifier" << appIdentifier.get()
+            }
+
+            if (itcProvider.present) {
+                arguments << "--itc_provider" << itcProvider.get()
+            }
+
+            arguments << "--skip_submission" << (skipSubmission.present && skipSubmission.get()).toString()
+            arguments << "--skip_waiting_for_build_processing" << (skipWaitingForBuildProcessing.present && skipWaitingForBuildProcessing.get()).toString()
+            arguments << "--ipa" << ipa.get().asFile.path
+
+            if (additionalArguments.present) {
+                additionalArguments.get().each {
+                    arguments << it
+                }
+            }
+
+            arguments
+        })
+    }
+}

--- a/src/main/resources/META-INF/gradle-plugins/net.wooga.fastlane.properties
+++ b/src/main/resources/META-INF/gradle-plugins/net.wooga.fastlane.properties
@@ -1,0 +1,20 @@
+#
+# Copyright 2018-2020 Wooga GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+#
+#
+
+implementation-class=wooga.gradle.fastlane.FastlanePlugin

--- a/src/test/groovy/wooga/gradle/fastlane/FastlanePluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/fastlane/FastlanePluginSpec.groovy
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wooga.gradle.fastlane
+
+import nebula.test.ProjectSpec
+import wooga.gradle.fastlane.internal.DefaultFastlanePluginExtension
+
+class FastlanePluginSpec extends ProjectSpec {
+    public static final String PLUGIN_NAME = 'net.wooga.fastlane'
+
+    def 'Creates the [fastlane] extension'() {
+        given:
+        assert !project.plugins.hasPlugin(PLUGIN_NAME)
+        assert !project.extensions.findByName(FastlanePlugin.EXTENSION_NAME)
+
+        when:
+        project.plugins.apply(PLUGIN_NAME)
+
+        then:
+        def extension = project.extensions.findByName(FastlanePlugin.EXTENSION_NAME)
+        extension instanceof DefaultFastlanePluginExtension
+    }
+}

--- a/src/test/groovy/wooga/gradle/fastlane/XcodeBuildPluginActivationSpec.groovy
+++ b/src/test/groovy/wooga/gradle/fastlane/XcodeBuildPluginActivationSpec.groovy
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wooga.gradle.fastlane
+
+import nebula.test.PluginProjectSpec
+
+class XcodeBuildPluginActivationSpec extends PluginProjectSpec {
+    @Override
+    String getPluginName() {
+        return 'net.wooga.fastlane'
+    }
+}


### PR DESCRIPTION
## Description

This patch adds a simple plugin definiton for `fastlane`. This allows to setup shared configuration in a single extention. I implemented only two settings in the provided fastlane extension: `username` and `password`.

| property              | gradle property name              | environment variable                |
| --------------------- | --------------------------------- | ----------------------------------- |
| username              | `fastlane.username`               | `FASTLANE_USERNAME`                 |
| password              | `fastlane.password`               | `FASTLANE_PASSWORD`                 |

In this case, we use the same env names as fastlanes would use as well.

Changes
=======

* ![ADD] ![GRADLE] `FastlanePlugin` with defaults


[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:https://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
[GRADLE]:https://atlas-resources.wooga.com/icons/icon_gradle.svg "Gradle"
