### PR TITLE
Add new macOS security task to create build keychain

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/build/IntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/IntegrationSpec.groovy
@@ -51,11 +51,11 @@ class IntegrationSpec extends nebula.test.IntegrationSpec{
         result.standardOutput.contains(message) || result.standardError.contains(message)
     }
 
-    String wrapValueBasedOnType(Object rawValue, Class type) {
-        wrapValueBasedOnType(rawValue, type.simpleName)
+    String wrapValueBasedOnType(Object rawValue, Class type, Closure<String> fallback = null) {
+        wrapValueBasedOnType(rawValue, type.simpleName, fallback)
     }
 
-    String wrapValueBasedOnType(Object rawValue, String type) {
+    String wrapValueBasedOnType(Object rawValue, String type, Closure<String> fallback = null) {
         def value
         def rawValueEscaped = String.isInstance(rawValue) ? "'${rawValue}'" : rawValue
         def subtypeMatches = type =~ /(?<mainType>\w+)<(?<subType>[\w<>]+)>/
@@ -64,7 +64,7 @@ class IntegrationSpec extends nebula.test.IntegrationSpec{
         switch (type) {
             case "Closure":
                 if (subType) {
-                    value = "{${wrapValueBasedOnType(rawValue, subType)}}"
+                    value = "{${wrapValueBasedOnType(rawValue, subType, fallback)}}"
                 } else {
                     value = "{$rawValueEscaped}"
                 }
@@ -78,10 +78,19 @@ class IntegrationSpec extends nebula.test.IntegrationSpec{
             case "Provider":
                 switch (subType) {
                     case "RegularFile":
-                        value = "project.layout.file(${wrapValueBasedOnType(rawValue, "Provider<File>")})"
+                        value = "project.layout.file(${wrapValueBasedOnType(rawValue, "Provider<File>", fallback)})"
+                        break
+                    case "Directory":
+                        value = """
+                                project.provider({
+                                    def d = project.layout.directoryProperty()
+                                    d.set(${wrapValueBasedOnType(rawValue, "File", fallback)})
+                                    d.get()
+                                })
+                        """.trim().stripIndent()
                         break
                     default:
-                        value = "project.provider(${wrapValueBasedOnType(rawValue, "Closure<${subType}>")})"
+                        value = "project.provider(${wrapValueBasedOnType(rawValue, "Closure<${subType}>", fallback)})"
                         break
                 }
                 break
@@ -89,7 +98,7 @@ class IntegrationSpec extends nebula.test.IntegrationSpec{
                 value = "${escapedPath(rawValueEscaped.toString())}"
                 break
             case "String[]":
-                value = "'{${rawValue.collect { '"' + it + '"' }.join(",")}}'.split(',')"
+                value = "'${rawValue.collect { it }.join(",")}'.split(',')"
                 break
             case "File":
                 value = "new File('${escapedPath(rawValue.toString())}')"
@@ -101,11 +110,11 @@ class IntegrationSpec extends nebula.test.IntegrationSpec{
                 value = "[${rawValue.collect { '"' + it + '"' }.join(", ")}]"
                 break
             case "Map":
-                value = "[" + rawValue.collect { k,v -> "${wrapValueBasedOnType(k, k.getClass())} : ${wrapValueBasedOnType(v, v.getClass())}" }.join(", ") + "]"
+                value = "[" + rawValue.collect { k, v -> "${wrapValueBasedOnType(k, k.getClass(), fallback)} : ${wrapValueBasedOnType(v, v.getClass(), fallback)}" }.join(", ") + "]"
                 value = value == "[]" ? "[:]" : value
                 break
             default:
-                value = rawValue
+                value = (fallback) ? fallback.call(type) : rawValue
         }
         value
     }

--- a/src/integrationTest/groovy/wooga/gradle/macOS/security/tasks/SecurityCreateKeychainIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/macOS/security/tasks/SecurityCreateKeychainIntegrationSpec.groovy
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2018 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.macOS.security.tasks
+
+import spock.lang.Requires
+import spock.lang.Shared
+import spock.lang.Unroll
+import wooga.gradle.build.IntegrationSpec
+import wooga.gradle.build.unity.ios.IOSBuildPlugin
+import wooga.gradle.fastlane.tasks.PilotUpload
+
+@Requires({ os.macOs })
+class SecurityCreateKeychainIntegrationSpec extends IntegrationSpec {
+
+    String testTaskName = "createKeychain"
+
+    Class taskType = SecurityCreateKeychain
+
+    String keychainPassword = "123456"
+
+    @Shared
+    File buildKeychain
+
+    def setup() {
+        buildFile << """
+        task ${testTaskName}(type: ${taskType.name}) {
+            baseName = "build"
+            extension = "keychain"
+            destinationDir = file("build/sign/keychains")
+            password = "${keychainPassword}"
+        }
+        """.stripIndent()
+
+        buildKeychain = new File(projectDir, 'build/sign/keychains/build.keychain')
+    }
+
+    def "creates a keychain"() {
+        given: "a future keychain"
+        assert !buildKeychain.exists()
+
+        when:
+        runTasksSuccessfully(testTaskName)
+
+        then:
+        buildKeychain.exists()
+    }
+
+    def "buildKeychain caches task outputs"() {
+        given: "a gradle run with buildKeychain"
+        runTasksSuccessfully(testTaskName)
+
+        when:
+        def result = runTasksSuccessfully(testTaskName)
+
+        then:
+        result.wasUpToDate(testTaskName)
+    }
+
+    @Unroll
+    def "createKeychain is not [UP-TO-DATE] when #reason"() {
+        given: "a gradle run with buildKeychain"
+        runTasksSuccessfully(testTaskName)
+
+        when:
+        buildKeychain.delete()
+        def result = runTasksSuccessfully(testTaskName)
+
+        then:
+        !result.wasUpToDate(testTaskName)
+    }
+
+    def "does not print password to stdout"() {
+        when:
+        def result = runTasksSuccessfully(testTaskName)
+
+        then:
+        !outputContains(result, "-p ${keychainPassword}")
+        outputContains(result, "-p ****")
+    }
+
+    @Unroll("can set property #property with #method and type #type")
+    def "can set property"() {
+        given: "a task to read back the value"
+        buildFile << """
+            task("readValue") {
+                doLast {
+                    println("property: " + ${testTaskName}.${property}.get())
+                }
+            }
+        """.stripIndent()
+        and: "a set property"
+
+        buildFile << """
+            ${testTaskName}.${method}($value)
+        """.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully("readValue")
+
+        then:
+        outputContains(result, "property: " + expectedValue.toString())
+
+        where:
+        property                   | method                         | rawValue        | type
+        "fileName"                 | "fileName"                     | "testName1"     | "String"
+        "fileName"                 | "fileName"                     | "testName2"     | "Provider<String>"
+        "fileName"                 | "fileName.set"                 | "testName1"     | "String"
+        "fileName"                 | "fileName.set"                 | "testName2"     | "Provider<String>"
+        "fileName"                 | "setFileName"                  | "testName3"     | "String"
+        "fileName"                 | "setFileName"                  | "testName4"     | "Provider<String>"
+
+        "baseName"                 | "baseName"                     | "testBaseName1" | "String"
+        "baseName"                 | "baseName"                     | "testBaseName2" | "Provider<String>"
+        "baseName"                 | "baseName.set"                 | "testBaseName1" | "String"
+        "baseName"                 | "baseName.set"                 | "testBaseName2" | "Provider<String>"
+        "baseName"                 | "setBaseName"                  | "testBaseName3" | "String"
+        "baseName"                 | "setBaseName"                  | "testBaseName4" | "Provider<String>"
+
+        "extension"                | "extension"                    | "ext2"          | "Provider<String>"
+        "extension"                | "extension.set"                | "ext1"          | "String"
+        "extension"                | "extension.set"                | "ext2"          | "Provider<String>"
+        "extension"                | "setExtension"                 | "ext3"          | "String"
+        "extension"                | "setExtension"                 | "ext4"          | "Provider<String>"
+
+        "password"                 | "password"                     | "password2"     | "Provider<String>"
+        "password"                 | "password.set"                 | "password1"     | "String"
+        "password"                 | "password.set"                 | "password2"     | "Provider<String>"
+        "password"                 | "setPassword"                  | "password3"     | "String"
+        "password"                 | "setPassword"                  | "password4"     | "Provider<String>"
+
+        "destinationDir"           | "destinationDir"               | "/some/path/1"  | "File"
+        "destinationDir"           | "destinationDir"               | "/some/path/2"  | "Provider<Directory>"
+        "destinationDir"           | "destinationDir.set"           | "/some/path/3"  | "File"
+        "destinationDir"           | "destinationDir.set"           | "/some/path/4"  | "Provider<Directory>"
+        "destinationDir"           | "setDestinationDir"            | "/some/path/5"  | "File"
+        "destinationDir"           | "setDestinationDir"            | "/some/path/6"  | "Provider<Directory>"
+
+        "lockKeychainWhenSleep"    | "lockKeychainWhenSleep"        | true            | "Boolean"
+        "lockKeychainWhenSleep"    | "lockKeychainWhenSleep"        | true            | "Provider<Boolean>"
+        "lockKeychainWhenSleep"    | "lockKeychainWhenSleep.set"    | true            | "Boolean"
+        "lockKeychainWhenSleep"    | "lockKeychainWhenSleep.set"    | true            | "Provider<Boolean>"
+        "lockKeychainWhenSleep"    | "setLockKeychainWhenSleep"     | true            | "Boolean"
+        "lockKeychainWhenSleep"    | "setLockKeychainWhenSleep"     | true            | "Provider<Boolean>"
+
+        "lockKeychainAfterTimeout" | "lockKeychainAfterTimeout"     | 1               | "Integer"
+        "lockKeychainAfterTimeout" | "lockKeychainAfterTimeout"     | 2               | "Provider<Integer>"
+        "lockKeychainAfterTimeout" | "lockKeychainAfterTimeout.set" | 3               | "Integer"
+        "lockKeychainAfterTimeout" | "lockKeychainAfterTimeout.set" | 4               | "Provider<Integer>"
+        "lockKeychainAfterTimeout" | "setLockKeychainAfterTimeout"  | 5               | "Provider<Integer>"
+        "lockKeychainAfterTimeout" | "setLockKeychainAfterTimeout"  | 6               | "Integer"
+        value = wrapValueBasedOnType(rawValue, type)
+        expectedValue = rawValue
+    }
+}

--- a/src/main/groovy/wooga/gradle/fastlane/tasks/PilotUpload.groovy
+++ b/src/main/groovy/wooga/gradle/fastlane/tasks/PilotUpload.groovy
@@ -1,0 +1,318 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wooga.gradle.fastlane.tasks
+
+import org.gradle.api.Task
+import org.gradle.api.file.FileCollection
+import org.gradle.api.file.RegularFile
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.specs.Spec
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.SkipWhenEmpty
+
+class PilotUpload extends AbstractFastlaneTask {
+
+    @SkipWhenEmpty
+    @InputFiles
+    protected FileCollection getInputFiles() {
+        if (ipa.present) {
+            return project.files(ipa)
+        }
+        project.files()
+    }
+
+    final RegularFileProperty ipa
+
+    void setIpa(File value) {
+        ipa.set(value)
+    }
+
+    void setIpa(Provider<RegularFile> value) {
+        ipa.set(value)
+    }
+
+    PilotUpload ipa(File value) {
+        setIpa(value)
+        this
+    }
+
+    PilotUpload ipa(Provider<RegularFile> value) {
+        setIpa(value)
+        this
+    }
+
+    final Property<String> appIdentifier
+
+    void setAppIdentifier(String value) {
+        appIdentifier.set(value)
+    }
+
+    void setAppIdentifier(Provider<String> value) {
+        appIdentifier.set(value)
+    }
+
+    PilotUpload appIdentifier(String value) {
+        setAppIdentifier(value)
+        this
+    }
+
+    PilotUpload appIdentifier(Provider<String> value) {
+        setAppIdentifier(value)
+        this
+    }
+
+    final Property<String> teamId
+
+    void setTeamId(String value) {
+        teamId.set(value)
+    }
+
+    void setTeamId(Provider<String> value) {
+        teamId.set(value)
+    }
+
+    PilotUpload teamId(String value) {
+        setTeamId(value)
+        this
+    }
+
+    PilotUpload teamId(Provider<String> value) {
+        setTeamId(value)
+        this
+    }
+
+    final Property<String> teamName
+
+    void setTeamName(String value) {
+        teamName.set(value)
+    }
+
+    void setTeamName(Provider<String> value) {
+        teamName.set(value)
+    }
+
+    PilotUpload teamName(String value) {
+        setTeamName(value)
+        this
+    }
+
+    PilotUpload teamName(Provider<String> value) {
+        setTeamName(value)
+        this
+    }
+
+    final Property<String> username
+
+    void setUsername(String value) {
+        username.set(value)
+    }
+
+    void setUsername(Provider<String> value) {
+        username.set(value)
+    }
+
+    PilotUpload username(String value) {
+        setUsername(value)
+        this
+    }
+
+    PilotUpload username(Provider<String> value) {
+        setUsername(value)
+        this
+    }
+
+    final Property<String> password
+
+    void setPassword(String value) {
+        password.set(value)
+    }
+
+    void setPassword(Provider<String> value) {
+        password.set(value)
+    }
+
+    PilotUpload password(String value) {
+        setPassword(value)
+        this
+    }
+
+    PilotUpload password(Provider<String> value) {
+        setPassword(value)
+        this
+    }
+
+    final Property<String> devPortalTeamId
+
+    void setDevPortalTeamId(String value) {
+        devPortalTeamId.set(value)
+    }
+
+    void setDevPortalTeamId(Provider<String> value) {
+        devPortalTeamId.set(value)
+    }
+
+    PilotUpload devPortalTeamId(String value) {
+        setDevPortalTeamId(value)
+        this
+    }
+
+    PilotUpload devPortalTeamId(Provider<String> value) {
+        setDevPortalTeamId(value)
+        this
+    }
+
+    final Property<String> itcProvider
+
+    void setItcProvider(String value) {
+        itcProvider.set(value)
+    }
+
+    void setItcProvider(Provider<String> value) {
+        itcProvider.set(value)
+    }
+
+    PilotUpload itcProvider(String value) {
+        setItcProvider(value)
+        this
+    }
+
+    PilotUpload itcProvider(Provider<String> value) {
+        setItcProvider(value)
+        this
+    }
+
+    final Property<Boolean> skipSubmission
+
+    void setSkipSubmission(Boolean value) {
+        skipSubmission.set(value)
+    }
+
+    void setSkipSubmission(Provider<Boolean> value) {
+        skipSubmission.set(value)
+    }
+
+    PilotUpload skipSubmission(Boolean value) {
+        setSkipSubmission(value)
+        this
+    }
+
+    PilotUpload skipSubmission(Provider<Boolean> value) {
+        setSkipSubmission(value)
+        this
+    }
+
+    final Property<Boolean> skipWaitingForBuildProcessing
+
+    void setSkipWaitingForBuildProcessing(Boolean value) {
+        skipWaitingForBuildProcessing.set(value)
+    }
+
+    void setSkipWaitingForBuildProcessing(Provider<Boolean> value) {
+        skipWaitingForBuildProcessing.set(value)
+    }
+
+    PilotUpload skipWaitingForBuildProcessing(Boolean value) {
+        setSkipWaitingForBuildProcessing(value)
+        this
+    }
+
+    PilotUpload skipWaitingForBuildProcessing(Provider<Boolean> value) {
+        setSkipWaitingForBuildProcessing(value)
+        this
+    }
+
+    @Input
+    final Provider<List<String>> arguments
+
+    @Input
+    final Provider<Map<String, String>> environment
+
+    PilotUpload() {
+        ipa = project.layout.fileProperty()
+        appIdentifier = project.objects.property(String)
+        teamId = project.objects.property(String)
+        devPortalTeamId = project.objects.property(String)
+        teamName = project.objects.property(String)
+        username = project.objects.property(String)
+        password = project.objects.property(String)
+        itcProvider = project.objects.property(String)
+        skipSubmission = project.objects.property(Boolean)
+        skipWaitingForBuildProcessing = project.objects.property(Boolean)
+
+        outputs.upToDateWhen(new Spec<Task>() {
+            @Override
+            boolean isSatisfiedBy(Task task) {
+                false
+            }
+        })
+
+        environment = project.provider({
+            Map<String, String> environment = [:]
+
+            if (password.isPresent()) {
+                environment['FASTLANE_PASSWORD'] = password.get()
+            }
+
+            environment
+        })
+
+        arguments = project.provider({
+            List<String> arguments = new ArrayList<String>()
+
+            arguments << "pilot" << "upload"
+
+            if (username.present) {
+                arguments << "--username" << username.get()
+            }
+
+            if (teamId.present) {
+                arguments << "--team_id" << teamId.get()
+            }
+
+            if (teamName.present) {
+                arguments << "--team_name" << teamName.get()
+            }
+
+            if (devPortalTeamId.present) {
+                arguments << "--dev_portal_team_id" << devPortalTeamId.get()
+            }
+
+            if (appIdentifier.present) {
+                arguments << "--app_identifier" << appIdentifier.get()
+            }
+
+            if (itcProvider.present) {
+                arguments << "--itc_provider" << itcProvider.get()
+            }
+
+            arguments << "--skip_submission" << (skipSubmission.present && skipSubmission.get()).toString()
+            arguments << "--skip_waiting_for_build_processing" << (skipWaitingForBuildProcessing.present && skipWaitingForBuildProcessing.get()).toString()
+            arguments << "--ipa" << ipa.get().asFile.path
+
+            if (additionalArguments.present) {
+                additionalArguments.get().each {
+                    arguments << it
+                }
+            }
+
+            arguments
+        })
+    }
+}

--- a/src/main/groovy/wooga/gradle/macOS/security/InteractiveSecurityActionSpec.groovy
+++ b/src/main/groovy/wooga/gradle/macOS/security/InteractiveSecurityActionSpec.groovy
@@ -1,0 +1,9 @@
+package wooga.gradle.macOS.security
+
+import org.gradle.api.file.RegularFile
+import org.gradle.api.provider.Provider
+
+interface InteractiveSecurityActionSpec<T extends InteractiveSecurityActionSpec> {
+    Provider<List<String>> getSecurityCommands()
+    Provider<RegularFile> getTempLockFile()
+}

--- a/src/main/groovy/wooga/gradle/macOS/security/internal/InteractiveSecurityAction.groovy
+++ b/src/main/groovy/wooga/gradle/macOS/security/internal/InteractiveSecurityAction.groovy
@@ -1,0 +1,58 @@
+package wooga.gradle.macOS.security.internal
+
+import org.gradle.api.Action
+import org.gradle.api.Project
+import org.gradle.process.ExecResult
+import org.gradle.process.ExecSpec
+import org.gradle.process.internal.ExecException
+
+import java.nio.charset.StandardCharsets
+import java.util.logging.Logger
+
+class InteractiveSecurityAction {
+    Logger logger = Logger.getLogger(InteractiveSecurityAction.name)
+
+    final Project project
+    final List<String> commands
+    final File tempLockFile
+
+    InteractiveSecurityAction(Project project, List<String> commands, File tempLockFile) {
+        this.project = project
+        this.commands = commands
+        this.tempLockFile = tempLockFile
+    }
+
+    ExecResult exec() {
+        logger.info("Run security tasks:")
+        logger.info(commands.join("\n").replaceAll("-([p|P]) '.*'") { _, flag ->
+            "-${flag} ****"
+        })
+
+        def stdout = new ByteArrayOutputStream()
+        def stderr = new ByteArrayOutputStream()
+
+        def execResult = project.exec(new Action<ExecSpec>() {
+            @Override
+            void execute(ExecSpec execSpec) {
+                execSpec.executable "security"
+                execSpec.args "-i"
+                execSpec.standardInput = new ByteArrayInputStream(commands.join("\n").getBytes(StandardCharsets.UTF_8))
+                execSpec.ignoreExitValue = true
+                execSpec.standardOutput = stdout
+                execSpec.errorOutput = stderr
+            }
+        })
+
+        logger.info(stdout.toString())
+        if (execResult.exitValue != 0) {
+            logger.error(stderr.toString())
+            throw new ExecException(stderr.toString())
+        }
+
+        if (tempLockFile.exists()) {
+            tempLockFile.deleteOnExit()
+            tempLockFile.delete()
+        }
+        execResult
+    }
+}

--- a/src/main/groovy/wooga/gradle/macOS/security/internal/SecurityKeychainSettingsSpec.groovy
+++ b/src/main/groovy/wooga/gradle/macOS/security/internal/SecurityKeychainSettingsSpec.groovy
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wooga.gradle.macOS.security.internal
+
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Input
+
+trait SecurityKeychainSettingsSpec extends SecurityKeychainSpec {
+
+    final Property<Boolean> lockKeychainWhenSleep = project.objects.property(Boolean)
+    
+    void setLockKeychainWhenSleep(Boolean value) {
+        lockKeychainWhenSleep.set(value)
+    }
+    
+    void setLockKeychainWhenSleep(Provider<Boolean> value) {
+        lockKeychainWhenSleep.set(value)
+    }
+    
+    SecurityKeychainSettingsSpec lockKeychainWhenSleep(Boolean value) {
+        setLockKeychainWhenSleep(value)
+        this
+    }
+    
+    SecurityKeychainSettingsSpec lockKeychainWhenSleep(Provider<Boolean> value) {
+        setLockKeychainWhenSleep(value)
+        this
+    }
+    
+    final Property<Integer> lockKeychainAfterTimeout = project.objects.property(Integer)
+    
+    void setLockKeychainAfterTimeout(Integer value) {
+        lockKeychainAfterTimeout.set(value)
+    }
+    
+    void setLockKeychainAfterTimeout(Provider<Integer> value) {
+        lockKeychainAfterTimeout.set(value)
+    }
+    
+    SecurityKeychainSettingsSpec lockKeychainAfterTimeout(Integer value) {
+        setLockKeychainAfterTimeout(value)
+        this
+    }
+    
+    SecurityKeychainSettingsSpec lockKeychainAfterTimeout(Provider<Integer> value) {
+        setLockKeychainAfterTimeout(value)
+        this
+    }
+
+    @Input
+    List<String> getKeychainSettingsArguments() {
+        def arguments = []
+        if(lockKeychainWhenSleep.present && lockKeychainWhenSleep.get()) {
+            arguments << "-l"
+        }
+
+        if(lockKeychainAfterTimeout.present) {
+            arguments << "-u" << "-t" << lockKeychainAfterTimeout.get().toString()
+        }
+        arguments
+    }
+}

--- a/src/main/groovy/wooga/gradle/macOS/security/internal/SecurityKeychainSpec.groovy
+++ b/src/main/groovy/wooga/gradle/macOS/security/internal/SecurityKeychainSpec.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wooga.gradle.macOS.security.internal
+
+import org.gradle.api.Project
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Input
+
+trait SecurityKeychainSpec {
+    abstract Project getProject()
+
+    @Input
+    Property<String> password = project.objects.property(String)
+
+    void setPassword(String value) {
+        password.set(value)
+    }
+
+    void setPassword(Provider<String> value) {
+        password.set(value)
+    }
+
+    SecurityKeychainSpec password(String value) {
+        setPassword(value)
+        this
+    }
+
+    SecurityKeychainSpec password(Provider<String> value) {
+        setPassword(value)
+        this
+    }
+}

--- a/src/main/groovy/wooga/gradle/macOS/security/tasks/AbstractInteractiveSecurityTask.groovy
+++ b/src/main/groovy/wooga/gradle/macOS/security/tasks/AbstractInteractiveSecurityTask.groovy
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wooga.gradle.macOS.security.tasks
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
+import wooga.gradle.macOS.security.InteractiveSecurityActionSpec
+import wooga.gradle.macOS.security.internal.InteractiveSecurityAction
+
+import java.security.MessageDigest
+
+abstract class AbstractInteractiveSecurityTask extends DefaultTask implements InteractiveSecurityActionSpec {
+
+    static String getTempKeychainFileName(String keychainName) {
+        MessageDigest digest = MessageDigest.getInstance("SHA-1")
+        digest.update(keychainName.getBytes("ASCII"))
+        byte[] passwordDigest = digest.digest()
+        String hexString = passwordDigest.collect { String.format('%02x', it) }.join()
+        ".fl${hexString.substring(0, 8).toUpperCase()}"
+    }
+
+    @TaskAction
+    protected void exec() {
+        def action = new InteractiveSecurityAction(project, securityCommands.get(), tempLockFile.get().asFile)
+        action.exec()
+    }
+}

--- a/src/main/groovy/wooga/gradle/macOS/security/tasks/SecurityCreateKeychain.groovy
+++ b/src/main/groovy/wooga/gradle/macOS/security/tasks/SecurityCreateKeychain.groovy
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wooga.gradle.macOS.security.tasks
+
+import org.gradle.api.file.Directory
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFile
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputFile
+import wooga.gradle.macOS.security.internal.SecurityKeychainSettingsSpec
+
+class SecurityCreateKeychain extends AbstractInteractiveSecurityTask implements SecurityKeychainSettingsSpec {
+
+    final Property<String> fileName
+
+    void setFileName(String value) {
+        fileName.set(value)
+    }
+
+    void setFileName(Provider<String> value) {
+        fileName.set(value)
+    }
+
+    SecurityCreateKeychain fileName(String value) {
+        setFileName(value)
+        this
+    }
+
+    SecurityCreateKeychain fileName(Provider<String> value) {
+        setFileName(value)
+        this
+    }
+
+    final Property<String> baseName
+
+    void setBaseName(String value) {
+        baseName.set(value)
+    }
+
+    void setBaseName(Provider<String> value) {
+        baseName.set(value)
+    }
+
+    SecurityCreateKeychain baseName(String value) {
+        setBaseName(value)
+        this
+    }
+
+    SecurityCreateKeychain baseName(Provider<String> value) {
+        setBaseName(value)
+        this
+    }
+
+    final Property<String> extension
+
+    void setExtension(String value) {
+        extension.set(value)
+    }
+
+    void setExtension(Provider<String> value) {
+        extension.set(value)
+    }
+
+    SecurityCreateKeychain extension(String value) {
+        setExtension(value)
+        this
+    }
+
+    SecurityCreateKeychain extension(Provider<String> value) {
+        setExtension(value)
+        this
+    }
+
+    final DirectoryProperty destinationDir
+
+    void setDestinationDir(File value) {
+        destinationDir.set(value)
+    }
+
+    void setDestinationDir(Provider<Directory> value) {
+        destinationDir.set(value)
+    }
+
+    SecurityCreateKeychain destinationDir(File value) {
+        setDestinationDir(value)
+        this
+    }
+
+    SecurityCreateKeychain destinationDir(Provider<Directory> value) {
+        setDestinationDir(value)
+        this
+    }
+
+    @OutputFile
+    final Provider<RegularFile> keychain
+
+    @Internal
+    final Provider<RegularFile> tempLockFile
+
+    @Internal
+    final Provider<List<String>> securityCommands
+
+    SecurityCreateKeychain() {
+        baseName = project.objects.property(String)
+        extension = project.objects.property(String)
+        fileName = project.objects.property(String)
+
+        fileName.set(baseName.map({
+            if (extension.present) {
+                return it + "." + extension.get()
+            }
+            it
+        }))
+
+        destinationDir = project.layout.directoryProperty()
+        keychain = destinationDir.file(fileName)
+        tempLockFile = destinationDir.file(fileName.map({
+            getTempKeychainFileName(it)
+        }))
+
+       securityCommands = project.provider({
+            List<String> commands = new ArrayList()
+            commands << "create-keychain -p '${password.get()}' ${keychain.get()}"
+            commands << "unlock-keychain -p '${password.get()}' ${keychain.get()}"
+            def keychainSettingsArgs = getKeychainSettingsArguments()
+            if(!keychainSettingsArgs.isEmpty()) {
+                commands << "set-keychain-settings ${getKeychainSettingsArguments().join(" ")} ${keychain.get()}"
+            }
+
+            commands
+        })
+    }
+}


### PR DESCRIPTION
## Description

As with the other lasts patches this one adds a new refactored taskimplementation for an older task. The new task `SecurityCreateKeychainIntegration` will partly replace `KeychainTask` from the `net.wooga.build-unity-ios`. I decided to split this task and create a separate task to import certificates. I'm still unsure if I should do the same for the keychain settings logic.

I tried something new with this patch. I moved some boilerplate propertie definitions into groovy trait objects. This allows me to reuse the same properties in multiple task classes without using inheritance.

## Changes

*![ADD] ![MACOS] security task `SecurityCreateKeychainIntegration`

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"