### PR TITLE
Add additional keychain commands

### DIFF
--- a/lib/macos-security/src/main/groovy/com/wooga/security/Domain.groovy
+++ b/lib/macos-security/src/main/groovy/com/wooga/security/Domain.groovy
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.wooga.security
+
+enum Domain {
+    user, system, common, dynamic
+}

--- a/lib/macos-security/src/main/groovy/com/wooga/security/command/DefaultKeychain.groovy
+++ b/lib/macos-security/src/main/groovy/com/wooga/security/command/DefaultKeychain.groovy
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.wooga.security.command
+
+import com.wooga.security.Domain
+
+/*
+ *  default-keychain [-h] [-d user|system|common|dynamic] [-s [keychain]]
+ *             Display or set the default keychain.
+ *
+ *             -d user|system|common|dynamic
+ *                      Use the specified preference domain.
+ *             -s       Set the default keychain to the specified keychain.
+ *                      Unset it if no keychain is specified.
+ */
+
+class DefaultKeychain extends SecurityCommand<File> implements KeychainCommand<DefaultKeychain> {
+    String command = "default-keychain"
+
+    Domain domain
+
+    DefaultKeychain withDomain(Domain value) {
+        this.domain = value
+        this
+    }
+
+    Boolean setDefaultKeychain
+
+    DefaultKeychain setDefaultKeychain(Boolean value = true) {
+        this.setDefaultKeychain = value
+        this
+    }
+
+    @Override
+    protected List<String> getArguments() {
+        def arguments = []
+        if (domain) {
+            arguments << "-d" << domain.toString()
+        }
+        if (setDefaultKeychain) {
+            arguments << "-s"
+            arguments.addAll(getOptionalKeychainArgument())
+        }
+        arguments
+    }
+
+    @Override
+    protected File convertResult(String output) {
+        if (!output) {
+            return null
+        }
+        new File(output.trim().replaceAll(/^"|"$/, ''))
+    }
+}

--- a/lib/macos-security/src/main/groovy/com/wooga/security/command/ListKeychains.groovy
+++ b/lib/macos-security/src/main/groovy/com/wooga/security/command/ListKeychains.groovy
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.wooga.security.command
+
+import com.wooga.security.Domain
+
+/*
+ * list-keychains [-h] [-d user|system|common|dynamic] [-s [keychain...]]
+ *             Display or manipulate the keychain search list.
+ *
+ *             -d user|system|common|dynamic
+ *                      Use the specified preference domain.
+ *             -s       Set the search list to the specified keychains.
+ */
+
+class ListKeychains extends SecurityCommand<List<File>> implements MultiKeychainCommand<ListKeychains> {
+    String command = "list-keychains"
+
+    Domain domain
+
+    ListKeychains withDomain(Domain value) {
+        this.domain = value
+        this
+    }
+
+    Boolean setKeychainSearchList
+
+    ListKeychains setKeychainSearchList(Boolean value = true) {
+        this.setKeychainSearchList = value
+        this
+    }
+
+    @Override
+    protected List<String> getArguments() {
+        def arguments = []
+        if (domain) {
+            arguments << "-d" << domain.toString()
+        }
+        if (setKeychainSearchList) {
+            arguments << "-s"
+            arguments.addAll(getMultiKeychainsArgument())
+        }
+        arguments
+    }
+
+    @Override
+    protected List<File> convertResult(String output) {
+        if (!output) {
+            return []
+        }
+        output.readLines().collect { new File(it.trim().replaceAll(/^"|"$/, '')) }
+    }
+}

--- a/lib/macos-security/src/main/groovy/com/wooga/security/command/LoginKeychain.groovy
+++ b/lib/macos-security/src/main/groovy/com/wooga/security/command/LoginKeychain.groovy
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.wooga.security.command
+
+import com.wooga.security.Domain
+
+class LoginKeychain extends SecurityCommand<File> implements KeychainCommand<LoginKeychain> {
+    String command = "login-keychain"
+
+    Domain domain
+
+    LoginKeychain withDomain(Domain value) {
+        this.domain = value
+        this
+    }
+
+    Boolean setLoginKeychain
+
+    LoginKeychain setLoginKeychain(Boolean value = true) {
+        this.setLoginKeychain = value
+        this
+    }
+
+    @Override
+    protected List<String> getArguments() {
+        def arguments = []
+        if (domain) {
+            arguments << "-d" << domain.toString()
+        }
+        if (setLoginKeychain) {
+            arguments << "-s"
+            arguments.addAll(getOptionalKeychainArgument())
+        }
+        arguments
+    }
+
+    @Override
+    protected File convertResult(String output) {
+        if (!output) {
+            return null
+        }
+        new File(output.trim().replaceAll(/^"|"$/, ''))
+    }
+}

--- a/lib/macos-security/src/main/groovy/com/wooga/security/command/MultiKeychainCommand.groovy
+++ b/lib/macos-security/src/main/groovy/com/wooga/security/command/MultiKeychainCommand.groovy
@@ -31,6 +31,11 @@ trait MultiKeychainCommand<T extends SecurityCommand> {
         this as T
     }
 
+    T withKeychains(Iterable<File> value) {
+        this.keychains.addAll(value)
+        this as T
+    }
+
     List<String> getMultiKeychainsArgument() {
         def arguments = []
         if (!keychains.empty) {

--- a/lib/macos-security/src/test/groovy/com/wooga/security/command/DefaultKeychainSpec.groovy
+++ b/lib/macos-security/src/test/groovy/com/wooga/security/command/DefaultKeychainSpec.groovy
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.wooga.security.command
+
+import com.wooga.security.Domain
+import spock.lang.Requires
+import spock.lang.Unroll
+
+@Requires({os.macOs})
+class DefaultKeychainSpec extends SecurityCommandSpec<DefaultKeychain> {
+    DefaultKeychain command = new DefaultKeychain()
+
+    def "returns default keychain"() {
+        when:
+        def result = command.execute()
+
+        then:
+        result != null
+        result.exists()
+    }
+
+    @Unroll("fails with #expectedExeption when #reason")
+    def "fails with exception when property is invalid"() {
+        given: "invalid keychain"
+        command.setProperty(property, value)
+        command.setDefaultKeychain()
+
+        when:
+        command.execute()
+
+        then:
+        def e = thrown(expectedExeption)
+        e.message.matches(messagePattern)
+
+        where:
+        property   | value                  | expectedExeption               | message
+        "keychain" | new File("/some/file") | IllegalArgumentException.class | "does not exist"
+        "keychain" | File.createTempDir()   | IllegalArgumentException.class | "is not a file"
+
+        reason = "provided ${property} ${message}"
+        messagePattern = /provided keychain.*${message}/
+    }
+
+    @Unroll("property #property sets commandline flag #commandlineFlag")
+    def "property sets commandline"() {
+        given: "set property"
+        command.invokeMethod(method, value)
+
+        when:
+        def arguments = command.getArguments().join(" ")
+        then:
+        arguments.contains(expectedArguments)
+
+        where:
+        property             | commandlineFlag | value
+        "setDefaultKeychain" | "-s"            | true
+        "domain"             | "-d"            | Domain.user
+        expectedArguments = Boolean.isInstance(value) ? "${commandlineFlag}" : "${commandlineFlag} ${value.toString()}"
+        method = Boolean.isInstance(value) ? property : "with${property.capitalize()}"
+    }
+}

--- a/lib/macos-security/src/test/groovy/com/wooga/security/command/ListKeychainsSpec.groovy
+++ b/lib/macos-security/src/test/groovy/com/wooga/security/command/ListKeychainsSpec.groovy
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.wooga.security.command
+
+import com.wooga.security.Domain
+import spock.lang.Requires
+import spock.lang.Unroll
+
+@Requires({os.macOs})
+class ListKeychainsSpec extends SecurityCommandSpec<ListKeychains> {
+    ListKeychains command = new ListKeychains()
+
+    def "lists keychain lookup list"() {
+        when:
+        def result = command.execute()
+
+        then:
+        result != null
+        !result.empty
+    }
+
+    @Unroll("fails with #expectedExeption when #reason")
+    def "fails with exception when property is invalid"() {
+        given: "invalid keychain"
+        command.setProperty(property, value)
+        command.setKeychainSearchList()
+
+        when:
+        command.execute()
+
+        then:
+        def e = thrown(expectedExeption)
+        e.message.matches(messagePattern)
+
+        where:
+        property    | value                    | expectedExeption               | message
+        "keychains" | [new File("/some/file")] | IllegalArgumentException.class | "does not exist"
+        "keychains" | [File.createTempDir()]   | IllegalArgumentException.class | "is not a file"
+
+        reason = "provided ${property} ${message}"
+        messagePattern = /provided keychain.*${message}/
+    }
+
+    @Unroll("property #property sets commandline flag #commandlineFlag")
+    def "property sets commandline"() {
+        given: "set property"
+        command.invokeMethod(method, value)
+
+        when:
+        def arguments = command.getArguments().join(" ")
+        then:
+        arguments.contains(expectedArguments)
+
+        where:
+        property                | commandlineFlag | value
+        "setKeychainSearchList" | "-s"            | true
+        "domain"                | "-d"            | Domain.user
+        expectedArguments = Boolean.isInstance(value) ? "${commandlineFlag}" : "${commandlineFlag} ${value.toString()}"
+        method = Boolean.isInstance(value) ? property : "with${property.capitalize()}"
+    }
+}

--- a/lib/macos-security/src/test/groovy/com/wooga/security/command/LoginKeychainSpec.groovy
+++ b/lib/macos-security/src/test/groovy/com/wooga/security/command/LoginKeychainSpec.groovy
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.wooga.security.command
+
+import com.wooga.security.Domain
+import spock.lang.Requires
+import spock.lang.Unroll
+
+@Requires({ os.macOs })
+class LoginKeychainSpec extends SecurityCommandSpec<LoginKeychain> {
+    LoginKeychain command = new LoginKeychain()
+
+    def "returns login keychain"() {
+        when:
+        def result = command.execute()
+
+        then:
+        result != null
+        result.exists()
+    }
+
+    @Unroll("fails with #expectedExeption when #reason")
+    def "fails with exception when property is invalid"() {
+        given: "invalid keychain"
+        command.setProperty(property, value)
+        command.setLoginKeychain()
+
+        when:
+        command.execute()
+
+        then:
+        def e = thrown(expectedExeption)
+        e.message.matches(messagePattern)
+
+        where:
+        property   | value                  | expectedExeption               | message
+        "keychain" | new File("/some/file") | IllegalArgumentException.class | "does not exist"
+        "keychain" | File.createTempDir()   | IllegalArgumentException.class | "is not a file"
+
+        reason = "provided ${property} ${message}"
+        messagePattern = /provided keychain.*${message}/
+    }
+
+    @Unroll("property #property sets commandline flag #commandlineFlag")
+    def "property sets commandline"() {
+        given: "set property"
+        command.invokeMethod(method, value)
+
+        when:
+        def arguments = command.getArguments().join(" ")
+        then:
+        arguments.contains(expectedArguments)
+
+        where:
+        property           | commandlineFlag | value
+        "setLoginKeychain" | "-s"            | true
+        "domain"           | "-d"            | Domain.user
+        expectedArguments = Boolean.isInstance(value) ? "${commandlineFlag}" : "${commandlineFlag} ${value.toString()}"
+        method = Boolean.isInstance(value) ? property : "with${property.capitalize()}"
+    }
+}


### PR DESCRIPTION
## Description

Add new keychain command implementations for:

* list-keychains
* default-keychain
* login-keychain

## Changes

* ![ADD] `ListKeychains` security command
* ![ADD] `DefaultKeychain` security command
* ![ADD] `LoginKeychain` security command

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
