### PR TITLE
Throw NullPointerException if provided securtity command parameter is null

### DIFF
--- a/lib/macos-security/src/main/groovy/com/wooga/security/Domain.groovy
+++ b/lib/macos-security/src/main/groovy/com/wooga/security/Domain.groovy
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.wooga.security
+
+enum Domain {
+    user, system, common, dynamic
+}

--- a/lib/macos-security/src/main/groovy/com/wooga/security/command/CreateKeychain.groovy
+++ b/lib/macos-security/src/main/groovy/com/wooga/security/command/CreateKeychain.groovy
@@ -67,7 +67,7 @@ class CreateKeychain extends SecurityCommand<MacOsKeychain> {
         arguments << "-p" << password
 
         if (!location) {
-            throw new IllegalArgumentException("provided location is null")
+            throw new NullPointerException("provided location is null")
         }
 
         arguments << location.path

--- a/lib/macos-security/src/main/groovy/com/wooga/security/command/DefaultKeychain.groovy
+++ b/lib/macos-security/src/main/groovy/com/wooga/security/command/DefaultKeychain.groovy
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.wooga.security.command
+
+import com.wooga.security.Domain
+
+/*
+ *  default-keychain [-h] [-d user|system|common|dynamic] [-s [keychain]]
+ *             Display or set the default keychain.
+ *
+ *             -d user|system|common|dynamic
+ *                      Use the specified preference domain.
+ *             -s       Set the default keychain to the specified keychain.
+ *                      Unset it if no keychain is specified.
+ */
+
+class DefaultKeychain extends SecurityCommand<File> implements KeychainCommand<DefaultKeychain> {
+    String command = "default-keychain"
+
+    Domain domain
+
+    DefaultKeychain withDomain(Domain value) {
+        this.domain = value
+        this
+    }
+
+    Boolean setDefaultKeychain
+
+    DefaultKeychain setDefaultKeychain(Boolean value = true) {
+        this.setDefaultKeychain = value
+        this
+    }
+
+    @Override
+    protected List<String> getArguments() {
+        def arguments = []
+        if (domain) {
+            arguments << "-d" << domain.toString()
+        }
+        if (setDefaultKeychain) {
+            arguments << "-s"
+            arguments.addAll(getOptionalKeychainArgument())
+        }
+        arguments
+    }
+
+    @Override
+    protected File convertResult(String output) {
+        if (!output) {
+            return null
+        }
+        new File(output.trim().replaceAll(/^"|"$/, ''))
+    }
+}

--- a/lib/macos-security/src/main/groovy/com/wooga/security/command/ListKeychains.groovy
+++ b/lib/macos-security/src/main/groovy/com/wooga/security/command/ListKeychains.groovy
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.wooga.security.command
+
+import com.wooga.security.Domain
+
+/*
+ * list-keychains [-h] [-d user|system|common|dynamic] [-s [keychain...]]
+ *             Display or manipulate the keychain search list.
+ *
+ *             -d user|system|common|dynamic
+ *                      Use the specified preference domain.
+ *             -s       Set the search list to the specified keychains.
+ */
+
+class ListKeychains extends SecurityCommand<List<File>> implements MultiKeychainCommand<ListKeychains> {
+    String command = "list-keychains"
+
+    Domain domain
+
+    ListKeychains withDomain(Domain value) {
+        this.domain = value
+        this
+    }
+
+    Boolean setKeychainSearchList
+
+    ListKeychains setKeychainSearchList(Boolean value = true) {
+        this.setKeychainSearchList = value
+        this
+    }
+
+    @Override
+    protected List<String> getArguments() {
+        def arguments = []
+        if (domain) {
+            arguments << "-d" << domain.toString()
+        }
+        if (setKeychainSearchList) {
+            arguments << "-s"
+            arguments.addAll(getMultiKeychainsArgument())
+        }
+        arguments
+    }
+
+    @Override
+    protected List<File> convertResult(String output) {
+        if (!output) {
+            return []
+        }
+        output.readLines().collect { new File(it.trim().replaceAll(/^"|"$/, '')) }
+    }
+}

--- a/lib/macos-security/src/main/groovy/com/wooga/security/command/LoginKeychain.groovy
+++ b/lib/macos-security/src/main/groovy/com/wooga/security/command/LoginKeychain.groovy
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.wooga.security.command
+
+import com.wooga.security.Domain
+
+class LoginKeychain extends SecurityCommand<File> implements KeychainCommand<LoginKeychain> {
+    String command = "login-keychain"
+
+    Domain domain
+
+    LoginKeychain withDomain(Domain value) {
+        this.domain = value
+        this
+    }
+
+    Boolean setLoginKeychain
+
+    LoginKeychain setLoginKeychain(Boolean value = true) {
+        this.setLoginKeychain = value
+        this
+    }
+
+    @Override
+    protected List<String> getArguments() {
+        def arguments = []
+        if (domain) {
+            arguments << "-d" << domain.toString()
+        }
+        if (setLoginKeychain) {
+            arguments << "-s"
+            arguments.addAll(getOptionalKeychainArgument())
+        }
+        arguments
+    }
+
+    @Override
+    protected File convertResult(String output) {
+        if (!output) {
+            return null
+        }
+        new File(output.trim().replaceAll(/^"|"$/, ''))
+    }
+}

--- a/lib/macos-security/src/main/groovy/com/wooga/security/command/MultiKeychainCommand.groovy
+++ b/lib/macos-security/src/main/groovy/com/wooga/security/command/MultiKeychainCommand.groovy
@@ -31,6 +31,11 @@ trait MultiKeychainCommand<T extends SecurityCommand> {
         this as T
     }
 
+    T withKeychains(Iterable<File> value) {
+        this.keychains.addAll(value)
+        this as T
+    }
+
     List<String> getMultiKeychainsArgument() {
         def arguments = []
         if (!keychains.empty) {

--- a/lib/macos-security/src/main/groovy/com/wooga/security/command/SecurityCommand.groovy
+++ b/lib/macos-security/src/main/groovy/com/wooga/security/command/SecurityCommand.groovy
@@ -87,7 +87,7 @@ abstract class SecurityCommand<T> {
 
     static void validateStringProperty(String value, String propertyName) {
         if (value == null) {
-            throw new IllegalArgumentException("provided ${propertyName} is null")
+            throw new NullPointerException("provided ${propertyName} is null")
         }
 
         if (value.isEmpty()) {
@@ -97,7 +97,7 @@ abstract class SecurityCommand<T> {
 
     static void validateFileProperty(File file, String propertyName) {
         if (!file) {
-            throw new IllegalArgumentException("provided ${propertyName} is null")
+            throw new NullPointerException("provided ${propertyName} is null")
         }
 
         if (!file.exists()) {

--- a/lib/macos-security/src/test/groovy/com/wooga/security/command/AddGenericPasswordSpec.groovy
+++ b/lib/macos-security/src/test/groovy/com/wooga/security/command/AddGenericPasswordSpec.groovy
@@ -42,7 +42,7 @@ class AddGenericPasswordSpec extends AddPasswordSpec<AddGenericPassword> {
 
         where:
         property  | value | expectedExeption               | message
-        "service" | null  | IllegalArgumentException.class | "is null"
+        "service" | null  | NullPointerException.class     | "is null"
         "service" | ""    | IllegalArgumentException.class | "is empty"
         reason = "provided ${property} ${message}"
         messagePattern = /provided ${property}.*${message}/

--- a/lib/macos-security/src/test/groovy/com/wooga/security/command/AddInternetPasswordSpec.groovy
+++ b/lib/macos-security/src/test/groovy/com/wooga/security/command/AddInternetPasswordSpec.groovy
@@ -43,7 +43,7 @@ class AddInternetPasswordSpec extends AddPasswordSpec<AddInternetPassword> {
 
         where:
         property | value | expectedExeption               | message
-        "server" | null  | IllegalArgumentException.class | "is null"
+        "server" | null  | NullPointerException.class     | "is null"
         "server" | ""    | IllegalArgumentException.class | "is empty"
         reason = "provided ${property} ${message}"
         messagePattern = /provided ${property}.*${message}/

--- a/lib/macos-security/src/test/groovy/com/wooga/security/command/AddPasswordSpec.groovy
+++ b/lib/macos-security/src/test/groovy/com/wooga/security/command/AddPasswordSpec.groovy
@@ -50,10 +50,10 @@ abstract class AddPasswordSpec<T extends SecurityCommand> extends SecurityComman
         "keychain" | new File("/some/file") | IllegalArgumentException.class | "does not exist"
         "keychain" | File.createTempDir()   | IllegalArgumentException.class | "is not a file"
 
-        "account"  | null                   | IllegalArgumentException.class | "is null"
+        "account"  | null                   | NullPointerException.class     | "is null"
         "account"  | ""                     | IllegalArgumentException.class | "is empty"
 
-        "password" | null                   | IllegalArgumentException.class | "is null"
+        "password" | null                   | NullPointerException.class     | "is null"
         "password" | ""                     | IllegalArgumentException.class | "is empty"
         reason = "provided ${property} ${message}"
         messagePattern = /provided ${property}.*${message}/

--- a/lib/macos-security/src/test/groovy/com/wooga/security/command/CreateKeychainSpec.groovy
+++ b/lib/macos-security/src/test/groovy/com/wooga/security/command/CreateKeychainSpec.groovy
@@ -67,11 +67,11 @@ class CreateKeychainSpec extends SecurityCommandSpec<CreateKeychain> {
         e.message.contains(message)
 
         where:
-        property   | value         | expectedExeption               | message                                         | command
-        "password" | "is null"     | IllegalArgumentException.class | "provided password is null"                     | new CreateKeychain(null, createTempKeychainLocation())
-        "location" | "is null"     | IllegalArgumentException.class | "provided location is null"                     | new CreateKeychain(keychainPassword, null)
-        "location" | "a directory" | IOException.class              | "A keychain with the same name already exists." | new CreateKeychain(keychainPassword, File.createTempDir())
-        "location" | "exists"      | IOException.class              | "A keychain with the same name already exists." | new CreateKeychain(keychainPassword, File.createTempDir())
+        property   | value         | expectedExeption           | message                                         | command
+        "password" | "is null"     | NullPointerException.class | "provided password is null"                     | new CreateKeychain(null, createTempKeychainLocation())
+        "location" | "is null"     | NullPointerException.class | "provided location is null"                     | new CreateKeychain(keychainPassword, null)
+        "location" | "a directory" | IOException.class          | "A keychain with the same name already exists." | new CreateKeychain(keychainPassword, File.createTempDir())
+        "location" | "exists"      | IOException.class          | "A keychain with the same name already exists." | new CreateKeychain(keychainPassword, File.createTempDir())
         reason = "property '${property}' '${value}'"
     }
 

--- a/lib/macos-security/src/test/groovy/com/wooga/security/command/DefaultKeychainSpec.groovy
+++ b/lib/macos-security/src/test/groovy/com/wooga/security/command/DefaultKeychainSpec.groovy
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.wooga.security.command
+
+import com.wooga.security.Domain
+import spock.lang.Requires
+import spock.lang.Unroll
+
+@Requires({os.macOs})
+class DefaultKeychainSpec extends SecurityCommandSpec<DefaultKeychain> {
+    DefaultKeychain command = new DefaultKeychain()
+
+    def "returns default keychain"() {
+        when:
+        def result = command.execute()
+
+        then:
+        result != null
+        result.exists()
+    }
+
+    @Unroll("fails with #expectedExeption when #reason")
+    def "fails with exception when property is invalid"() {
+        given: "invalid keychain"
+        command.setProperty(property, value)
+        command.setDefaultKeychain()
+
+        when:
+        command.execute()
+
+        then:
+        def e = thrown(expectedExeption)
+        e.message.matches(messagePattern)
+
+        where:
+        property   | value                  | expectedExeption               | message
+        "keychain" | new File("/some/file") | IllegalArgumentException.class | "does not exist"
+        "keychain" | File.createTempDir()   | IllegalArgumentException.class | "is not a file"
+
+        reason = "provided ${property} ${message}"
+        messagePattern = /provided keychain.*${message}/
+    }
+
+    @Unroll("property #property sets commandline flag #commandlineFlag")
+    def "property sets commandline"() {
+        given: "set property"
+        command.invokeMethod(method, value)
+
+        when:
+        def arguments = command.getArguments().join(" ")
+        then:
+        arguments.contains(expectedArguments)
+
+        where:
+        property             | commandlineFlag | value
+        "setDefaultKeychain" | "-s"            | true
+        "domain"             | "-d"            | Domain.user
+        expectedArguments = Boolean.isInstance(value) ? "${commandlineFlag}" : "${commandlineFlag} ${value.toString()}"
+        method = Boolean.isInstance(value) ? property : "with${property.capitalize()}"
+    }
+}

--- a/lib/macos-security/src/test/groovy/com/wooga/security/command/FindGenericPasswordSpec.groovy
+++ b/lib/macos-security/src/test/groovy/com/wooga/security/command/FindGenericPasswordSpec.groovy
@@ -49,7 +49,7 @@ class FindGenericPasswordSpec extends FindPasswordSpec<FindGenericPassword> {
 
         where:
         property  | value | expectedExeption               | message
-        "service" | null  | IllegalArgumentException.class | "is null"
+        "service" | null  | NullPointerException.class     | "is null"
         "service" | ""    | IllegalArgumentException.class | "is empty"
         reason = "provided ${property} ${message}"
         messagePattern = /provided ${property}.*${message}/

--- a/lib/macos-security/src/test/groovy/com/wooga/security/command/FindInternetPasswordSpec.groovy
+++ b/lib/macos-security/src/test/groovy/com/wooga/security/command/FindInternetPasswordSpec.groovy
@@ -49,7 +49,7 @@ class FindInternetPasswordSpec extends FindPasswordSpec<FindInternetPassword> {
 
         where:
         property | value | expectedExeption               | message
-        "server" | null  | IllegalArgumentException.class | "is null"
+        "server" | null  | NullPointerException.class     | "is null"
         "server" | ""    | IllegalArgumentException.class | "is empty"
         reason = "provided ${property} ${message}"
         messagePattern = /provided ${property}.*${message}/

--- a/lib/macos-security/src/test/groovy/com/wooga/security/command/FindPasswordSpec.groovy
+++ b/lib/macos-security/src/test/groovy/com/wooga/security/command/FindPasswordSpec.groovy
@@ -56,7 +56,7 @@ abstract class FindPasswordSpec<T extends SecurityCommand> extends SecurityComma
         "keychains" | [new File("/some/file")] | IllegalArgumentException.class | "does not exist"
         "keychains" | [File.createTempDir()]   | IllegalArgumentException.class | "is not a file"
 
-        "account"   | null                     | IllegalArgumentException.class | "is null"
+        "account"   | null                     | NullPointerException.class     | "is null"
         "account"   | ""                       | IllegalArgumentException.class | "is empty"
         reason = "provided ${property} ${message}"
         propertyPattern = property == "keychains" ? "keychain" : property

--- a/lib/macos-security/src/test/groovy/com/wooga/security/command/ImportSpec.groovy
+++ b/lib/macos-security/src/test/groovy/com/wooga/security/command/ImportSpec.groovy
@@ -91,11 +91,11 @@ class ImportSpec extends SecurityCommandSpec<Import> {
 
         where:
         property    | value                  | expectedExeption               | message
-        "keychain"  | null                   | IllegalArgumentException.class | "is null"
+        "keychain"  | null                   | NullPointerException.class     | "is null"
         "keychain"  | new File("/some/file") | IllegalArgumentException.class | "does not exist"
         "keychain"  | File.createTempDir()   | IllegalArgumentException.class | "is not a file"
 
-        "inputFile" | null                   | IllegalArgumentException.class | "is null"
+        "inputFile" | null                   | NullPointerException.class     | "is null"
         "inputFile" | new File("/some/file") | IllegalArgumentException.class | "does not exist"
         "inputFile" | File.createTempDir()   | IllegalArgumentException.class | "is not a file"
 

--- a/lib/macos-security/src/test/groovy/com/wooga/security/command/ListKeychainsSpec.groovy
+++ b/lib/macos-security/src/test/groovy/com/wooga/security/command/ListKeychainsSpec.groovy
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.wooga.security.command
+
+import com.wooga.security.Domain
+import spock.lang.Requires
+import spock.lang.Unroll
+
+@Requires({os.macOs})
+class ListKeychainsSpec extends SecurityCommandSpec<ListKeychains> {
+    ListKeychains command = new ListKeychains()
+
+    def "lists keychain lookup list"() {
+        when:
+        def result = command.execute()
+
+        then:
+        result != null
+        !result.empty
+    }
+
+    @Unroll("fails with #expectedExeption when #reason")
+    def "fails with exception when property is invalid"() {
+        given: "invalid keychain"
+        command.setProperty(property, value)
+        command.setKeychainSearchList()
+
+        when:
+        command.execute()
+
+        then:
+        def e = thrown(expectedExeption)
+        e.message.matches(messagePattern)
+
+        where:
+        property    | value                    | expectedExeption               | message
+        "keychains" | [new File("/some/file")] | IllegalArgumentException.class | "does not exist"
+        "keychains" | [File.createTempDir()]   | IllegalArgumentException.class | "is not a file"
+
+        reason = "provided ${property} ${message}"
+        messagePattern = /provided keychain.*${message}/
+    }
+
+    @Unroll("property #property sets commandline flag #commandlineFlag")
+    def "property sets commandline"() {
+        given: "set property"
+        command.invokeMethod(method, value)
+
+        when:
+        def arguments = command.getArguments().join(" ")
+        then:
+        arguments.contains(expectedArguments)
+
+        where:
+        property                | commandlineFlag | value
+        "setKeychainSearchList" | "-s"            | true
+        "domain"                | "-d"            | Domain.user
+        expectedArguments = Boolean.isInstance(value) ? "${commandlineFlag}" : "${commandlineFlag} ${value.toString()}"
+        method = Boolean.isInstance(value) ? property : "with${property.capitalize()}"
+    }
+}

--- a/lib/macos-security/src/test/groovy/com/wooga/security/command/LoginKeychainSpec.groovy
+++ b/lib/macos-security/src/test/groovy/com/wooga/security/command/LoginKeychainSpec.groovy
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.wooga.security.command
+
+import com.wooga.security.Domain
+import spock.lang.Requires
+import spock.lang.Unroll
+
+@Requires({ os.macOs })
+class LoginKeychainSpec extends SecurityCommandSpec<LoginKeychain> {
+    LoginKeychain command = new LoginKeychain()
+
+    def "returns login keychain"() {
+        when:
+        def result = command.execute()
+
+        then:
+        result != null
+        result.exists()
+    }
+
+    @Unroll("fails with #expectedExeption when #reason")
+    def "fails with exception when property is invalid"() {
+        given: "invalid keychain"
+        command.setProperty(property, value)
+        command.setLoginKeychain()
+
+        when:
+        command.execute()
+
+        then:
+        def e = thrown(expectedExeption)
+        e.message.matches(messagePattern)
+
+        where:
+        property   | value                  | expectedExeption               | message
+        "keychain" | new File("/some/file") | IllegalArgumentException.class | "does not exist"
+        "keychain" | File.createTempDir()   | IllegalArgumentException.class | "is not a file"
+
+        reason = "provided ${property} ${message}"
+        messagePattern = /provided keychain.*${message}/
+    }
+
+    @Unroll("property #property sets commandline flag #commandlineFlag")
+    def "property sets commandline"() {
+        given: "set property"
+        command.invokeMethod(method, value)
+
+        when:
+        def arguments = command.getArguments().join(" ")
+        then:
+        arguments.contains(expectedArguments)
+
+        where:
+        property           | commandlineFlag | value
+        "setLoginKeychain" | "-s"            | true
+        "domain"           | "-d"            | Domain.user
+        expectedArguments = Boolean.isInstance(value) ? "${commandlineFlag}" : "${commandlineFlag} ${value.toString()}"
+        method = Boolean.isInstance(value) ? property : "with${property.capitalize()}"
+    }
+}

--- a/lib/macos-security/src/test/groovy/com/wooga/security/command/ShowKeychainInfoSpec.groovy
+++ b/lib/macos-security/src/test/groovy/com/wooga/security/command/ShowKeychainInfoSpec.groovy
@@ -55,7 +55,7 @@ class ShowKeychainInfoSpec extends SecurityCommandSpec<ShowKeychainInfo> {
 
         where:
         property   | expectedExeption               | message          | command
-        "keychain" | IllegalArgumentException.class | "is null"        | new ShowKeychainInfo((File) null)
+        "keychain" | NullPointerException.class     | "is null"        | new ShowKeychainInfo((File) null)
         "keychain" | IllegalArgumentException.class | "does not exist" | new ShowKeychainInfo(new File("/some/file"))
         "keychain" | IllegalArgumentException.class | "is not a file"  | new ShowKeychainInfo(File.createTempDir())
 


### PR DESCRIPTION
## Description

This is a small fix. This patch makes sure the security command implemenations throw `NullPointerException`s instead of `IllegalArgumentExceptions` when provided parameters are null or contain null in case of list based options.

## Changes

* ![IMPROVE] throw `NullPointerException` when provided parameter is null

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
