### PR TITLE
Add reimplementation of KeychainLookupList

### DIFF
--- a/lib/macos-security/build.gradle
+++ b/lib/macos-security/build.gradle
@@ -30,6 +30,7 @@ group "com.wooga.security"
 dependencies {
     implementation 'org.codehaus.groovy:groovy-all:2.4.15'
     testImplementation 'org.spockframework:spock-core:1.2-groovy-2.4'
+    testImplementation 'com.github.stefanbirkner:system-rules:1.18.0'
 }
 List<String> cliTasks = project.rootProject.gradle.startParameter.taskNames
 if (cliTasks.contains("rc")) {

--- a/lib/macos-security/src/main/groovy/com/wooga/security/Domain.groovy
+++ b/lib/macos-security/src/main/groovy/com/wooga/security/Domain.groovy
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.wooga.security
+
+enum Domain {
+    user, system, common, dynamic
+}

--- a/lib/macos-security/src/main/groovy/com/wooga/security/KeychainLookupList.groovy
+++ b/lib/macos-security/src/main/groovy/com/wooga/security/KeychainLookupList.groovy
@@ -1,0 +1,344 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.wooga.security
+
+import com.wooga.security.command.DefaultKeychain
+import com.wooga.security.command.ListKeychains
+
+class KeychainLookupList implements List<File>, Set<File> {
+
+    private class KeychainLookupIterator implements Iterator<File> {
+        private Iterator<File> innerIterator
+        private File current
+
+        KeychainLookupIterator(Iterator<File> innerIterator) {
+            this.innerIterator = innerIterator
+        }
+
+        @Override
+        boolean hasNext() {
+            return innerIterator.hasNext()
+        }
+
+        @Override
+        File next() {
+            current = innerIterator.next()
+            return current
+        }
+
+        @Override
+        void remove() {
+            remove(current)
+        }
+    }
+
+    private class KeychainLookupListIterator implements ListIterator<File> {
+        private ListIterator<File> innerIterator
+        private File current
+
+        KeychainLookupListIterator(ListIterator<File> innerIterator) {
+            this.innerIterator = innerIterator
+        }
+
+        @Override
+        boolean hasNext() {
+            return innerIterator.hasNext()
+        }
+
+        @Override
+        File next() {
+            current = innerIterator.next()
+            return current
+        }
+
+        @Override
+        void remove() {
+            remove(current)
+        }
+
+        @Override
+        boolean hasPrevious() {
+            return innerIterator.hasPrevious()
+        }
+
+        @Override
+        File previous() {
+            current = innerIterator.previous()
+            return current
+        }
+
+        @Override
+        int nextIndex() {
+            return innerIterator.nextIndex()
+        }
+
+        @Override
+        int previousIndex() {
+            return innerIterator.previousIndex()
+        }
+
+        @Override
+        void set(File file) {
+            throw new UnsupportedOperationException()
+        }
+
+        @Override
+        void add(File file) {
+            throw new UnsupportedOperationException()
+        }
+    }
+
+    private final Domain domain
+
+    KeychainLookupList(Domain domain) {
+        this.domain = domain
+    }
+
+    KeychainLookupList() {
+        this(Domain.user)
+    }
+
+    private static List<File> listKeychains(Domain domain) {
+        new ListKeychains().withDomain(domain).execute()
+    }
+
+    private static void setKeychains(Iterable<File> keychains, Domain domain) {
+        new ListKeychains().withDomain(domain).withKeychains(keychains).setKeychainSearchList().execute()
+    }
+
+    @Override
+    int size() {
+        listKeychains(domain).size()
+    }
+
+    @Override
+    boolean isEmpty() {
+        size() == 0
+    }
+
+    @Override
+    boolean contains(Object o) {
+        Objects.requireNonNull(o)
+
+        if (!File.isInstance(o)) {
+            throw new ClassCastException("expect object of type java.io.File")
+        }
+
+        File keychain = o as File
+        listKeychains(domain).contains(canonical(keychain))
+    }
+
+    @Override
+    Iterator<File> iterator() {
+        new KeychainLookupIterator(listKeychains(domain).iterator())
+    }
+
+    @Override
+    Object[] toArray() {
+        listKeychains(domain).toArray()
+    }
+
+    @Override
+    def <T> T[] toArray(T[] a) {
+        listKeychains(domain).toArray(a)
+    }
+
+    @Override
+    boolean add(File keychain) {
+        Objects.requireNonNull(keychain)
+        keychain = canonical(keychain)
+        def keychains = listKeychains(domain)
+        if (!keychains.contains(keychain) && keychains.add(keychain)) {
+            setKeychains(keychains, domain)
+            return true
+        }
+        false
+    }
+
+    @Override
+    boolean remove(Object o) {
+        Objects.requireNonNull(o)
+
+        if (!File.isInstance(o)) {
+            throw new ClassCastException("expect object of type java.io.File")
+        }
+
+        File k = canonical(o as File)
+        def keychains = listKeychains(domain)
+        if (keychains.remove(k)) {
+            setKeychains(keychains, domain)
+            return true
+        }
+        false
+    }
+
+    @Override
+    boolean containsAll(Collection<?> c) {
+        Objects.requireNonNull(c as Object)
+        def keychains = c.collect {
+            if (!File.isInstance(it)) {
+                throw new ClassCastException("expect object of type java.io.File")
+            }
+            canonical(it as File)
+        }
+        listKeychains(domain).containsAll(keychains)
+    }
+
+    @Override
+    boolean addAll(Collection<? extends File> c) {
+        Objects.requireNonNull(c)
+        def keychains = listKeychains(domain)
+        if (keychains.addAll(c)) {
+            setKeychains(keychains, domain)
+            return true
+        }
+        false
+    }
+
+    @Override
+    boolean addAll(int index, Collection<? extends File> c) {
+        throw new UnsupportedOperationException()
+    }
+
+    @Override
+    boolean removeAll(Collection<?> c) {
+        Objects.requireNonNull(c as Object)
+        def keychainsToRemove = c.collect {
+            if (!File.isInstance(it)) {
+                throw new ClassCastException("expect object of type java.io.File")
+            }
+            canonical(it as File)
+        }
+        def keychains = listKeychains(domain)
+        def result = keychains.removeAll(keychainsToRemove)
+        new ListKeychains().withDomain(domain).withKeychains(keychains).setKeychainSearchList().execute()
+        result
+    }
+
+    @Override
+    boolean retainAll(Collection<?> c) {
+        throw new UnsupportedOperationException()
+    }
+
+    @Override
+    void clear() {
+        reset()
+    }
+
+    void reset() {
+        resetKeychains(domain)
+    }
+
+    @Override
+    File get(int index) {
+        listKeychains(domain).get(index)
+    }
+
+    @Override
+    File set(int index, File element) {
+        throw new UnsupportedOperationException()
+    }
+
+    @Override
+    void add(int index, File element) {
+        throw new UnsupportedOperationException()
+    }
+
+    @Override
+    File remove(int index) {
+        throw new UnsupportedOperationException()
+    }
+
+    @Override
+    int indexOf(Object o) {
+        Objects.requireNonNull(o)
+
+        if (!File.isInstance(o)) {
+            throw new ClassCastException("expect object of type java.io.File")
+        }
+
+        listKeychains(domain).indexOf(canonical(o as File))
+    }
+
+    @Override
+    int lastIndexOf(Object o) {
+        Objects.requireNonNull(o)
+
+        if (!File.isInstance(o)) {
+            throw new ClassCastException("expect object of type java.io.File")
+        }
+
+        listKeychains(domain).lastIndexOf(canonical(o as File))
+    }
+
+    @Override
+    ListIterator<File> listIterator() {
+        listIterator(0)
+    }
+
+    @Override
+    ListIterator<File> listIterator(int index) {
+        new KeychainLookupListIterator(listKeychains(domain).listIterator(index))
+    }
+
+    @Override
+    List<File> subList(int fromIndex, int toIndex) {
+        listKeychains(domain).subList(fromIndex, toIndex)
+    }
+
+    File getLoginKeyChain() {
+        getLoginKeyChain(domain)
+    }
+
+    File getDefaultKeyChain() {
+        getDefaultKeyChain(domain)
+    }
+
+    static File getLoginKeyChain(Domain domain) {
+        new DefaultKeychain().withDomain(domain).execute()
+    }
+
+    static File getDefaultKeyChain(Domain domain) {
+        new DefaultKeychain().withDomain(domain).execute()
+    }
+
+    static String expandPath(String path) {
+        if (path.startsWith("~" + File.separator)) {
+            path = System.getProperty("user.home") + path.substring(1)
+        }
+        path
+    }
+
+    static File expandPath(File path) {
+        new File(expandPath(path.path))
+    }
+
+    static File canonical(File keychain) {
+        expandPath(keychain).canonicalFile
+    }
+
+    static void resetKeychains(Domain domain = Domain.user) {
+        def rawValue = System.getenv().get("ATLAS_BUILD_UNITY_IOS_DEFAULT_KEYCHAINS")
+        def defaultKeyChains
+        if (rawValue) {
+            defaultKeyChains = rawValue.split(File.pathSeparator).collect { canonical(new File(it)) }
+        } else {
+            defaultKeyChains = [getLoginKeyChain(domain), getDefaultKeyChain(domain)].unique()
+        }
+        setKeychains(defaultKeyChains, domain)
+    }
+}

--- a/lib/macos-security/src/main/groovy/com/wooga/security/command/CreateKeychain.groovy
+++ b/lib/macos-security/src/main/groovy/com/wooga/security/command/CreateKeychain.groovy
@@ -67,7 +67,7 @@ class CreateKeychain extends SecurityCommand<MacOsKeychain> {
         arguments << "-p" << password
 
         if (!location) {
-            throw new IllegalArgumentException("provided location is null")
+            throw new NullPointerException("provided location is null")
         }
 
         arguments << location.path

--- a/lib/macos-security/src/main/groovy/com/wooga/security/command/DefaultKeychain.groovy
+++ b/lib/macos-security/src/main/groovy/com/wooga/security/command/DefaultKeychain.groovy
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.wooga.security.command
+
+import com.wooga.security.Domain
+
+/*
+ *  default-keychain [-h] [-d user|system|common|dynamic] [-s [keychain]]
+ *             Display or set the default keychain.
+ *
+ *             -d user|system|common|dynamic
+ *                      Use the specified preference domain.
+ *             -s       Set the default keychain to the specified keychain.
+ *                      Unset it if no keychain is specified.
+ */
+
+class DefaultKeychain extends SecurityCommand<File> implements KeychainCommand<DefaultKeychain> {
+    String command = "default-keychain"
+
+    Domain domain
+
+    DefaultKeychain withDomain(Domain value) {
+        this.domain = value
+        this
+    }
+
+    Boolean setDefaultKeychain
+
+    DefaultKeychain setDefaultKeychain(Boolean value = true) {
+        this.setDefaultKeychain = value
+        this
+    }
+
+    @Override
+    protected List<String> getArguments() {
+        def arguments = []
+        if (domain) {
+            arguments << "-d" << domain.toString()
+        }
+        if (setDefaultKeychain) {
+            arguments << "-s"
+            arguments.addAll(getOptionalKeychainArgument())
+        }
+        arguments
+    }
+
+    @Override
+    protected File convertResult(String output) {
+        if (!output) {
+            return null
+        }
+        new File(output.trim().replaceAll(/^"|"$/, ''))
+    }
+}

--- a/lib/macos-security/src/main/groovy/com/wooga/security/command/KeychainCommand.groovy
+++ b/lib/macos-security/src/main/groovy/com/wooga/security/command/KeychainCommand.groovy
@@ -33,7 +33,7 @@ trait KeychainCommand<T extends SecurityCommand> {
     List<String> getMandatoryKeychainArguments() {
         def arguments = []
         SecurityCommand.validateKeychainProperty(keychain)
-        arguments << "-k" << keychain.path
+        arguments << "-k" << SecurityCommand.expandPath(keychain.canonicalPath)
         arguments
     }
 
@@ -41,7 +41,7 @@ trait KeychainCommand<T extends SecurityCommand> {
         def arguments = []
         if (keychain) {
             SecurityCommand.validateKeychainProperty(keychain)
-            arguments << keychain.path
+            arguments << SecurityCommand.expandPath(keychain.canonicalPath)
         }
         arguments
     }

--- a/lib/macos-security/src/main/groovy/com/wooga/security/command/ListKeychains.groovy
+++ b/lib/macos-security/src/main/groovy/com/wooga/security/command/ListKeychains.groovy
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.wooga.security.command
+
+import com.wooga.security.Domain
+
+/*
+ * list-keychains [-h] [-d user|system|common|dynamic] [-s [keychain...]]
+ *             Display or manipulate the keychain search list.
+ *
+ *             -d user|system|common|dynamic
+ *                      Use the specified preference domain.
+ *             -s       Set the search list to the specified keychains.
+ */
+
+class ListKeychains extends SecurityCommand<List<File>> implements MultiKeychainCommand<ListKeychains> {
+    String command = "list-keychains"
+
+    Domain domain
+
+    ListKeychains withDomain(Domain value) {
+        this.domain = value
+        this
+    }
+
+    Boolean setKeychainSearchList
+
+    ListKeychains setKeychainSearchList(Boolean value = true) {
+        this.setKeychainSearchList = value
+        this
+    }
+
+    @Override
+    protected List<String> getArguments() {
+        def arguments = []
+        if (domain) {
+            arguments << "-d" << domain.toString()
+        }
+        if (setKeychainSearchList) {
+            arguments << "-s"
+            arguments.addAll(getMultiKeychainsArgument())
+        }
+        arguments
+    }
+
+    @Override
+    protected List<File> convertResult(String output) {
+        if (!output) {
+            return []
+        }
+        output.readLines().collect { new File(it.trim().replaceAll(/^"|"$/, '')) }
+    }
+}

--- a/lib/macos-security/src/main/groovy/com/wooga/security/command/LoginKeychain.groovy
+++ b/lib/macos-security/src/main/groovy/com/wooga/security/command/LoginKeychain.groovy
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.wooga.security.command
+
+import com.wooga.security.Domain
+
+class LoginKeychain extends SecurityCommand<File> implements KeychainCommand<LoginKeychain> {
+    String command = "login-keychain"
+
+    Domain domain
+
+    LoginKeychain withDomain(Domain value) {
+        this.domain = value
+        this
+    }
+
+    Boolean setLoginKeychain
+
+    LoginKeychain setLoginKeychain(Boolean value = true) {
+        this.setLoginKeychain = value
+        this
+    }
+
+    @Override
+    protected List<String> getArguments() {
+        def arguments = []
+        if (domain) {
+            arguments << "-d" << domain.toString()
+        }
+        if (setLoginKeychain) {
+            arguments << "-s"
+            arguments.addAll(getOptionalKeychainArgument())
+        }
+        arguments
+    }
+
+    @Override
+    protected File convertResult(String output) {
+        if (!output) {
+            return null
+        }
+        new File(output.trim().replaceAll(/^"|"$/, ''))
+    }
+}

--- a/lib/macos-security/src/main/groovy/com/wooga/security/command/MultiKeychainCommand.groovy
+++ b/lib/macos-security/src/main/groovy/com/wooga/security/command/MultiKeychainCommand.groovy
@@ -31,6 +31,11 @@ trait MultiKeychainCommand<T extends SecurityCommand> {
         this as T
     }
 
+    T withKeychains(Iterable<File> value) {
+        this.keychains.addAll(value)
+        this as T
+    }
+
     List<String> getMultiKeychainsArgument() {
         def arguments = []
         if (!keychains.empty) {

--- a/lib/macos-security/src/main/groovy/com/wooga/security/command/MultiKeychainCommand.groovy
+++ b/lib/macos-security/src/main/groovy/com/wooga/security/command/MultiKeychainCommand.groovy
@@ -40,7 +40,7 @@ trait MultiKeychainCommand<T extends SecurityCommand> {
         def arguments = []
         if (!keychains.empty) {
             SecurityCommand.validateKeychainsProperty(keychains)
-            arguments.addAll(keychains.collect({ it.path }))
+            arguments.addAll(keychains.collect({ SecurityCommand.expandPath(it.canonicalPath) }).unique())
         }
         arguments
     }

--- a/lib/macos-security/src/main/groovy/com/wooga/security/command/SecurityCommand.groovy
+++ b/lib/macos-security/src/main/groovy/com/wooga/security/command/SecurityCommand.groovy
@@ -118,4 +118,11 @@ abstract class SecurityCommand<T> {
             validateKeychainProperty(it)
         }
     }
+
+    static String expandPath(String path) {
+        if (path.startsWith("~" + File.separator)) {
+            path = System.getProperty("user.home") + path.substring(1)
+        }
+        path
+    }
 }

--- a/lib/macos-security/src/main/groovy/com/wooga/security/command/SecurityCommand.groovy
+++ b/lib/macos-security/src/main/groovy/com/wooga/security/command/SecurityCommand.groovy
@@ -87,7 +87,7 @@ abstract class SecurityCommand<T> {
 
     static void validateStringProperty(String value, String propertyName) {
         if (value == null) {
-            throw new IllegalArgumentException("provided ${propertyName} is null")
+            throw new NullPointerException("provided ${propertyName} is null")
         }
 
         if (value.isEmpty()) {
@@ -97,7 +97,7 @@ abstract class SecurityCommand<T> {
 
     static void validateFileProperty(File file, String propertyName) {
         if (!file) {
-            throw new IllegalArgumentException("provided ${propertyName} is null")
+            throw new NullPointerException("provided ${propertyName} is null")
         }
 
         if (!file.exists()) {

--- a/lib/macos-security/src/test/groovy/com/wooga/security/KeychainLookupListSpec.groovy
+++ b/lib/macos-security/src/test/groovy/com/wooga/security/KeychainLookupListSpec.groovy
@@ -1,0 +1,666 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.wooga.security
+
+import org.junit.Rule
+import org.junit.contrib.java.lang.system.EnvironmentVariables
+import org.junit.contrib.java.lang.system.ProvideSystemProperty
+import spock.lang.Ignore
+import spock.lang.Requires
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+import spock.util.environment.RestoreSystemProperties
+import static com.wooga.security.KeychainLookupList.canonical
+import static com.wooga.security.KeychainLookupList.resetKeychains
+
+@Requires({ os.macOs && env['ATLAS_BUILD_UNITY_IOS_EXECUTE_KEYCHAIN_SPEC'] == 'YES' })
+@RestoreSystemProperties
+class KeychainLookupListSpec extends Specification {
+
+    @Shared
+    File newHome = File.createTempDir("user", "home")
+
+    @Rule
+    public ProvideSystemProperty systemProperties = new ProvideSystemProperty("user.home", newHome.path)
+
+    @Shared
+    KeychainLookupList subject = new KeychainLookupList()
+
+    @Rule
+    public final EnvironmentVariables environmentVariables = new EnvironmentVariables()
+
+    def setup() {
+        newHome.mkdirs()
+        resetKeychains()
+    }
+
+    def cleanup() {
+        resetKeychains()
+    }
+
+    def cleanupSpec() {
+        resetKeychains()
+    }
+
+    File createTestKeychainFromPath(String path) {
+        if (path.startsWith("~" + File.separator)) {
+            path = System.getProperty("user.home") + path.substring(1)
+        }
+        def f = new File(path).canonicalFile
+        createTestKeychain(f.name, f.parentFile)
+    }
+
+    File createTestKeychain(String fileName, File baseDir = File.createTempDir()) {
+        fileName = fileName.endsWith(".keychain") ? fileName : "${fileName}.keychain"
+        def keychain = new File(baseDir, fileName)
+        baseDir.mkdirs()
+        keychain << "A test keychain file mock"
+        keychain
+    }
+
+    def "populated list has size != 0"() {
+        given: "a populated list"
+        subject.add(createTestKeychain("test1"))
+        subject.add(createTestKeychain("test2"))
+
+        expect:
+        subject.size() != 0
+        !subject.isEmpty()
+    }
+
+    def "adds a single keychain to the lookup list"() {
+        given: "a empty lookup list"
+        def initialSize = subject.size()
+        assert subject.size() != 0
+
+        when:
+        def k1 = createTestKeychain("test")
+        def result = subject.add(k1)
+
+        then:
+        result
+        subject.size() == initialSize + 1
+        subject.contains(k1)
+
+        when:
+        def k2 = createTestKeychain("test2")
+        result = subject.add(k2)
+
+        then:
+        result
+        subject.size() == initialSize + 2
+        subject.contains(k1)
+        subject.contains(k2)
+    }
+
+    def "adds multiple keychains to the lookup list"() {
+        given: "a empty lookup list"
+        def initialSize = subject.size()
+        assert subject.size() != 0
+
+        when:
+        def k1 = createTestKeychain("test.keychain")
+        def k2 = createTestKeychain("test2.keychain")
+        def k3 = createTestKeychain("test3.keychain")
+        def k4 = createTestKeychain("test4.keychain")
+        def result = subject.addAll([k1, k2])
+
+        then:
+        result
+        subject.size() == initialSize + 2
+        subject.contains(k1)
+        subject.contains(k2)
+
+        when:
+        result = subject.addAll([k3, k4])
+
+        then:
+        result
+        subject.size() == initialSize + 4
+        subject.contains(k1)
+        subject.contains(k2)
+        subject.contains(k3)
+        subject.contains(k4)
+    }
+
+    @Unroll
+    def "doesn't add duplicate entries when #message"() {
+        given: "lookup list with one entry"
+        def initialSize = subject.size()
+        def keychain = createTestKeychain("test.keychain", new File(newHome, "path/to"))
+        subject.add(keychain)
+        assert subject.size() == initialSize + 1
+
+        when:
+        def result = subject.add(new File(fileToAdd))
+
+        then:
+        !result
+        subject.size() == initialSize + 1
+
+        where:
+        fileToAdd                                       | message
+        "~/path/to/test.keychain"                       | "path is equal"
+        "~/path/../path/to/test.keychain"               | "resolved path is equal"
+        "${newHome.path}/path/../path/to/test.keychain" | "expanded ~/ path is equal"
+    }
+
+    @Unroll
+    def "#method throws #error when #message"() {
+        when:
+        subject.invokeMethod(method, testObject)
+
+        then:
+        thrown(error)
+
+        where:
+        method        | testObject | error                     | message
+        "contains"    | null       | NullPointerException      | "object is null"
+        "indexOf"     | null       | NullPointerException      | "object is null"
+        "lastIndexOf" | null       | NullPointerException      | "object is null"
+        "contains"    | "test"     | ClassCastException        | "object is not a java.io.File"
+        "remove"      | "test"     | ClassCastException        | "object is not a java.io.File"
+        "indexOf"     | "test"     | ClassCastException        | "object is not a java.io.File"
+        "lastIndexOf" | "test"     | ClassCastException        | "object is not a java.io.File"
+        "add"         | "test"     | ClassCastException        | "object is not a java.io.File"
+        "get"         | 22         | IndexOutOfBoundsException | "index is out of bounds"
+    }
+
+    // need to unroll these cases by hand because `invokeMethod` calls them with:
+    // - non null default buildArguments
+    // or
+    // - doesn't know which overload to call
+
+    def "retainAll throws UnsupportedOperationException"() {
+        when:
+        subject.retainAll(null)
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+
+    def "set(int,File) throws UnsupportedOperationException"() {
+        when:
+        subject.set(0, new File('some/file'))
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+
+    def "add(int,File) throws UnsupportedOperationException"() {
+        when:
+        subject.add(0, new File('some/file'))
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+
+    def "remove(int) throws UnsupportedOperationException"() {
+        when:
+        subject.remove(0)
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+
+    def "addAll(int, Collection<? extends File>) throws UnsupportedOperationException"() {
+        when:
+        subject.addAll(0, [new File('some/file')])
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+
+
+    def "remove throws NullPointerException when object is null"() {
+        when:
+        subject.remove(null)
+
+        then:
+        thrown(NullPointerException)
+    }
+
+    def "add throws NullPointerException when object is null"() {
+        when:
+        subject.add(null)
+
+        then:
+        thrown(NullPointerException)
+    }
+
+    def "addAll throws NullPointerException when object is null"() {
+        when:
+        subject.addAll(null as Collection)
+
+        then:
+        thrown(NullPointerException)
+    }
+
+    def "addAll throws NullPointerException when one or more objects in list are null"() {
+        when:
+        subject.addAll([createTestKeychain("test.keychain"), null])
+
+        then:
+        thrown(NullPointerException)
+    }
+
+    def "removeAll throws NullPointerException when object is null"() {
+        when:
+        subject.removeAll(null)
+
+        then:
+        thrown(NullPointerException)
+    }
+
+    def "containsAll throws NullPointerException when object is null"() {
+        when:
+        subject.containsAll(null)
+
+        then:
+        thrown(NullPointerException)
+    }
+
+    def "containsAll throws ClassCastException when one or more objects in list are not of type java.io.File"() {
+        when:
+        subject.containsAll([new File('some/file'), "a String"])
+
+        then:
+        thrown(ClassCastException)
+    }
+
+    def "toArray throws NullPointerException when object is null"() {
+        when:
+        subject.toArray(null)
+
+        then:
+        thrown(NullPointerException)
+    }
+
+    def "toArray throws ArrayStoreException when object is not a java.io.File[] array"() {
+        given: "lookup list with multiple entries"
+        subject.add(new File("~/path/to/test.keychain"))
+
+        when:
+        subject.toArray(new String[0])
+
+        then:
+        thrown(ArrayStoreException)
+    }
+
+    @Unroll
+    def "contains checks if resolved path are equal when #message"() {
+        given: "lookup list with one entry"
+        def initialSize = subject.size()
+        subject.add(new File("~/path/to/test.keychain"))
+        assert subject.size() == initialSize + 1
+
+        expect:
+        subject.contains(new File(fileToCheck))
+
+        where:
+        fileToCheck                                     | message
+        //"~/path/to/test.keychain"                       | "path is equal"
+        //"~/path/../path/to/test.keychain"               | "resolved path is equal"
+        "${newHome.path}/path/../path/to/test.keychain" | "expanded ~/ path is equal"
+    }
+
+    @Unroll
+    def "containsAll checks if all keychains provided are in the list"() {
+        given: "lookup list with multiple entries"
+        def initialSize = subject.size()
+        subject.add(createTestKeychainFromPath("~/path/to/test.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test2.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test3.keychain"))
+        assert subject.size() == initialSize + 3
+
+        expect:
+        subject.containsAll(check) == expectedValue
+
+        where:
+        check                                                                       || expectedValue
+        [new File("~/path/to/test.keychain")]                                       || true
+        [new File("~/path/to/test.keychain"), new File("~/path/to/test2.keychain")] || true
+        [new File("~/path/to/test.keychain"), new File("~/path/to/test4.keychain")] || false
+        [new File("~/path/to/test4.keychain")]                                      || false
+    }
+
+    @Unroll
+    def "clear resets keychain"() {
+        given: "lookup list with multiple entries"
+        def initialSize = subject.size()
+        subject.add(createTestKeychainFromPath("~/path/to/test.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test2.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test3.keychain"))
+        assert subject.size() == initialSize + 3
+
+        when:
+        subject.clear()
+
+        then:
+        !subject.isEmpty()
+        subject.size() == initialSize
+        !subject.contains(canonical(new File("~/path/to/test.keychain")))
+        !subject.contains(canonical(new File("~/path/to/test2.keychain")))
+        !subject.contains(canonical(new File("~/path/to/test3.keychain")))
+    }
+
+    @Unroll
+    def "removes items from the list when #message"() {
+        given: "lookup list with multiple entries"
+        def initialSize = subject.size()
+        subject.add(createTestKeychainFromPath("~/path/to/test.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test2.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test3.keychain"))
+        assert subject.size() == initialSize + 3
+
+        when:
+        def result = subject.remove(new File(fileToRemove))
+
+        then:
+        result
+        subject.size() == initialSize + 2
+        !subject.contains(new File(fileToRemove))
+
+        where:
+        fileToRemove                                    | message
+        "~/path/to/test.keychain"                       | "path is equal"
+        "~/path/../path/to/test.keychain"               | "resolved path is equal"
+        "${newHome.path}/path/../path/to/test.keychain" | "expanded ~/ path is equal"
+    }
+
+    @Unroll
+    def "removes multiple items from the list"() {
+        given: "lookup list with multiple entries"
+        def initialSize = subject.size()
+        subject.add(createTestKeychainFromPath("~/path/to/test.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test2.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test3.keychain"))
+        assert subject.size() == initialSize + 3
+
+        when:
+        def result = subject.removeAll(filesToRemove)
+
+        then:
+        result == hasChanges
+        subject.size() == initialSize + expectedSize
+        !subject.containsAll(filesToRemove)
+
+        where:
+        filesToRemove                                                               || expectedSize | hasChanges
+        [new File("~/path/to/test.keychain")]                                       || 2            | true
+        [new File("~/path/to/test.keychain"), new File("~/path/to/test2.keychain")] || 1            | true
+        [new File("~/path/to/test.keychain"), new File("~/path/to/test4.keychain")] || 2            | true
+        [new File("~/path/to/test4.keychain")]                                      || 3            | false
+    }
+
+    @Unroll
+    def "creates #type over items"() {
+        given: "lookup list with multiple entries"
+        def initialSize = subject.size()
+        subject.add(createTestKeychainFromPath("~/path/to/test.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test2.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test3.keychain"))
+        assert subject.size() == initialSize + 3
+
+        and: "a check counter"
+        def checkList = []
+
+        when:
+        def iter = subject.invokeMethod(method, null)
+        while (iter.hasNext()) {
+            checkList.add(iter.next())
+        }
+
+        then:
+        checkList.size() == subject.size()
+        subject.containsAll(checkList)
+
+        where:
+        type            | method
+        "iterator"      | "iterator"
+        "list iterator" | "listIterator"
+    }
+
+    @Unroll
+    def "list iterator can move in both directions"() {
+        given: "lookup list with multiple entries"
+        def initialSize = subject.size()
+        subject.add(createTestKeychainFromPath("~/path/to/test.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test2.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test3.keychain"))
+        assert subject.size() == initialSize + 3
+
+        and: "a check counter"
+        def checkList = []
+
+        when:
+        def iter = subject.listIterator(3)
+        while (iter.hasPrevious()) {
+            iter.previousIndex()
+            checkList.add(iter.previous())
+        }
+
+        then:
+        checkList.size() + initialSize == subject.size()
+        subject.containsAll(checkList)
+
+        when:
+        checkList.clear()
+        iter = subject.listIterator(0)
+        while (iter.hasNext()) {
+            iter.nextIndex()
+            checkList.add(iter.next())
+        }
+
+        then:
+        checkList.size() == subject.size()
+        subject.containsAll(checkList)
+    }
+
+    def "list iterator doesn't support set(File)"() {
+        given: "lookup list with multiple entries"
+        def initialSize = subject.size()
+        subject.add(createTestKeychainFromPath("~/path/to/test.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test2.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test3.keychain"))
+        assert subject.size() == initialSize + 3
+
+        when:
+        def iter = subject.listIterator()
+        iter.next()
+        iter.set(new File("some/file"))
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+
+    def "list iterator doesn't support add(File)"() {
+        given: "lookup list with multiple entries"
+        def initialSize = subject.size()
+        subject.add(createTestKeychainFromPath("~/path/to/test.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test2.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test3.keychain"))
+        assert subject.size() == initialSize + 3
+
+        when:
+        def iter = subject.listIterator()
+        iter.next()
+        iter.add(new File("some/file"))
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+
+    @Unroll
+    def "#type can modify lookup list"() {
+        given: "lookup list with multiple entries"
+        def initialSize = subject.size()
+        subject.add(createTestKeychainFromPath("~/path/to/test.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test2.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test3.keychain"))
+        assert subject.size() == initialSize + 3
+
+        when:
+        Iterator iter = subject.invokeMethod(method, null)
+        while (iter.hasNext()) {
+            if (iter.next() == canonical(new File("~/path/to/test2.keychain"))) {
+                iter.remove()
+            }
+        }
+
+        then:
+        subject.size() == initialSize + 2
+        !subject.contains(new File("~/path/to/test2.keychain"))
+
+        where:
+        type            | method
+        "iterator"      | "iterator"
+        "list iterator" | "listIterator"
+    }
+
+    def "creates Object[] array copy of items"() {
+        given: "lookup list with multiple entries"
+        def initialSize = subject.size()
+        subject.add(createTestKeychainFromPath("~/path/to/test.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test2.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test3.keychain"))
+        assert subject.size() == initialSize + 3
+
+        when:
+        def arr = subject.toArray()
+
+        then:
+        arr.length == subject.size()
+        subject.containsAll(arr)
+
+        when:
+        arr = subject.toArray()
+        subject.remove(new File("~/path/to/test2.keychain"))
+
+        then:
+        arr.length != subject.size()
+        !subject.containsAll(arr)
+    }
+
+    @Unroll
+    def "creates File[] array copy of items with #testArr"() {
+        given: "lookup list with multiple entries"
+        def initialSize = subject.size()
+        subject.add(createTestKeychainFromPath("~/path/to/test.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test2.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test3.keychain"))
+        assert subject.size() == initialSize + 3
+
+        and:
+        def expectSameSize = testArr.length <= subject.size()
+
+        when:
+        def arr = subject.toArray(testArr)
+
+        then:
+        (arr.length == subject.size()) == expectSameSize
+        subject.containsAll(arr.findAll { it != null })
+
+        when:
+        arr = subject.toArray()
+        subject.remove(new File("~/path/to/test2.keychain"))
+
+        then:
+        arr.length != subject.size()
+        !subject.containsAll(arr.findAll { it != null })
+
+        where:
+        testArr << [new File[0], new File[3], new File[5]]
+    }
+
+    def "retrieves item by index"() {
+        given: "lookup list with multiple entries"
+        def initialSize = subject.size()
+        subject.add(createTestKeychainFromPath("~/path/to/test.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test2.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test3.keychain"))
+        assert subject.size() == initialSize + 3
+
+        expect:
+        subject[initialSize + 1] == canonical(new File("~/path/to/test2.keychain"))
+    }
+
+    @Unroll
+    def "#method returns #message"() {
+        given: "lookup list with multiple entries"
+        def initialSize = subject.size()
+        subject.add(createTestKeychainFromPath("~/path/to/test.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test2.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test3.keychain"))
+        assert subject.size() == initialSize + 3
+
+        and: "adjusted expected index"
+        expectedIndex = (expectedIndex >= 0) ? expectedIndex + initialSize : expectedIndex
+
+        expect:
+        subject.invokeMethod(method, item) == expectedIndex
+
+        where:
+        method        | item                                 | message                                | expectedIndex
+        "indexOf"     | new File("~/path/to/test2.keychain") | "index when item is contained in list" | 1
+        "indexOf"     | new File("~/path/to/test4.keychain") | "-1 when item can not be found"        | -1
+        "lastIndexOf" | new File("~/path/to/test2.keychain") | "index when item is contained in list" | 1
+        "lastIndexOf" | new File("~/path/to/test4.keychain") | "-1 when item can not be found"        | -1
+    }
+
+    def "creates a faulty sublist"() {
+        given: "lookup list with multiple entries"
+        def initialSize = subject.size()
+        subject.add(createTestKeychainFromPath("~/path/to/test.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test2.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test3.keychain"))
+        assert subject.size() == initialSize + 3
+
+        expect:
+        subject.subList(1, 2).size() == 1
+    }
+
+    @Ignore
+    def "reset "() {
+        given: "lookup list with multiple entries"
+        def initialSize = subject.size()
+        subject.add(createTestKeychainFromPath("~/path/to/test.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test2.keychain"))
+        subject.add(createTestKeychainFromPath("~/path/to/test3.keychain"))
+        assert subject.size() == initialSize + 3
+
+        and: "a custom reset list"
+        def originalDefaultKeychains = System.getenv("ATLAS_BUILD_UNITY_IOS_DEFAULT_KEYCHAINS")
+        environmentVariables.set("ATLAS_BUILD_UNITY_IOS_DEFAULT_KEYCHAINS", expectedKeychains.join(File.pathSeparator))
+
+        when:
+        subject.reset()
+
+        then:
+        subject.size() == expectedKeychains.size()
+        expectedKeychains.every { subject.contains(new File(it)) }
+
+        cleanup:
+        environmentVariables.set("ATLAS_BUILD_UNITY_IOS_DEFAULT_KEYCHAINS", originalDefaultKeychains)
+        resetKeychains()
+
+        where:
+        expectedKeychains = ["~/path/to/test.keychain", "~/path/to/test3.keychain"]
+    }
+
+}

--- a/lib/macos-security/src/test/groovy/com/wooga/security/command/AddGenericPasswordSpec.groovy
+++ b/lib/macos-security/src/test/groovy/com/wooga/security/command/AddGenericPasswordSpec.groovy
@@ -42,7 +42,7 @@ class AddGenericPasswordSpec extends AddPasswordSpec<AddGenericPassword> {
 
         where:
         property  | value | expectedExeption               | message
-        "service" | null  | IllegalArgumentException.class | "is null"
+        "service" | null  | NullPointerException.class     | "is null"
         "service" | ""    | IllegalArgumentException.class | "is empty"
         reason = "provided ${property} ${message}"
         messagePattern = /provided ${property}.*${message}/

--- a/lib/macos-security/src/test/groovy/com/wooga/security/command/AddInternetPasswordSpec.groovy
+++ b/lib/macos-security/src/test/groovy/com/wooga/security/command/AddInternetPasswordSpec.groovy
@@ -43,7 +43,7 @@ class AddInternetPasswordSpec extends AddPasswordSpec<AddInternetPassword> {
 
         where:
         property | value | expectedExeption               | message
-        "server" | null  | IllegalArgumentException.class | "is null"
+        "server" | null  | NullPointerException.class     | "is null"
         "server" | ""    | IllegalArgumentException.class | "is empty"
         reason = "provided ${property} ${message}"
         messagePattern = /provided ${property}.*${message}/

--- a/lib/macos-security/src/test/groovy/com/wooga/security/command/AddPasswordSpec.groovy
+++ b/lib/macos-security/src/test/groovy/com/wooga/security/command/AddPasswordSpec.groovy
@@ -50,10 +50,10 @@ abstract class AddPasswordSpec<T extends SecurityCommand> extends SecurityComman
         "keychain" | new File("/some/file") | IllegalArgumentException.class | "does not exist"
         "keychain" | File.createTempDir()   | IllegalArgumentException.class | "is not a file"
 
-        "account"  | null                   | IllegalArgumentException.class | "is null"
+        "account"  | null                   | NullPointerException.class     | "is null"
         "account"  | ""                     | IllegalArgumentException.class | "is empty"
 
-        "password" | null                   | IllegalArgumentException.class | "is null"
+        "password" | null                   | NullPointerException.class     | "is null"
         "password" | ""                     | IllegalArgumentException.class | "is empty"
         reason = "provided ${property} ${message}"
         messagePattern = /provided ${property}.*${message}/

--- a/lib/macos-security/src/test/groovy/com/wooga/security/command/CreateKeychainSpec.groovy
+++ b/lib/macos-security/src/test/groovy/com/wooga/security/command/CreateKeychainSpec.groovy
@@ -67,11 +67,11 @@ class CreateKeychainSpec extends SecurityCommandSpec<CreateKeychain> {
         e.message.contains(message)
 
         where:
-        property   | value         | expectedExeption               | message                                         | command
-        "password" | "is null"     | IllegalArgumentException.class | "provided password is null"                     | new CreateKeychain(null, createTempKeychainLocation())
-        "location" | "is null"     | IllegalArgumentException.class | "provided location is null"                     | new CreateKeychain(keychainPassword, null)
-        "location" | "a directory" | IOException.class              | "A keychain with the same name already exists." | new CreateKeychain(keychainPassword, File.createTempDir())
-        "location" | "exists"      | IOException.class              | "A keychain with the same name already exists." | new CreateKeychain(keychainPassword, File.createTempDir())
+        property   | value         | expectedExeption           | message                                         | command
+        "password" | "is null"     | NullPointerException.class | "provided password is null"                     | new CreateKeychain(null, createTempKeychainLocation())
+        "location" | "is null"     | NullPointerException.class | "provided location is null"                     | new CreateKeychain(keychainPassword, null)
+        "location" | "a directory" | IOException.class          | "A keychain with the same name already exists." | new CreateKeychain(keychainPassword, File.createTempDir())
+        "location" | "exists"      | IOException.class          | "A keychain with the same name already exists." | new CreateKeychain(keychainPassword, File.createTempDir())
         reason = "property '${property}' '${value}'"
     }
 

--- a/lib/macos-security/src/test/groovy/com/wooga/security/command/DefaultKeychainSpec.groovy
+++ b/lib/macos-security/src/test/groovy/com/wooga/security/command/DefaultKeychainSpec.groovy
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.wooga.security.command
+
+import com.wooga.security.Domain
+import spock.lang.Requires
+import spock.lang.Unroll
+
+@Requires({os.macOs})
+class DefaultKeychainSpec extends SecurityCommandSpec<DefaultKeychain> {
+    DefaultKeychain command = new DefaultKeychain()
+
+    def "returns default keychain"() {
+        when:
+        def result = command.execute()
+
+        then:
+        result != null
+        result.exists()
+    }
+
+    @Unroll("fails with #expectedExeption when #reason")
+    def "fails with exception when property is invalid"() {
+        given: "invalid keychain"
+        command.setProperty(property, value)
+        command.setDefaultKeychain()
+
+        when:
+        command.execute()
+
+        then:
+        def e = thrown(expectedExeption)
+        e.message.matches(messagePattern)
+
+        where:
+        property   | value                  | expectedExeption               | message
+        "keychain" | new File("/some/file") | IllegalArgumentException.class | "does not exist"
+        "keychain" | File.createTempDir()   | IllegalArgumentException.class | "is not a file"
+
+        reason = "provided ${property} ${message}"
+        messagePattern = /provided keychain.*${message}/
+    }
+
+    @Unroll("property #property sets commandline flag #commandlineFlag")
+    def "property sets commandline"() {
+        given: "set property"
+        command.invokeMethod(method, value)
+
+        when:
+        def arguments = command.getArguments().join(" ")
+        then:
+        arguments.contains(expectedArguments)
+
+        where:
+        property             | commandlineFlag | value
+        "setDefaultKeychain" | "-s"            | true
+        "domain"             | "-d"            | Domain.user
+        expectedArguments = Boolean.isInstance(value) ? "${commandlineFlag}" : "${commandlineFlag} ${value.toString()}"
+        method = Boolean.isInstance(value) ? property : "with${property.capitalize()}"
+    }
+}

--- a/lib/macos-security/src/test/groovy/com/wooga/security/command/FindGenericPasswordSpec.groovy
+++ b/lib/macos-security/src/test/groovy/com/wooga/security/command/FindGenericPasswordSpec.groovy
@@ -49,7 +49,7 @@ class FindGenericPasswordSpec extends FindPasswordSpec<FindGenericPassword> {
 
         where:
         property  | value | expectedExeption               | message
-        "service" | null  | IllegalArgumentException.class | "is null"
+        "service" | null  | NullPointerException.class     | "is null"
         "service" | ""    | IllegalArgumentException.class | "is empty"
         reason = "provided ${property} ${message}"
         messagePattern = /provided ${property}.*${message}/

--- a/lib/macos-security/src/test/groovy/com/wooga/security/command/FindInternetPasswordSpec.groovy
+++ b/lib/macos-security/src/test/groovy/com/wooga/security/command/FindInternetPasswordSpec.groovy
@@ -49,7 +49,7 @@ class FindInternetPasswordSpec extends FindPasswordSpec<FindInternetPassword> {
 
         where:
         property | value | expectedExeption               | message
-        "server" | null  | IllegalArgumentException.class | "is null"
+        "server" | null  | NullPointerException.class     | "is null"
         "server" | ""    | IllegalArgumentException.class | "is empty"
         reason = "provided ${property} ${message}"
         messagePattern = /provided ${property}.*${message}/

--- a/lib/macos-security/src/test/groovy/com/wooga/security/command/FindPasswordSpec.groovy
+++ b/lib/macos-security/src/test/groovy/com/wooga/security/command/FindPasswordSpec.groovy
@@ -56,7 +56,7 @@ abstract class FindPasswordSpec<T extends SecurityCommand> extends SecurityComma
         "keychains" | [new File("/some/file")] | IllegalArgumentException.class | "does not exist"
         "keychains" | [File.createTempDir()]   | IllegalArgumentException.class | "is not a file"
 
-        "account"   | null                     | IllegalArgumentException.class | "is null"
+        "account"   | null                     | NullPointerException.class     | "is null"
         "account"   | ""                       | IllegalArgumentException.class | "is empty"
         reason = "provided ${property} ${message}"
         propertyPattern = property == "keychains" ? "keychain" : property

--- a/lib/macos-security/src/test/groovy/com/wooga/security/command/ImportSpec.groovy
+++ b/lib/macos-security/src/test/groovy/com/wooga/security/command/ImportSpec.groovy
@@ -91,11 +91,11 @@ class ImportSpec extends SecurityCommandSpec<Import> {
 
         where:
         property    | value                  | expectedExeption               | message
-        "keychain"  | null                   | IllegalArgumentException.class | "is null"
+        "keychain"  | null                   | NullPointerException.class     | "is null"
         "keychain"  | new File("/some/file") | IllegalArgumentException.class | "does not exist"
         "keychain"  | File.createTempDir()   | IllegalArgumentException.class | "is not a file"
 
-        "inputFile" | null                   | IllegalArgumentException.class | "is null"
+        "inputFile" | null                   | NullPointerException.class     | "is null"
         "inputFile" | new File("/some/file") | IllegalArgumentException.class | "does not exist"
         "inputFile" | File.createTempDir()   | IllegalArgumentException.class | "is not a file"
 

--- a/lib/macos-security/src/test/groovy/com/wooga/security/command/ListKeychainsSpec.groovy
+++ b/lib/macos-security/src/test/groovy/com/wooga/security/command/ListKeychainsSpec.groovy
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.wooga.security.command
+
+import com.wooga.security.Domain
+import spock.lang.Requires
+import spock.lang.Unroll
+
+@Requires({os.macOs})
+class ListKeychainsSpec extends SecurityCommandSpec<ListKeychains> {
+    ListKeychains command = new ListKeychains()
+
+    def "lists keychain lookup list"() {
+        when:
+        def result = command.execute()
+
+        then:
+        result != null
+        !result.empty
+    }
+
+    @Unroll("fails with #expectedExeption when #reason")
+    def "fails with exception when property is invalid"() {
+        given: "invalid keychain"
+        command.setProperty(property, value)
+        command.setKeychainSearchList()
+
+        when:
+        command.execute()
+
+        then:
+        def e = thrown(expectedExeption)
+        e.message.matches(messagePattern)
+
+        where:
+        property    | value                    | expectedExeption               | message
+        "keychains" | [new File("/some/file")] | IllegalArgumentException.class | "does not exist"
+        "keychains" | [File.createTempDir()]   | IllegalArgumentException.class | "is not a file"
+
+        reason = "provided ${property} ${message}"
+        messagePattern = /provided keychain.*${message}/
+    }
+
+    @Unroll("property #property sets commandline flag #commandlineFlag")
+    def "property sets commandline"() {
+        given: "set property"
+        command.invokeMethod(method, value)
+
+        when:
+        def arguments = command.getArguments().join(" ")
+        then:
+        arguments.contains(expectedArguments)
+
+        where:
+        property                | commandlineFlag | value
+        "setKeychainSearchList" | "-s"            | true
+        "domain"                | "-d"            | Domain.user
+        expectedArguments = Boolean.isInstance(value) ? "${commandlineFlag}" : "${commandlineFlag} ${value.toString()}"
+        method = Boolean.isInstance(value) ? property : "with${property.capitalize()}"
+    }
+}

--- a/lib/macos-security/src/test/groovy/com/wooga/security/command/LoginKeychainSpec.groovy
+++ b/lib/macos-security/src/test/groovy/com/wooga/security/command/LoginKeychainSpec.groovy
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.wooga.security.command
+
+import com.wooga.security.Domain
+import spock.lang.Requires
+import spock.lang.Unroll
+
+@Requires({ os.macOs })
+class LoginKeychainSpec extends SecurityCommandSpec<LoginKeychain> {
+    LoginKeychain command = new LoginKeychain()
+
+    def "returns login keychain"() {
+        when:
+        def result = command.execute()
+
+        then:
+        result != null
+        result.exists()
+    }
+
+    @Unroll("fails with #expectedExeption when #reason")
+    def "fails with exception when property is invalid"() {
+        given: "invalid keychain"
+        command.setProperty(property, value)
+        command.setLoginKeychain()
+
+        when:
+        command.execute()
+
+        then:
+        def e = thrown(expectedExeption)
+        e.message.matches(messagePattern)
+
+        where:
+        property   | value                  | expectedExeption               | message
+        "keychain" | new File("/some/file") | IllegalArgumentException.class | "does not exist"
+        "keychain" | File.createTempDir()   | IllegalArgumentException.class | "is not a file"
+
+        reason = "provided ${property} ${message}"
+        messagePattern = /provided keychain.*${message}/
+    }
+
+    @Unroll("property #property sets commandline flag #commandlineFlag")
+    def "property sets commandline"() {
+        given: "set property"
+        command.invokeMethod(method, value)
+
+        when:
+        def arguments = command.getArguments().join(" ")
+        then:
+        arguments.contains(expectedArguments)
+
+        where:
+        property           | commandlineFlag | value
+        "setLoginKeychain" | "-s"            | true
+        "domain"           | "-d"            | Domain.user
+        expectedArguments = Boolean.isInstance(value) ? "${commandlineFlag}" : "${commandlineFlag} ${value.toString()}"
+        method = Boolean.isInstance(value) ? property : "with${property.capitalize()}"
+    }
+}

--- a/lib/macos-security/src/test/groovy/com/wooga/security/command/ShowKeychainInfoSpec.groovy
+++ b/lib/macos-security/src/test/groovy/com/wooga/security/command/ShowKeychainInfoSpec.groovy
@@ -55,7 +55,7 @@ class ShowKeychainInfoSpec extends SecurityCommandSpec<ShowKeychainInfo> {
 
         where:
         property   | expectedExeption               | message          | command
-        "keychain" | IllegalArgumentException.class | "is null"        | new ShowKeychainInfo((File) null)
+        "keychain" | NullPointerException.class     | "is null"        | new ShowKeychainInfo((File) null)
         "keychain" | IllegalArgumentException.class | "does not exist" | new ShowKeychainInfo(new File("/some/file"))
         "keychain" | IllegalArgumentException.class | "is not a file"  | new ShowKeychainInfo(File.createTempDir())
 


### PR DESCRIPTION
## Description

This patch brings a reimplementation of the `KeychainLookupList` to the security library. I replaced all invocations of `SecurityUtil` from the old class with the new security command versions.

This class will be used to query and alter the keychain lookup list. The old implementation used to normalize the path passed to the security cli tool. I reimplemented that also in the new security commands.

## Changes

* ![ADD] `KeychainLookupList` class
* ![IMPROVE] normallize keychain path before passing it to `security` cli

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
