### PR TITLE
Implement appstore connection auth for fastlane

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/fastlane/FastlanePluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/fastlane/FastlanePluginIntegrationSpec.groovy
@@ -16,10 +16,12 @@
 
 package wooga.gradle.fastlane
 
+import spock.lang.Requires
 import spock.lang.Unroll
 import wooga.gradle.fastlane.tasks.PilotUpload
 import wooga.gradle.fastlane.tasks.SighRenew
 
+@Requires({ os.macOs })
 class FastlanePluginIntegrationSpec extends FastlaneIntegrationSpec {
 
     @Unroll()
@@ -63,28 +65,37 @@ class FastlanePluginIntegrationSpec extends FastlaneIntegrationSpec {
         result.standardOutput.contains("${extensionName}.${property}: ${testValue}")
 
         where:
-        property   | method         | rawValue        | expectedValue | type               | location                  | additionalInfo
-        "username" | _              | "someUser1"     | _             | _                  | PropertyLocation.env      | ""
-        "username" | _              | "someUser2"     | _             | _                  | PropertyLocation.property | ""
-        "username" | _              | "someUser3"     | _             | "String"           | PropertyLocation.script   | ""
-        "username" | _              | "someUser4"     | _             | "Provider<String>" | PropertyLocation.script   | ""
-        "username" | "username.set" | "someUser5"     | _             | "String"           | PropertyLocation.script   | ""
-        "username" | "username.set" | "someUser6"     | _             | "Provider<String>" | PropertyLocation.script   | ""
-        "username" | "username"     | "someUser7"     | _             | "String"           | PropertyLocation.script   | ""
-        "username" | "username"     | "someUser8"     | _             | "Provider<String>" | PropertyLocation.script   | ""
-        "username" | _              | _               | null          | _                  | PropertyLocation.none     | ""
+        property     | method           | rawValue             | expectedValue | type                     | location                  | additionalInfo
+        "username"   | _                | "someUser1"          | _             | _                        | PropertyLocation.env      | ""
+        "username"   | _                | "someUser2"          | _             | _                        | PropertyLocation.property | ""
+        "username"   | _                | "someUser3"          | _             | "String"                 | PropertyLocation.script   | ""
+        "username"   | _                | "someUser4"          | _             | "Provider<String>"       | PropertyLocation.script   | ""
+        "username"   | "username.set"   | "someUser5"          | _             | "String"                 | PropertyLocation.script   | ""
+        "username"   | "username.set"   | "someUser6"          | _             | "Provider<String>"       | PropertyLocation.script   | ""
+        "username"   | "username"       | "someUser7"          | _             | "String"                 | PropertyLocation.script   | ""
+        "username"   | "username"       | "someUser8"          | _             | "Provider<String>"       | PropertyLocation.script   | ""
+        "username"   | _                | _                    | null          | _                        | PropertyLocation.none     | ""
 
 
-        "password" | _              | "somePassword1" | _             | _                  | PropertyLocation.env      | ""
-        "password" | _              | "somePassword2" | _             | _                  | PropertyLocation.property | ""
-        "password" | _              | "somePassword3" | _             | "String"           | PropertyLocation.script   | ""
-        "password" | _              | "somePassword4" | _             | "Provider<String>" | PropertyLocation.script   | ""
-        "password" | "password.set" | "somePassword5" | _             | "String"           | PropertyLocation.script   | ""
-        "password" | "password.set" | "somePassword6" | _             | "Provider<String>" | PropertyLocation.script   | ""
-        "password" | "password"     | "somePassword7" | _             | "String"           | PropertyLocation.script   | ""
-        "password" | "password"     | "somePassword8" | _             | "Provider<String>" | PropertyLocation.script   | ""
-        "password" | _              | _               | null          | _                  | PropertyLocation.none     | ""
+        "password"   | _                | "somePassword1"      | _             | _                        | PropertyLocation.env      | ""
+        "password"   | _                | "somePassword2"      | _             | _                        | PropertyLocation.property | ""
+        "password"   | _                | "somePassword3"      | _             | "String"                 | PropertyLocation.script   | ""
+        "password"   | _                | "somePassword4"      | _             | "Provider<String>"       | PropertyLocation.script   | ""
+        "password"   | "password.set"   | "somePassword5"      | _             | "String"                 | PropertyLocation.script   | ""
+        "password"   | "password.set"   | "somePassword6"      | _             | "Provider<String>"       | PropertyLocation.script   | ""
+        "password"   | "password"       | "somePassword7"      | _             | "String"                 | PropertyLocation.script   | ""
+        "password"   | "password"       | "somePassword8"      | _             | "Provider<String>"       | PropertyLocation.script   | ""
+        "password"   | _                | _                    | null          | _                        | PropertyLocation.none     | ""
 
+        "apiKeyPath" | _                | "/path/to/key1.json" | _             | _                        | PropertyLocation.env      | ""
+        "apiKeyPath" | _                | "/path/to/key2.json" | _             | _                        | PropertyLocation.property | ""
+        "apiKeyPath" | _                | "/path/to/key3.json" | _             | "File"                   | PropertyLocation.script   | ""
+        "apiKeyPath" | _                | "/path/to/key4.json" | _             | "Provider<RegularFile>"  | PropertyLocation.script   | ""
+        "apiKeyPath" | "apiKeyPath.set" | "/path/to/key5.json" | _             | "File"                   | PropertyLocation.script   | ""
+        "apiKeyPath" | "apiKeyPath.set" | "/path/to/key6.json" | _             | "Provider<RegularFile>"  | PropertyLocation.script   | ""
+        "apiKeyPath" | "apiKeyPath"     | "/path/to/key7.json" | _             | "File"                   | PropertyLocation.script   | ""
+        "apiKeyPath" | "apiKeyPath"     | "/path/to/key8.json" | _             | "Provider<RegularFile>" | PropertyLocation.script   | ""
+        "apiKeyPath" | _                | _                    | null          | _                        | PropertyLocation.none     | ""
         extensionName = "fastlane"
         value = (type != _) ? wrapValueBasedOnType(rawValue, type) : rawValue
         providedValue = (location == PropertyLocation.script) ? type : value
@@ -123,12 +134,15 @@ class FastlanePluginIntegrationSpec extends FastlaneIntegrationSpec {
         result.standardOutput.contains("${taskName}.${property}: ${testValue}")
 
         where:
-        property   | extensionProperty | tasktype    | rawValue    | expectedValue | type     | useProviderApi
-        "username" | "username"        | SighRenew   | "userName1" | _             | "String" | true
-        "username" | "username"        | PilotUpload | "userName2" | _             | "String" | true
+        property     | extensionProperty | tasktype    | rawValue             | expectedValue | type     | useProviderApi
+        "username"   | "username"        | SighRenew   | "userName1"          | _             | "String" | true
+        "username"   | "username"        | PilotUpload | "userName2"          | _             | "String" | true
 
-        "password" | "password"        | SighRenew   | "password1" | _             | "String" | true
-        "password" | "password"        | PilotUpload | "password2" | _             | "String" | true
+        "password"   | "password"        | SighRenew   | "password1"          | _             | "String" | true
+        "password"   | "password"        | PilotUpload | "password2"          | _             | "String" | true
+
+        "apiKeyPath" | "apiKeyPath"      | SighRenew   | "/path/to/key1.json" | _             | "File"   | true
+        "apiKeyPath" | "apiKeyPath"      | PilotUpload | "/path/to/key2.json" | _             | "File"   | true
 
         extensionName = "fastlane"
         taskName = "fastlaneTask"

--- a/src/integrationTest/groovy/wooga/gradle/fastlane/tasks/AbstractFastlaneTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/fastlane/tasks/AbstractFastlaneTaskIntegrationSpec.groovy
@@ -56,13 +56,19 @@ abstract class AbstractFastlaneTaskIntegrationSpec extends FastlaneIntegrationSp
         outputContains(result, "property: " + testValue.toString())
 
         where:
-        property  | method        | rawValue               | expectedValue | type
-        "logFile" | "logFile"     | "/some/path/test1.log" | _             | "File"
-        "logFile" | "logFile"     | "/some/path/test2.log" | _             | "Provider<RegularFile>"
-        "logFile" | "logFile.set" | "/some/path/test3.log" | _             | "File"
-        "logFile" | "logFile.set" | "/some/path/test4.log" | _             | "Provider<RegularFile>"
-        "logFile" | "setLogFile"  | "/some/path/test5.log" | _             | "File"
-        "logFile" | "setLogFile"  | "/some/path/test6.log" | _             | "Provider<RegularFile>"
+        property     | method           | rawValue               | expectedValue | type
+        "logFile"    | "logFile"        | "/some/path/test1.log" | _             | "File"
+        "logFile"    | "logFile"        | "/some/path/test2.log" | _             | "Provider<RegularFile>"
+        "logFile"    | "logFile.set"    | "/some/path/test3.log" | _             | "File"
+        "logFile"    | "logFile.set"    | "/some/path/test4.log" | _             | "Provider<RegularFile>"
+        "logFile"    | "setLogFile"     | "/some/path/test5.log" | _             | "File"
+        "logFile"    | "setLogFile"     | "/some/path/test6.log" | _             | "Provider<RegularFile>"
+        "apiKeyPath" | "apiKeyPath"     | "/some/path/key1.json" | _             | "File"
+        "apiKeyPath" | "apiKeyPath"     | "/some/path/key2.json" | _             | "Provider<RegularFile>"
+        "apiKeyPath" | "apiKeyPath.set" | "/some/path/key3.json" | _             | "File"
+        "apiKeyPath" | "apiKeyPath.set" | "/some/path/key4.json" | _             | "Provider<RegularFile>"
+        "apiKeyPath" | "setApiKeyPath"  | "/some/path/key5.json" | _             | "File"
+        "apiKeyPath" | "setApiKeyPath"  | "/some/path/key6.json" | _             | "Provider<RegularFile>"
 
 
         value = wrapValueBasedOnType(rawValue, type, { type ->

--- a/src/integrationTest/groovy/wooga/gradle/fastlane/tasks/PilotUploadIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/fastlane/tasks/PilotUploadIntegrationSpec.groovy
@@ -80,6 +80,7 @@ class PilotUploadIntegrationSpec extends AbstractFastlaneTaskIntegrationSpec {
         "skipWaitingForBuildProcessing" | _                                   | _                          | "Boolean"      || "--skip_waiting_for_build_processing false"
         "ipa"                           | "ipa.set"                           | "/path/to/test2.ipa"       | "File"         || "--ipa /path/to/test2.ipa"
         "additionalArguments"           | "setAdditionalArguments"            | ["--verbose", "--foo bar"] | "List<String>" || "--verbose --foo bar"
+        "apiKeyPath"                    | "apiKeyPath.set"                    | "/path/to/key.json"        | "File"         || "--api-key-path /path/to/key.json"
         value = wrapValueBasedOnType(rawValue, type)
         valueMessage = (rawValue != _) ? "with value ${value}" : "without value"
     }

--- a/src/integrationTest/groovy/wooga/gradle/fastlane/tasks/SighRenewIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/fastlane/tasks/SighRenewIntegrationSpec.groovy
@@ -84,6 +84,7 @@ class SighRenewIntegrationSpec extends AbstractFastlaneTaskIntegrationSpec {
         "fileName"                        | "fileName.set"                        | "test2.mobileprovisioning" | "String"       || "--filename test2.mobileprovisioning"
         "destinationDir"                  | "destinationDir.set"                  | "/some/path"               | "File"         || "--output_path /some/path"
         "additionalArguments"             | "setAdditionalArguments"              | ["--verbose", "--foo bar"] | "List<String>" || "--verbose --foo bar"
+        "apiKeyPath"                      | "apiKeyPath.set"                      | "/path/to/key.json"        | "File"         || "--api-key-path /path/to/key.json"
         value = wrapValueBasedOnType(rawValue, type)
         valueMessage = (rawValue != _) ? "with value ${value}" : "without value"
     }

--- a/src/main/groovy/wooga/gradle/fastlane/FastlaneActionSpec.groovy
+++ b/src/main/groovy/wooga/gradle/fastlane/FastlaneActionSpec.groovy
@@ -39,4 +39,12 @@ interface FastlaneActionSpec<T extends FastlaneActionSpec> {
     T argument(String argument)
     T arguments(String... arguments)
     T arguments(Iterable<String> arguments)
+
+    RegularFileProperty getApiKeyPath()
+
+    void setApiKeyPath(File value)
+    void setApiKeyPath(Provider<RegularFile> value)
+
+    T apiKeyPath(File value)
+    T apiKeyPath(Provider<RegularFile> value)
 }

--- a/src/main/groovy/wooga/gradle/fastlane/FastlanePluginConsts.groovy
+++ b/src/main/groovy/wooga/gradle/fastlane/FastlanePluginConsts.groovy
@@ -22,4 +22,5 @@ class FastlanePluginConsts {
 
     static final PropertyLookup USERNAME_LOOKUP = new PropertyLookup("FASTLANE_USERNAME", "fastlane.username", null)
     static final PropertyLookup PASSWORD_LOOKUP = new PropertyLookup("FASTLANE_PASSWORD", "fastlane.password", null)
+    static final PropertyLookup API_KEY_PATH_LOOKUP = new PropertyLookup("FASTLANE_API_KEY_PATH", "fastlane.apiKeyPath", null)
 }

--- a/src/main/groovy/wooga/gradle/fastlane/FastlanePluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/fastlane/FastlanePluginExtension.groovy
@@ -16,7 +16,8 @@
 
 package wooga.gradle.fastlane
 
-
+import org.gradle.api.file.RegularFile
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 
@@ -36,4 +37,12 @@ interface FastlanePluginExtension<T extends FastlanePluginExtension> {
 
     T password(String value)
     T password(Provider<String> value)
+
+    RegularFileProperty getApiKeyPath()
+
+    void setApiKeyPath(File value)
+    void setApiKeyPath(Provider<RegularFile> value)
+
+    T apiKeyPath(File value)
+    T apiKeyPath(Provider<RegularFile> value)
 }

--- a/src/main/groovy/wooga/gradle/fastlane/internal/DefaultFastlanePluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/fastlane/internal/DefaultFastlanePluginExtension.groovy
@@ -18,6 +18,8 @@ package wooga.gradle.fastlane.internal
 
 
 import org.gradle.api.Project
+import org.gradle.api.file.RegularFile
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import wooga.gradle.fastlane.FastlanePluginExtension
@@ -31,6 +33,7 @@ class DefaultFastlanePluginExtension implements FastlanePluginExtension {
 
         username = project.objects.property(String)
         password = project.objects.property(String)
+        apiKeyPath = project.layout.fileProperty()
     }
 
     final Property<String> username
@@ -81,4 +84,27 @@ class DefaultFastlanePluginExtension implements FastlanePluginExtension {
         this
     }
 
+    final RegularFileProperty apiKeyPath
+
+    @Override
+    void setApiKeyPath(File value) {
+        apiKeyPath.set(value)
+    }
+
+    @Override
+    void setApiKeyPath(Provider<RegularFile> value) {
+        apiKeyPath.set(value)
+    }
+
+    @Override
+    FastlanePluginExtension apiKeyPath(File value) {
+        setApiKeyPath(value)
+        this
+    }
+
+    @Override
+    FastlanePluginExtension apiKeyPath(Provider<RegularFile> value) {
+        setApiKeyPath(value)
+        this
+    }
 }

--- a/src/main/groovy/wooga/gradle/fastlane/tasks/AbstractFastlaneTask.groovy
+++ b/src/main/groovy/wooga/gradle/fastlane/tasks/AbstractFastlaneTask.groovy
@@ -21,7 +21,9 @@ import org.gradle.api.file.RegularFile
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 import wooga.gradle.fastlane.FastlaneActionSpec
 import wooga.gradle.fastlane.internal.FastlaneAction
@@ -83,9 +85,36 @@ abstract class AbstractFastlaneTask extends DefaultTask implements FastlaneActio
         return this
     }
 
+    @Optional
+    @InputFile
+    final RegularFileProperty apiKeyPath
+
+    @Override
+    void setApiKeyPath(File value) {
+        apiKeyPath.set(value)
+    }
+
+    @Override
+    void setApiKeyPath(Provider<RegularFile> value) {
+        apiKeyPath.set(value)
+    }
+
+    @Override
+    AbstractFastlaneTask apiKeyPath(File value) {
+        setApiKeyPath(value)
+        this
+    }
+
+    @Override
+    AbstractFastlaneTask apiKeyPath(Provider<RegularFile> value) {
+        setApiKeyPath(value)
+        this
+    }
+
     AbstractFastlaneTask() {
         additionalArguments = project.objects.listProperty(String)
         logFile = project.layout.fileProperty()
+        apiKeyPath = project.layout.fileProperty()
     }
 
     @TaskAction

--- a/src/main/groovy/wooga/gradle/fastlane/tasks/PilotUpload.groovy
+++ b/src/main/groovy/wooga/gradle/fastlane/tasks/PilotUpload.groovy
@@ -302,6 +302,10 @@ class PilotUpload extends AbstractFastlaneTask {
                 arguments << "--itc_provider" << itcProvider.get()
             }
 
+            if (apiKeyPath.present) {
+                arguments << "--api-key-path" << apiKeyPath.get().asFile.path
+            }
+
             arguments << "--skip_submission" << (skipSubmission.present && skipSubmission.get()).toString()
             arguments << "--skip_waiting_for_build_processing" << (skipWaitingForBuildProcessing.present && skipWaitingForBuildProcessing.get()).toString()
             arguments << "--ipa" << ipa.get().asFile.path

--- a/src/main/groovy/wooga/gradle/fastlane/tasks/SighRenew.groovy
+++ b/src/main/groovy/wooga/gradle/fastlane/tasks/SighRenew.groovy
@@ -313,6 +313,10 @@ class SighRenew extends AbstractFastlaneTask {
                 arguments << "--provisioning_name" << provisioningName.get()
             }
 
+            if (apiKeyPath.present) {
+                arguments << "--api-key-path" << apiKeyPath.get().asFile.path
+            }
+
             arguments << "--adhoc" << (adhoc.present && adhoc.get()).toString()
             arguments << "--readonly" << (readOnly.present && readOnly.get()).toString()
             arguments << "--ignore_profiles_with_different_name" << (ignoreProfilesWithDifferentName.present && ignoreProfilesWithDifferentName.get()).toString()


### PR DESCRIPTION
## Description

This patch adds missing setup to use the an appstore connection key with fastlane. Fastlane commands expect a json file with all information passed to with `--api-key-path` commandline argument. More informations about this file can be found [here](https://docs.fastlane.tools/app-store-connect-api/#using-fastlane-api-key-json-file)

This patch adds all gradle properties to pass down this field. The path to the file can also be configured in the fastlane plugin extension, gradle properties or environment variables.

| property              | gradle property name              | environment variable                |
| --------------------- | --------------------------------- | ----------------------------------- |
| apiKeyPath            | `fastlane.apiKeyPath`             | `FASTLANE_API_KEY_PATH`             |

## Changes

* ![IMPROVE] ![IOS] fastlane appstore conntection support


[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
