### PR TITLE
Move library macos-security to external repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,10 @@ dependencies {
         force = true
     }
 
-    compile(project(path: ':lib:macos-security', configuration: 'archives'))
+    compile('com.wooga.security:macos-security:1.+') {
+        exclude group: "org.codehaus.groovy", module: "groovy-all"
+    }
+
     integrationTestCompile(project(path: ':lib:spock-macos-keychain-extension', configuration: 'archives')) {
         exclude group: "org.codehaus.groovy", module: "groovy-all"
     }

--- a/lib/spock-macos-keychain-extension/build.gradle
+++ b/lib/spock-macos-keychain-extension/build.gradle
@@ -36,7 +36,7 @@ if (cliTasks.contains("rc")) {
 
 dependencies {
     implementation ('org.spockframework:spock-core:1.2-groovy-2.4')
-    api project(path: ':lib:macos-security', configuration: 'archives')
+    api 'com.wooga.security:macos-security:1.0.0'
 }
 
 repositories {

--- a/settings.gradle
+++ b/settings.gradle
@@ -26,4 +26,3 @@
 
 rootProject.name = 'atlas-build-unity'
 include ':lib:spock-macos-keychain-extension'
-include ':lib:macos-security'


### PR DESCRIPTION
## Description

This patch moves the helper library `macos-keychain` to a new repository https://github.com/wooga/macos-security.groovy Its not available through jcenter just now so to use it we need to configure a repository to fetch it from:

```groovy
repositories {
    maven {
        url  "https://dl.bintray.com/wooga/maven"
    }
}
```

I send a request to jcenter to host this library. But that might take a few minutes/hours.

For use in a gradle project souround this with a `buildScript` block.

## Changes

* ![IMPROVE] move library `macos-security` to external repo

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
