### PR TITLE
Add keychain search list manipulation tasks

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/build/IntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/IntegrationSpec.groovy
@@ -107,6 +107,7 @@ class IntegrationSpec extends nebula.test.IntegrationSpec{
                 value = "${rawValue.collect { '"' + it + '"' }.join(", ")}"
                 break
             case "List":
+            case "Iterable":
                 value = "[${rawValue.collect { '"' + it + '"' }.join(", ")}]"
                 break
             case "Map":

--- a/src/integrationTest/groovy/wooga/gradle/macOS/security/tasks/KeychainSearchListSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/macOS/security/tasks/KeychainSearchListSpec.groovy
@@ -1,0 +1,88 @@
+package wooga.gradle.macOS.security.tasks
+
+import com.wooga.security.Domain
+import com.wooga.security.MacOsKeychain
+import com.wooga.security.MacOsKeychainSearchList
+import com.wooga.spock.extensios.security.Keychain
+import spock.lang.Shared
+import spock.lang.Unroll
+import wooga.gradle.build.IntegrationSpec
+
+abstract class KeychainSearchListSpec extends IntegrationSpec {
+
+    abstract String getTestTaskName()
+
+    abstract Class getTaskType()
+
+    MacOsKeychainSearchList keychainSearchList = new MacOsKeychainSearchList()
+
+    @Shared
+    @Keychain
+    MacOsKeychain buildKeychain
+
+    @Shared
+    @Keychain
+    MacOsKeychain buildKeychain2
+
+    @Shared
+    @Keychain
+    MacOsKeychain buildKeychain3
+
+    def setup() {
+        keychainSearchList.reset()
+        buildFile << """
+        task ${testTaskName}(type: ${taskType.name}) {
+        }
+        """.stripIndent()
+    }
+
+    def cleanup() {
+        keychainSearchList.reset()
+    }
+
+
+    @Unroll("can set property #property with #method and type #type")
+    def "can set property keychainSearchListSpec"() {
+        given: "a task to read back the value"
+        buildFile << """
+            task("readValue") {
+                doLast {
+                    println("property: " + ${testTaskName}.${property}.get())
+                }
+            }
+        """.stripIndent()
+        and: "a set property"
+
+        buildFile << """
+            ${testTaskName}.${method}($value)
+        """.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully("readValue")
+
+        then:
+        outputContains(result, "property: " + expectedValue.toString())
+
+        where:
+        property | method       | rawValue  | type
+        "domain" | "domain"     | "user"    | "String"
+        "domain" | "domain"     | "system"  | "Domain"
+        "domain" | "domain"     | "common"  | "Provider<Domain>"
+        "domain" | "domain.set" | "dynamic" | "Domain"
+        "domain" | "domain.set" | "user"    | "Provider<Domain>"
+        "domain" | "setDomain"  | "system"  | "String"
+        "domain" | "setDomain"  | "common"  | "Domain"
+        "domain" | "setDomain"  | "dynamic" | "Provider<Domain>"
+
+        value = wrapValueBasedOnType(rawValue, type) { type ->
+
+            switch (type) {
+                case Domain.simpleName:
+                    return "${Domain.class.name}.valueOf('${rawValue.toString()}')"
+                default:
+                    return rawValue
+            }
+        }
+        expectedValue = rawValue
+    }
+}

--- a/src/integrationTest/groovy/wooga/gradle/macOS/security/tasks/SecurityResetKeychainSearchListIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/macOS/security/tasks/SecurityResetKeychainSearchListIntegrationSpec.groovy
@@ -1,0 +1,45 @@
+package wooga.gradle.macOS.security.tasks
+
+import jdk.nashorn.internal.ir.annotations.Ignore
+import spock.lang.Requires
+
+@Requires({ os.macOs && env['ATLAS_BUILD_UNITY_IOS_EXECUTE_KEYCHAIN_SPEC'] == 'YES' })
+class SecurityResetKeychainSearchListIntegrationSpec extends KeychainSearchListSpec {
+    String testTaskName = "resetKeychainSearchList"
+    Class taskType = SecurityResetKeychainSearchList
+
+    @Ignore
+    def "can reset keychain lookup list"() {
+        given: "a default keychain"
+        def defaultLookupList = keychainSearchList.collect()
+
+        and: "value in environment to opt in for reset"
+        environmentVariables.set("ATLAS_BUILD_UNITY_IOS_RESET_KEYCHAINS", "YES")
+
+        and: "some keychains added"
+        keychainSearchList.addAll(keychains.collect { it.location })
+
+        when:
+        def result = runTasksSuccessfully(testTaskName)
+
+        then:
+        !result.wasSkipped(testTaskName)
+        keychainSearchList.collect() == defaultLookupList
+
+        where:
+        keychains                                       | message
+        [buildKeychain, buildKeychain2, buildKeychain3] | "multiple keychains"
+    }
+
+    def "skip reset if ATLAS_BUILD_UNITY_IOS_RESET_KEYCHAINS is not set to YES"() {
+        given: "environment setting disabled"
+        environmentVariables.set('ATLAS_BUILD_UNITY_IOS_RESET_KEYCHAINS', "NO")
+        fork = true
+
+        when:
+        def result = runTasksSuccessfully(testTaskName)
+
+        then:
+        result.wasSkipped(testTaskName)
+    }
+}

--- a/src/integrationTest/groovy/wooga/gradle/macOS/security/tasks/SecuritySetKeychainSearchListIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/macOS/security/tasks/SecuritySetKeychainSearchListIntegrationSpec.groovy
@@ -1,0 +1,200 @@
+package wooga.gradle.macOS.security.tasks
+
+
+import spock.lang.Requires
+import spock.lang.Unroll
+
+@Requires({ os.macOs && env['ATLAS_BUILD_UNITY_IOS_EXECUTE_KEYCHAIN_SPEC'] == 'YES' })
+class SecuritySetKeychainSearchListIntegrationSpec extends KeychainSearchListSpec {
+    String testTaskName = "keychainLookup"
+    Class taskType = SecuritySetKeychainSearchList
+
+    @Unroll
+    def "can add #message to the lookup list"() {
+        given: "a lookup list without the keychain added"
+        keychains.each {
+            assert !keychainSearchList.contains(it.location)
+        }
+
+        and: "the keychain configured"
+        buildFile << """
+        ${testTaskName} {
+            action = "add"
+            keychains(files('${keychains.collect { it.location.path }.join('\', \'')}'))
+        }
+        """.stripIndent()
+
+        when:
+        runTasksSuccessfully(testTaskName)
+
+        then:
+        keychains.every {
+            keychainSearchList.contains(it.location)
+        }
+
+        where:
+        keychains                                       | message
+        [buildKeychain]                                 | "a single keychain"
+        [buildKeychain, buildKeychain2, buildKeychain3] | "multiple keychains"
+    }
+
+    @Unroll
+    def "can remove #message to the lookup list"() {
+        given: "a lookup list without the keychain added"
+        keychainSearchList.addAll(keychains.collect { it.location })
+        keychains.each {
+            assert keychainSearchList.contains(it.location)
+        }
+
+        and: "the keychain configured"
+        buildFile << """
+        ${testTaskName} {
+            action = "remove"
+            keychains(files('${keychains.collect { it.location.path }.join('\', \'')}'))
+        }
+        """.stripIndent()
+
+        when:
+        runTasksSuccessfully(testTaskName)
+
+        then:
+        !keychains.every {
+            keychainSearchList.contains(it.location)
+        }
+
+        where:
+        keychains                                       | message
+        [buildKeychain]                                 | "a single keychain"
+        [buildKeychain, buildKeychain2, buildKeychain3] | "multiple keychains"
+    }
+
+    @Unroll
+    def "skips with no source when action is #action and no keychains are configured"() {
+        given:
+        buildFile << """
+        ${testTaskName} {
+            action = "${action}"
+        }
+        """.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully(testTaskName)
+
+        then:
+        result.standardOutput.contains("Task :${testTaskName} NO-SOURCE")
+
+        where:
+        action << ["add", "remove"]
+    }
+
+    @Unroll
+    def "skipped when #message"() {
+        given: "keychains in the search list"
+        keychainSearchList.addAll(keychainsInSearchList.collect { it.location })
+        keychainsInSearchList.each {
+            assert keychainSearchList.contains(it.location)
+        }
+
+        and: "test task configured with action and keychains"
+        buildFile << """
+        ${testTaskName} {
+            action = "${action}"
+            keychains(files('${keychains.collect { it.location.path }.join('\', \'')}'))
+        }
+        """.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully(testTaskName)
+
+        then:
+        result.wasSkipped(testTaskName)
+
+        where:
+        action   | keychains                       | keychainsInSearchList                           | message
+        "add"    | [buildKeychain, buildKeychain2] | [buildKeychain, buildKeychain2, buildKeychain3] | "all keychains already added"
+        "remove" | [buildKeychain3]                | [buildKeychain, buildKeychain2]                 | "keychain to remove not in search list"
+    }
+
+    @Unroll("can set property #property with #method and type #type")
+    def "can set property"() {
+        given: "a task to read back the value"
+        buildFile << """
+            task("readValue") {
+                doLast {
+                    println("property: " + ${testTaskName}.${property}.get())
+                }
+            }
+        """.stripIndent()
+        and: "a set property"
+
+        buildFile << """
+            ${testTaskName}.${method}($value)
+        """.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully("readValue")
+
+        then:
+        outputContains(result, "property: " + expectedValue.toString())
+
+        where:
+        property | method       | rawValue | type
+        "action" | "action"     | "add"    | "String"
+        "action" | "action"     | "remove" | "Action"
+        "action" | "action"     | "add"    | "Provider<Action>"
+        "action" | "action.set" | "remove" | "Action"
+        "action" | "action.set" | "add"    | "Provider<Action>"
+        "action" | "setAction"  | "remove" | "String"
+        "action" | "setAction"  | "add"    | "Action"
+        "action" | "setAction"  | "remove" | "Provider<Action>"
+
+        value = wrapValueBasedOnType(rawValue, type) { type ->
+
+            switch (type) {
+                case SecuritySetKeychainSearchList.Action.simpleName:
+                    return "${SecuritySetKeychainSearchList.Action.class.name}.valueOf('${rawValue.toString()}')"
+                default:
+                    return rawValue
+            }
+        }
+        expectedValue = rawValue
+    }
+
+    @Unroll("method :#method with type #type #message")
+    def "method alters keychains property"() {
+        given: "a task to read back the value"
+        buildFile << """
+            task("readValue") {
+                doLast {
+                    println("property: " + ${testTaskName}.keychains.files)
+                }
+            }
+        """.stripIndent()
+        and: "a set property"
+        buildFile << """
+            ${testTaskName}.keychains.setFrom($baseValueWrapped)
+            ${testTaskName}.${method}($value)
+        """.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully("readValue")
+
+        then:
+        outputContains(result, "property: " + expectedValue.toString())
+
+        where:
+        method         | rawValue                          | type                       | appends
+        "keychain"     | "/some/path/1"                    | "File"                     | true
+        "keychain"     | "/some/path/2"                    | "Provider<File>"           | true
+        "keychains"    | ["/some/path/3", "/some/path/4"]  | "Iterable<File>"           | true
+        "keychains"    | ["/some/path/5", "/some/path/6"]  | "Provider<Iterable<File>>" | true
+        "setKeychains" | ["/some/path/7", "/some/path/8"]  | "Iterable<File>"           | false
+        "setKeychains" | ["/some/path/9", "/some/path/10"] | "Provider<Iterable<File>>" | false
+
+        baseValue = ["/some/path/0"]
+        value = wrapValueBasedOnType(rawValue, type)
+        baseValueWrapped = wrapValueBasedOnType(baseValue, "List<File>")
+        expectedValue = appends ? [baseValue, [rawValue]].flatten() : [rawValue].flatten()
+        message = appends ? "appends to keychains collection" : "set keychains collection"
+    }
+}

--- a/src/main/groovy/wooga/gradle/macOS/security/tasks/AbstractSecurityKeychainSearchListTask.groovy
+++ b/src/main/groovy/wooga/gradle/macOS/security/tasks/AbstractSecurityKeychainSearchListTask.groovy
@@ -1,0 +1,57 @@
+package wooga.gradle.macOS.security.tasks
+
+import com.wooga.security.Domain
+import com.wooga.security.MacOsKeychainSearchList
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+
+abstract class AbstractSecurityKeychainSearchListTask<T extends AbstractSecurityKeychainSearchListTask> extends DefaultTask {
+    final Provider<MacOsKeychainSearchList> searchListProvider
+
+    MacOsKeychainSearchList getSearchList() {
+        searchListProvider.get()
+    }
+
+    @Optional
+    @Input
+    final Property<Domain> domain
+
+    void setDomain(Domain value) {
+        domain.set(value)
+    }
+
+    void setDomain(String value) {
+        domain.set(Domain.valueOf(value))
+    }
+
+    void setDomain(Provider<Domain> value) {
+        domain.set(value)
+    }
+
+    T domain(Domain value) {
+        setDomain(value)
+        this as T
+    }
+
+    T domain(String value) {
+        setDomain(Domain.valueOf(value))
+    }
+
+    T domain(Provider<Domain> value) {
+        setDomain(value)
+        this as T
+    }
+
+    AbstractSecurityKeychainSearchListTask() {
+        this.domain = project.objects.property(Domain)
+        this.searchListProvider = project.provider({
+            if (domain.isPresent()) {
+                return new MacOsKeychainSearchList(domain.get())
+            }
+            new MacOsKeychainSearchList()
+        })
+    }
+}

--- a/src/main/groovy/wooga/gradle/macOS/security/tasks/SecurityResetKeychainSearchList.groovy
+++ b/src/main/groovy/wooga/gradle/macOS/security/tasks/SecurityResetKeychainSearchList.groovy
@@ -1,0 +1,22 @@
+package wooga.gradle.macOS.security.tasks
+
+import org.gradle.api.specs.Spec
+import org.gradle.api.tasks.TaskAction
+
+class SecurityResetKeychainSearchList extends AbstractSecurityKeychainSearchListTask {
+
+    SecurityResetKeychainSearchList() {
+        super()
+        onlyIf(new Spec<SecurityResetKeychainSearchList>() {
+            @Override
+            boolean isSatisfiedBy(SecurityResetKeychainSearchList task) {
+                return System.getenv("ATLAS_BUILD_UNITY_IOS_RESET_KEYCHAINS") == "YES"
+            }
+        })
+    }
+
+    @TaskAction
+    protected void reset() {
+        searchList.reset()
+    }
+}

--- a/src/main/groovy/wooga/gradle/macOS/security/tasks/SecuritySetKeychainSearchList.groovy
+++ b/src/main/groovy/wooga/gradle/macOS/security/tasks/SecuritySetKeychainSearchList.groovy
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2018-2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wooga.gradle.macOS.security.tasks
+
+
+import org.gradle.api.Task
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.specs.Spec
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.SkipWhenEmpty
+import org.gradle.api.tasks.TaskAction
+
+class SecuritySetKeychainSearchList extends AbstractSecurityKeychainSearchListTask {
+
+    enum Action {
+        add,
+        remove
+    }
+
+    @Input
+    final Property<Action> action
+
+    void setAction(String value) {
+        action.set(Action.valueOf(value))
+    }
+
+    void setAction(Action value) {
+        action.set(value)
+    }
+
+    void setAction(Provider<Action> value) {
+        action.set(value)
+    }
+
+    SecuritySetKeychainSearchList action(String value) {
+        setAction(Action.valueOf(value))
+        this
+    }
+
+    SecuritySetKeychainSearchList action(Action value) {
+        setAction(value)
+        this
+    }
+
+    SecuritySetKeychainSearchList action(Provider<Action> value) {
+        setAction(value)
+        this
+    }
+
+    @SkipWhenEmpty
+    @InputFiles
+    final ConfigurableFileCollection keychains
+
+    void setKeychains(Iterable<File> value) {
+        keychains.setFrom(value)
+    }
+
+    void setKeychains(Provider<Iterable<File>> value) {
+        keychains.setFrom(value)
+    }
+
+    SecuritySetKeychainSearchList keychains(Iterable<File> value) {
+        keychains.from(project.provider({ value }))
+        this
+    }
+
+    SecuritySetKeychainSearchList keychains(Provider<Iterable<File>> value) {
+        keychains.from(value)
+        this
+    }
+
+    void keychain(Provider<File> keychain) {
+        keychains.from(keychain)
+    }
+
+    void keychain(File keychain) {
+        keychains.from(keychain)
+    }
+
+
+    SecuritySetKeychainSearchList() {
+        keychains = project.layout.configurableFiles()
+        action = project.objects.property(Action)
+
+        onlyIf(new Spec<Task>() {
+            @Override
+            boolean isSatisfiedBy(Task task) {
+                //Don't skip if keychains are empty. We want gradle to return NO-SOURCE skip reason
+                if (keychains.isEmpty()) {
+                    return true
+                }
+                switch (action.get()) {
+                    case Action.add:
+                        def filesToCheck = keychains.files.findAll { it.exists() }
+                        return !searchList.containsAll(filesToCheck)
+                    case Action.remove:
+                        return keychains.files.any { searchList.contains(it) }
+                }
+            }
+        })
+    }
+
+    @TaskAction
+    protected list() {
+        def keychains = getKeychains().files
+        switch (action.get()) {
+            case Action.add:
+                searchList.addAll(keychains)
+                break
+            case Action.remove:
+                searchList.removeAll(keychains)
+                break
+        }
+    }
+}


### PR DESCRIPTION
## Description

This is a more generic implementation of the old `ListKeychain` task. It uses the `MacOsKeychainSearchList` class to add/remove keychains to the search list. I also split out the `reset` action into it's own command `SecurityResetKeychainSearchList` as the interface is different.

## Changes

* ![ADD] `SecuritySetKeychainSearchList` task
* ![ADD] `SecurityResetKeychainSearchList` task


[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
