### PR TITLE
Add new task type ImportCodeSigningIdentity

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/build/unity/ios/tasks/ImportCodeSigningIdentityIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/unity/ios/tasks/ImportCodeSigningIdentityIntegrationSpec.groovy
@@ -1,0 +1,144 @@
+package wooga.gradle.build.unity.ios.tasks
+
+import com.wooga.security.MacOsKeychain
+import com.wooga.security.SecurityHelper
+import com.wooga.spock.extensios.security.Keychain
+import spock.lang.Requires
+import spock.lang.Shared
+import spock.lang.Unroll
+import wooga.gradle.build.IntegrationSpec
+
+@Requires({ os.macOs })
+class ImportCodeSigningIdentityIntegrationSpec extends IntegrationSpec {
+
+    String testTaskName = "importSigningIdentity"
+    Class taskType = ImportCodeSigningIdentity
+
+    @Keychain(unlockKeychain = true)
+    MacOsKeychain buildKeychain
+
+    def setup() {
+        buildFile << """
+        task ${testTaskName}(type: ${taskType.name}) {
+            keychain = file('${buildKeychain.location}')
+        }
+        """.stripIndent()
+    }
+
+    @Unroll("import #taskStatus when #reason")
+    def "imports signing identity"() {
+        given: "an invalid sighing certificate"
+        def passphrase = "123456"
+        def cert = SecurityHelper.createTestCodeSigningCertificatePkcs12([commonName: testSigningIdentity], passphrase)
+        buildFile << """
+        ${testTaskName} {
+            passphrase = "${passphrase}"
+            p12 = file('${cert.path}')
+            signingIdentity = "${expectedSigningIdentity}"
+            ignoreInvalidSigningIdentity = ${ignoreInvalidSigningIdentities}
+        }
+        """.stripIndent()
+
+        when:
+        def result = runTasks(testTaskName)
+
+        then:
+        result.success == taskSuccessfull
+        result.standardOutput.contains(expectedLogMessage)
+
+        where:
+        testSigningIdentity        | signingIdentity          | ignoreInvalidSigningIdentities || taskSuccessfull | reason                                           | logMessage
+        "test signing: Wooga GmbH" | _                        | false                          || false           | "imported identity is invalid"                   | "Unable to find valid code sign identity '#expectedSigningIdentity' in keychain"
+        "test signing: Wooga GmbH" | _                        | true                           || true            | "imported identity is invalid but error ignored" | "Signing Identity '#expectedSigningIdentity' found but invalid"
+        "test signing: Wooga GmbH" | "some signing: Foo GmbH" | true                           || false           | "expected identity was not imported"             | "Unable to find code sign identity '#expectedSigningIdentity' in keychain"
+
+        expectedSigningIdentity = signingIdentity == _ ? testSigningIdentity : signingIdentity
+        expectedLogMessage = logMessage.toString().replaceAll("#expectedSigningIdentity", expectedSigningIdentity.toString())
+        taskStatus = taskSuccessfull ? "succeeds" : "fails"
+    }
+
+    @Unroll("can set property #property with #method and type #type")
+    def "can set property"() {
+        given: "a task to read back the value"
+        buildFile << """
+            task("readValue") {
+                doLast {
+                    println("property: " + ${testTaskName}.${property}.get())
+                }
+            }
+        """.stripIndent()
+        and: "a set property"
+
+        buildFile << """
+            ${testTaskName}.${method}($value)
+        """.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully("readValue")
+
+        then:
+        outputContains(result, "property: " + expectedValue.toString())
+
+        where:
+        property                       | method                             | rawValue             | type
+        "ignoreInvalidSigningIdentity" | "ignoreInvalidSigningIdentity"     | true                 | "Boolean"
+        "ignoreInvalidSigningIdentity" | "ignoreInvalidSigningIdentity"     | false                | "Provider<Boolean>"
+        "ignoreInvalidSigningIdentity" | "ignoreInvalidSigningIdentity.set" | true                 | "Boolean"
+        "ignoreInvalidSigningIdentity" | "ignoreInvalidSigningIdentity.set" | false                | "Provider<Boolean>"
+        "ignoreInvalidSigningIdentity" | "setIgnoreInvalidSigningIdentity"  | true                 | "Boolean"
+        "ignoreInvalidSigningIdentity" | "setIgnoreInvalidSigningIdentity"  | false                | "Provider<Boolean>"
+
+        "p12"                          | "p12"                              | "/path/to/p12"       | "File"
+        "p12"                          | "p12"                              | "/path/to/p12"       | "Provider<RegularFile>"
+        "p12"                          | "p12.set"                          | "/path/to/p12"       | "File"
+        "p12"                          | "p12.set"                          | "/path/to/p12"       | "Provider<RegularFile>"
+        "p12"                          | "setP12"                           | "/path/to/p12"       | "File"
+        "p12"                          | "setP12"                           | "/path/to/p12"       | "Provider<RegularFile>"
+
+        "keychain"                     | "keychain"                         | "/path/to/keychain1" | "File"
+        "keychain"                     | "keychain"                         | "/path/to/keychain2" | "Provider<RegularFile>"
+        "keychain"                     | "keychain.set"                     | "/path/to/keychain3" | "File"
+        "keychain"                     | "keychain.set"                     | "/path/to/keychain4" | "Provider<RegularFile>"
+        "keychain"                     | "setKeychain"                      | "/path/to/keychain5" | "File"
+        "keychain"                     | "setKeychain"                      | "/path/to/keychain6" | "Provider<RegularFile>"
+
+        "passphrase"                   | "passphrase"                       | "testPassphrase1"    | "String"
+        "passphrase"                   | "passphrase"                       | "testPassphrase2"    | "Provider<String>"
+        "passphrase"                   | "passphrase.set"                   | "testPassphrase3"    | "String"
+        "passphrase"                   | "passphrase.set"                   | "testPassphrase4"    | "Provider<String>"
+        "passphrase"                   | "setPassphrase"                    | "testPassphrase5"    | "String"
+        "passphrase"                   | "setPassphrase"                    | "testPassphrase6"    | "Provider<String>"
+
+        "signingIdentity"              | "signingIdentity"                  | "code sign: ID1"     | "String"
+        "signingIdentity"              | "signingIdentity"                  | "code sign: ID2"     | "Provider<String>"
+        "signingIdentity"              | "signingIdentity.set"              | "code sign: ID3"     | "String"
+        "signingIdentity"              | "signingIdentity.set"              | "code sign: ID4"     | "Provider<String>"
+        "signingIdentity"              | "setSigningIdentity"               | "code sign: ID5"     | "String"
+        "signingIdentity"              | "setSigningIdentity"               | "code sign: ID6"     | "Provider<String>"
+        value = wrapValueBasedOnType(rawValue, type)
+        expectedValue = rawValue
+    }
+
+    def "skips task if identity is already in keychain"() {
+        def passphrase = "123456"
+        def identityName = "codesign test"
+        def cert = SecurityHelper.createTestCodeSigningCertificatePkcs12([commonName: identityName], passphrase)
+
+        buildKeychain.importFile(cert, [passphrase: passphrase])
+
+        buildFile << """
+        ${testTaskName} {
+            passphrase = "${passphrase}"
+            p12 = file('${cert.path}')
+            signingIdentity = "${identityName}"
+            ignoreInvalidSigningIdentity = true
+        }
+        """.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully(testTaskName)
+
+        then:
+        result.wasSkipped(testTaskName)
+    }
+}

--- a/src/main/groovy/com/wooga/security/FindIdentityResult.groovy
+++ b/src/main/groovy/com/wooga/security/FindIdentityResult.groovy
@@ -1,0 +1,46 @@
+package com.wooga.security
+
+import java.util.regex.Matcher
+
+class FindIdentityResult {
+    final List<String> matchingIdentities
+    final List<String> validIdentities
+
+    Boolean hasValidIdentity(String identityName) {
+        validIdentities.contains(identityName)
+    }
+
+    Boolean hasIdentity(String identityName, Boolean valid = false) {
+        if (valid) {
+            return hasValidIdentity(identityName)
+        }
+        matchingIdentities.contains(identityName)
+    }
+
+    FindIdentityResult(List<String> matchingIdentities, List<String> validIdentities) {
+        this.matchingIdentities = matchingIdentities
+        this.validIdentities = validIdentities
+    }
+
+    static FindIdentityResult fromOutPut(String output) {
+        Boolean parseMatchingIdentities = false
+        Boolean parseValidIdentities = false
+        List<String> matchingIdentities = []
+        List<String> validIdentities = []
+        output.eachLine {
+            def line = it.trim()
+            if (line =~ /\d+\) ([A-Z0-9]{40}) "(.*?)"/) {
+                def list = parseMatchingIdentities ? matchingIdentities : validIdentities
+                list.push(Matcher.lastMatcher[0][2].toString())
+            } else if (line == "Matching identities") {
+                parseMatchingIdentities = true
+                parseValidIdentities = false
+            } else if (line == "Valid identities") {
+                parseMatchingIdentities = false
+                parseValidIdentities = true
+            }
+        }
+
+        new FindIdentityResult(matchingIdentities, validIdentities)
+    }
+}

--- a/src/main/groovy/wooga/gradle/build/unity/ios/tasks/ImportCodeSigningIdentity.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/tasks/ImportCodeSigningIdentity.groovy
@@ -1,0 +1,176 @@
+package wooga.gradle.build.unity.ios.tasks
+
+import com.wooga.security.FindIdentityResult
+import com.wooga.security.command.FindIdentity
+import com.wooga.security.command.Import
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.Task
+import org.gradle.api.file.RegularFile
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.specs.Spec
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.TaskAction
+
+class ImportCodeSigningIdentity extends DefaultTask {
+    @InputFile
+    final RegularFileProperty p12
+
+    void setP12(File value) {
+        p12.set(value)
+    }
+
+    void setP12(Provider<RegularFile> value) {
+        p12.set(value)
+    }
+
+    ImportCodeSigningIdentity p12(File value) {
+        setP12(value)
+        this
+    }
+
+    ImportCodeSigningIdentity p12(Provider<RegularFile> value) {
+        setP12(value)
+        this
+    }
+
+    @Input
+    final Property<String> passphrase
+
+    void setPassphrase(String value) {
+        passphrase.set(value)
+    }
+
+    void setPassphrase(Provider<String> value) {
+        passphrase.set(value)
+    }
+
+    ImportCodeSigningIdentity passphrase(String value) {
+        setPassphrase(value)
+        this
+    }
+
+    ImportCodeSigningIdentity passphrase(Provider<String> value) {
+        setPassphrase(value)
+        this
+    }
+
+    @Input
+    final Property<Boolean> ignoreInvalidSigningIdentity
+
+    void setIgnoreInvalidSigningIdentity(Boolean value) {
+        ignoreInvalidSigningIdentity.set(value)
+    }
+
+    void setIgnoreInvalidSigningIdentity(Provider<Boolean> value) {
+        ignoreInvalidSigningIdentity.set(value)
+    }
+
+    ImportCodeSigningIdentity ignoreInvalidSigningIdentity(Boolean value) {
+        setIgnoreInvalidSigningIdentity(value)
+        this
+    }
+
+    ImportCodeSigningIdentity ignoreInvalidSigningIdentity(Provider<Boolean> value) {
+        setIgnoreInvalidSigningIdentity(value)
+        this
+    }
+
+    @InputFile
+    final RegularFileProperty keychain
+
+    void setKeychain(File value) {
+        keychain.set(value)
+    }
+
+    void setKeychain(Provider<RegularFile> value) {
+        keychain.set(value)
+    }
+
+    ImportCodeSigningIdentity keychain(File value) {
+        setKeychain(value)
+        this
+    }
+
+    ImportCodeSigningIdentity keychain(Provider<RegularFile> value) {
+        setKeychain(value)
+        this
+    }
+
+    @Input
+    final Property<String> signingIdentity
+
+    void setSigningIdentity(String value) {
+        signingIdentity.set(value)
+    }
+
+    void setSigningIdentity(Provider<String> value) {
+        signingIdentity.set(value)
+    }
+
+    ImportCodeSigningIdentity signingIdentity(String value) {
+        setSigningIdentity(value)
+        this
+    }
+
+    ImportCodeSigningIdentity signingIdentity(Provider<String> value) {
+        setSigningIdentity(value)
+        this
+    }
+
+    ImportCodeSigningIdentity() {
+        keychain = project.layout.fileProperty()
+        p12 = project.layout.fileProperty()
+        passphrase = project.objects.property(String)
+        signingIdentity = project.objects.property(String)
+        ignoreInvalidSigningIdentity = project.objects.property(Boolean)
+
+        onlyIf(new Spec<Task>() {
+            @Override
+            boolean isSatisfiedBy(Task task) {
+                return !hasSigningIdentity(signingIdentity.get(), !ignoreInvalidSigningIdentity.get())
+            }
+        })
+    }
+
+    Boolean hasSigningIdentity(String identity, Boolean validIdentities = true) {
+        def command = new FindIdentity()
+                .withKeychain(keychain.get().asFile)
+                .withPolicy(FindIdentity.Policy.Codesigning)
+                .validIdentities(validIdentities)
+        def foundIdentity = command.execute()
+        if (foundIdentity == null || foundIdentity.isEmpty()) {
+            return false
+        }
+
+        FindIdentityResult identityResult = FindIdentityResult.fromOutPut(foundIdentity)
+        identityResult.hasIdentity(identity, validIdentities)
+    }
+
+    @TaskAction
+    protected void importCodeSigningIdentity() {
+        def signingIdentity = signingIdentity.get()
+        def keychain = keychain.get().asFile
+
+        def importCertificates = new Import(p12.get().asFile, keychain)
+                .withPassphrase(passphrase.get())
+                .withType(Import.Type.Cert)
+                .withFormat(Import.Format.Pkcs12)
+        importCertificates.execute()
+
+        if (!hasSigningIdentity(signingIdentity, false)) {
+            throw new GradleException("Unable to find code sign identity '${signingIdentity}' in keychain ${keychain.path}")
+        } else {
+            if (hasSigningIdentity(signingIdentity)) {
+                logger.info("Signing Identity '${signingIdentity}' successfull imported into keychain ${keychain.path}")
+            } else if (!ignoreInvalidSigningIdentity.get()) {
+                throw new GradleException("Unable to find valid code sign identity '${signingIdentity}' in keychain ${keychain.path}")
+            } else {
+                logger.warn("Signing Identity '${signingIdentity}' found but invalid")
+            }
+        }
+    }
+}

--- a/src/test/groovy/com/wooga/security/SecurityHelper.groovy
+++ b/src/test/groovy/com/wooga/security/SecurityHelper.groovy
@@ -1,0 +1,282 @@
+/*
+ * Copyright 2021 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.wooga.security
+
+class SecurityHelper {
+
+    static class CA {
+        final File key
+        final File certificate
+        final File config
+        final String passphrase
+
+        CA(File key, File certificate, File cnf, String passphrase) {
+            this.key = key
+            this.certificate = certificate
+            this.config = cnf
+            this.passphrase = passphrase
+        }
+    }
+
+    static File createPrivateKey() {
+        def tempOutputDir = File.createTempDir()
+        def keyFile = new File(tempOutputDir, "key.pem")
+
+        if (['openssl', 'genpkey', '-algorithm', 'RSA', '-out', keyFile.path].execute().waitFor() == 0) {
+            return keyFile
+        }
+        null
+    }
+
+    static CA newCA(Map options = [:], File directory = null) {
+        Map defaultOptions = [
+                country         : "DE",
+                state           : "Berlin",
+                city            : "Berlin",
+                organisationName: "Wooga Gmbh",
+                organisationUnit: "Atlas",
+                CAcommonName    : "Test CA certificate",
+                emailAddress    : "jenkins@wooga.net",
+                days            : "365",
+        ]
+
+        options = defaultOptions << options
+        File cw = directory ? directory : File.createTempDir()
+        File certs = new File(cw, "certs")
+        certs.mkdirs()
+        File crl = new File(cw, "crl")
+        crl.mkdirs()
+        File _private = new File(cw, "private")
+        _private.mkdirs()
+        File newCerts = new File(cw, "newcerts")
+        newCerts.mkdirs()
+
+        File caKey = new File(_private, "cakey.pem")
+        File caReq = new File(cw, "careq.pem")
+        File caCert = new File(cw, "cacert.pem")
+        File caDataBase = new File(cw, "certs.db")
+        caDataBase.createNewFile()
+
+        def cnf = new File(cw, "ca.cnf")
+        cnf << """
+        # unnamed section of generic options
+        default_md              = md5
+         
+        # default section for "req" command options
+        [req]
+        prompt                  = no
+        distinguished_name      = my_req_dn_no_prompt
+
+        [ca]
+        default_ca              = my_ca_default
+
+        [my_ca_default]
+        default_md              = md5
+        default_days            = 3000
+        policy                  = policy_any 
+        serial                  = ${cw.path}/certs.seq        
+        new_certs_dir           = ${certs.path}
+        database                = ${cw.path}/certs.db
+        private_key             = ${caKey.path}
+        certificate             = ${caCert.path}
+
+        [my_req_dn_no_prompt]
+        commonName              = ${options["CAcommonName"]}
+        countryName             = ${options["country"]}
+        stateOrProvinceName     = ${options["state"]}
+        localityName            = ${options["city"]}
+        organizationName        = ${options["organisationName"]}
+        organizationalUnitName  = ${options["organisationUnit"]}
+        emailAddress            = ${options["emailAddress"]}
+
+        [usr_cert]
+        basicConstraints        = CA:FALSE
+        keyUsage                = digitalSignature
+        extendedKeyUsage        = codeSigning  
+        subjectKeyIdentifier    = hash
+        authorityKeyIdentifier  = keyid,issuer
+        subjectAltName          = email:move
+
+        [v3_req]
+        keyUsage                = digitalSignature
+        extendedKeyUsage        = codeSigning
+
+        [policy_any]
+        countryName             = supplied
+        stateOrProvinceName     = optional
+        organizationName        = optional
+        organizationalUnitName  = optional
+        commonName              = supplied
+        emailAddress            = optional
+        
+        ####################################################################
+        # Same as above, but cert req already has SubjectAltName
+        [ usr_cert_has_san ]
+        basicConstraints = CA:false
+        subjectKeyIdentifier = hash
+        authorityKeyIdentifier = keyid,issuer
+        
+        ####################################################################
+        # Extensions to use when signing a CA
+        [ v3_ca ]
+        subjectKeyIdentifier = hash
+        authorityKeyIdentifier = keyid:always,issuer:always
+        basicConstraints = CA:true
+        subjectAltName=email:move
+        
+        ####################################################################
+        # Same as above, but CA req already has SubjectAltName
+        [ v3_ca_has_san ]
+        subjectKeyIdentifier = hash
+        authorityKeyIdentifier = keyid:always,issuer:always
+        basicConstraints = CA:true
+        """.stripIndent()
+
+        def passphrase = "123456"
+        if (['openssl', 'req',
+             '-new',
+             '-keyout', caKey.path,
+             '-passout', "pass:${passphrase}",
+             '-out', caReq.path,
+             '-config', cnf.path
+        ].execute().waitFor() == 0) {
+            if (['openssl', 'ca', '-create_serial',
+                 '-out', caCert, '-batch',
+                 '-keyfile', caKey.path,
+                 '-selfsign',
+                 '-extensions',
+                 'v3_ca',
+                 '-passin', "pass:${passphrase}",
+                 '-config', cnf.path,
+                 '-infiles', caReq.path
+            ].execute().waitFor() == 0) {
+                return new CA(caKey, caCert, cnf, "123456")
+            }
+        }
+        null
+    }
+
+    static File createCodeSigningCertificateRequest(Map options = [:], File privateKey) {
+        Map defaultOptions = [
+                commonName: "Test code signing certificate",
+                days      : "365",
+        ]
+        options = defaultOptions << options
+
+        def tempOutputDir = File.createTempDir()
+        def cnf = new File(tempOutputDir, "csr.cnf")
+        cnf << """
+        [v3_req]
+        keyUsage = digitalSignature
+        extendedKeyUsage = codeSigning
+
+        # default section for "req" command options
+        [req]
+        default_bits           = 2048                
+        encrypt_key            = yes                  
+        default_md             = sha256               
+        utf8                   = yes                  
+        string_mask            = utf8only             
+        req_extensions         = codesign_reqext      
+        prompt                 = no   
+        distinguished_name     = my_req_dn_no_prompt
+        
+        [my_req_dn_no_prompt]
+        commonName             = ${options["commonName"]}
+        countryName            = DE
+
+        [codesign_reqext]
+        keyUsage               = critical,digitalSignature
+        extendedKeyUsage       = critical,codeSigning
+        subjectKeyIdentifier   = hash
+        """.stripIndent()
+
+        def csr = new File(tempOutputDir, "ca.csr")
+        def r = ['openssl', 'req',
+                 '-new',
+                 '-outform', 'PEM',
+                 '-key', privateKey,
+                 '-out', csr.path,
+                 '-days', options["days"],
+                 '-config', cnf.path,
+        ].execute().waitFor()
+
+        if (r == 0) {
+            return csr
+        }
+        null
+    }
+
+    static File signCSR(File csr, CA ca) {
+        def tempOutputDir = File.createTempDir()
+        def cert = new File(tempOutputDir, "user.crt")
+        def r = ['openssl', 'ca', '-batch',
+                 '-policy', 'policy_any',
+                 '-config', ca.config.path,
+                 '-extensions', 'usr_cert',
+                 '-out', cert.path,
+                 '-passin', "pass:${ca.passphrase}",
+                 '-infiles', csr.path].execute().waitFor()
+        if (r == 0) {
+            return cert
+        }
+        null
+    }
+
+    static File createTestCertificatePkcs12(Map options = [:], File key, File cert, String password) {
+        Map defaultOptions = [privateKeyName: "Test Certificate"]
+        options = defaultOptions << options
+        def tempOutputDir = File.createTempDir()
+        def p12 = new File(tempOutputDir, "cert.p12")
+        def args = ['openssl', 'pkcs12',
+                    '-export',
+                    '-in', cert.path,
+                    '-inkey', key.path,
+                    '-out', p12.path,
+                    '-name', options['privateKeyName'],
+                    '-passout', "pass:${password}"
+        ]
+        if (args.execute().waitFor() == 0) {
+            return p12
+        }
+        null
+    }
+
+    static File createTestCodeSigningCertificatePkcs12(Map options = [:], String password) {
+        def ca = newCA(options)
+        if (!ca) {
+            return null
+        }
+        def key = createPrivateKey()
+
+        if (!key) {
+            return null
+        }
+
+        def csr = createCodeSigningCertificateRequest(options, key)
+
+        if (!csr) {
+            return null
+        }
+
+        def cert = signCSR(csr, ca)
+        if (!cert) {
+            return null
+        }
+        createTestCertificatePkcs12(options, key, cert, password)
+    }
+}


### PR DESCRIPTION
## Description

This patch adds a new ios specific task type to the `net.wooga.build-unity-ios` plugin. It's main purpose is to import code signing identities (private key + certificate) to a configured keychain.

The task implementation supports validation to check if the provided p12 file actually contained a valid identity with the given name. One can configure to allow invalid signing identities.

## Changes

* ![ADD] `ImportCodeSigningIdentity` task



[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
