### PR TITLE
Fix generate valid app configs in tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,6 @@ withCredentials([
                     "ATLAS_AWS_INTEGRATION_ACCESS_KEY=${accesskey}",
                     "ATLAS_AWS_INTEGRATION_SECRET_KEY=${secretkey}",
                     "ATLAS_BUILD_UNITY_IOS_EXECUTE_KEYCHAIN_SPEC=YES",
-                    {"DEVELOPER_DIR=${XCODE_12_DEVELOPER_DIR}"}
             ]
     ]
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,12 @@
  *
  */
 
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+}
+
 plugins {
     id 'net.wooga.plugins' version '1.5.0'
 }

--- a/src/integrationTest/groovy/wooga/gradle/build/UnityBuildPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/UnityBuildPluginIntegrationSpec.groovy
@@ -43,6 +43,8 @@ class UnityBuildPluginIntegrationSpec extends UnityIntegrationSpec {
         appConfigsDir.mkdirs()
 
         ['ios_ci', 'android_ci', 'webGL_ci'].collect { createFile("${it}.asset", appConfigsDir) }.each {
+            it << UNITY_ASSET_HEADER
+            it << "\n"
             Yaml yaml = new Yaml()
             def buildTarget = it.name.split(/_/, 2).first().toLowerCase()
             def appConfig = ['MonoBehaviour': ['bundleId': 'net.wooga.test', 'batchModeBuildTarget': buildTarget]]
@@ -50,7 +52,12 @@ class UnityBuildPluginIntegrationSpec extends UnityIntegrationSpec {
         }
 
         Yaml yaml = new Yaml()
-        createFile("custom.asset", appConfigsDir) << yaml.dump(['MonoBehaviour': ['bundleId': 'net.wooga.test']])
+        def appconfig = createFile("custom.asset", appConfigsDir)
+        appconfig << UNITY_ASSET_HEADER
+        appconfig << "\n"
+        appconfig << yaml.dump(['MonoBehaviour': ['bundleId': 'net.wooga.test']])
+
+
     }
 
     @Unroll

--- a/src/integrationTest/groovy/wooga/gradle/build/UnityBuildPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/UnityBuildPluginIntegrationSpec.groovy
@@ -27,6 +27,7 @@ import spock.lang.Shared
 import spock.lang.Unroll
 import wooga.gradle.unity.batchMode.BatchModeFlags
 import wooga.gradle.unity.batchMode.BuildTarget
+import static wooga.gradle.build.unity.TestUnityAsset.unityAsset
 
 class UnityBuildPluginIntegrationSpec extends UnityIntegrationSpec {
 

--- a/src/integrationTest/groovy/wooga/gradle/build/UnityIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/UnityIntegrationSpec.groovy
@@ -53,6 +53,12 @@ abstract class UnityIntegrationSpec extends IntegrationSpec {
         unityTestLocation
     }
 
+    public static final String UNITY_ASSET_HEADER = """
+            %YAML 1.1
+            %TAG !u! tag:unity3d.com,2011:
+            --- !u!114 &11400000
+            """.stripIndent().trim()
+
     def setup() {
         String osName = System.getProperty("os.name").toLowerCase()
         unityMainDirectory = projectDir

--- a/src/integrationTest/groovy/wooga/gradle/build/unity/TestUnityAsset.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/unity/TestUnityAsset.groovy
@@ -1,0 +1,35 @@
+package wooga.gradle.build.unity
+
+import org.yaml.snakeyaml.Yaml
+
+class TestUnityAsset implements Map {
+    public static final String UNITY_ASSET_HEADER = """
+            %YAML 1.1
+            %TAG !u! tag:unity3d.com,2011:
+            --- !u!114 &11400000
+            """.stripIndent().trim()
+
+    @Delegate
+    private final Map inner = [:]
+
+    private TestUnityAsset(Map content = [:]) {
+        inner.putAll(content)
+    }
+
+    static TestUnityAsset unityAsset(Map content = [:]) {
+        new TestUnityAsset(content)
+    }
+
+    Boolean write(File output) {
+        output.text = dump()
+    }
+
+    String dump() {
+        def output = new StringBuilder()
+        output.append(UNITY_ASSET_HEADER)
+        output.append("\n")
+        Yaml yaml = new Yaml()
+        output.append(yaml.dump(inner))
+        output.toString()
+    }
+}

--- a/src/integrationTest/groovy/wooga/gradle/build/unity/tasks/GradleBuildIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/unity/tasks/GradleBuildIntegrationSpec.groovy
@@ -116,7 +116,7 @@ class GradleBuildIntegrationSpec extends IntegrationSpec {
 
         then:
         result.standardOutput.contains("foo executed")
-        result.standardOutput.contains(new File(".gradle/daemon/${gradleVersion}").path)
+        result.standardOutput.contains(new File("/daemon/${gradleVersion}").path)
         where:
         gradleVersion << ["4.0", "4.10", "5.0"]
     }

--- a/src/integrationTest/groovy/wooga/gradle/build/unity/tasks/UnityBuildPlayerTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/unity/tasks/UnityBuildPlayerTaskIntegrationSpec.groovy
@@ -38,6 +38,8 @@ class UnityBuildPlayerTaskIntegrationSpec extends UnityIntegrationSpec {
 
         def appConfig = ['MonoBehaviour': ['bundleId': 'net.wooga.test', 'batchModeBuildTarget': 'android']]
         ['custom', 'test'].collect { createFile("${it}.asset", appConfigsDir) }.each {
+            it << UNITY_ASSET_HEADER
+            it << "\n"
             Yaml yaml = new Yaml()
             it << yaml.dump(appConfig)
         }
@@ -169,7 +171,7 @@ class UnityBuildPlayerTaskIntegrationSpec extends UnityIntegrationSpec {
         def appConfigsDir = new File(assets, "CustomConfigs")
 
         def appConfigFile = createFile('buildTarget_config.asset', appConfigsDir)
-        appConfigFile.text = "MonoBehaviour: {bundleId: net.wooga.test, batchModeBuildTarget: $batchModeBuildTarget}"
+        appConfigFile.text = "${UNITY_ASSET_HEADER}\nMonoBehaviour: {bundleId: net.wooga.test, batchModeBuildTarget: $batchModeBuildTarget}"
 
         and: "the app config configured"
         buildFile << """


### PR DESCRIPTION
## Description

With a recent change in the plugin `net.wooga.unity`, the plugin has a stricter parsing defintion for unity asset objects. This means that we can't simply create a yaml file and let it parse.

The patch adds the normal asset file header for Unity assets so that the implementation works as expected.

## Changes

* ![FIX] generate valid appconfig in tests

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
