### PR TITLE
Improve keychain cleanup after gradle process kill

### DIFF
--- a/src/integrationTest/groovy/net/wooga/system/ProcessList.groovy
+++ b/src/integrationTest/groovy/net/wooga/system/ProcessList.groovy
@@ -1,0 +1,39 @@
+package net.wooga.system
+
+import groovy.transform.stc.ClosureParams
+import groovy.transform.stc.SimpleType
+
+class ProcessList {
+    static List<Integer> findPID(@ClosureParams(value = SimpleType, options = ['java.lang.String']) Closure predicate) {
+        def stdout = new StringBuffer()
+        def stderr = new StringBuffer()
+
+        "ps aux".execute().waitForProcessOutput(stdout, stderr)
+
+        stdout.readLines().findAll(predicate).collect {Integer.parseInt(it.split(/\s+/)[1])}
+    }
+
+    enum Signal {
+        HUP,
+        INT,
+        QUIT,
+        ABRT,
+        KILL,
+        ALRM,
+        TERM
+    }
+
+    static Boolean kill(Integer pid, signal = Signal.TERM) {
+        def r = "kill -s ${signal} ${pid}".execute().waitFor()
+        r == 0
+    }
+
+    static List<Integer> waitForProcess(@ClosureParams(value = SimpleType, options = ['java.lang.String']) Closure predicate) {
+        List<Integer> pids = []
+        while(pids.empty) {
+            sleep(1 * 1000)
+            pids = findPID(predicate)
+        }
+        pids
+    }
+}

--- a/src/main/groovy/wooga/gradle/build/unity/ios/tasks/ListKeychainTask.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/tasks/ListKeychainTask.groovy
@@ -111,6 +111,16 @@ class ListKeychainTask extends DefaultTask {
         })
     }
 
+    void shutdown() {
+        if(!this.didWork) {
+            System.err.println("task ${this.name} did not run yet. Force execution")
+            list()
+        } else {
+            System.err.println("task ${this.name} did run.")
+        }
+        System.err.flush()
+    }
+
     @TaskAction
     protected list() {
         def keychains = getKeychains().files

--- a/src/main/groovy/wooga/gradle/fastlane/internal/PropertyLookup.groovy
+++ b/src/main/groovy/wooga/gradle/fastlane/internal/PropertyLookup.groovy
@@ -21,7 +21,7 @@ class PropertyLookup {
     final String property
     final String defaultValue
 
-    PropertyLookup(String env, String property, String defaultValue) {
+    PropertyLookup(String env, String property, String defaultValue = null) {
         this.env = env
         this.property = property
         this.defaultValue = defaultValue


### PR DESCRIPTION
## Description

This patch adds a shutdown handler to the `net.wooga.build-io` plugin to cleanup created build keychains in case of abrupt build process termination. It uses the `java.lang.Runtime#addShutdownHook` API and registeres a hook after the `addKeychain` task was executed and removes said hook when `removeKeychian` was executed. These shutdown hooks run even during normal termination so it is crucial to only do the work when needed.

I setup a tests that runs a build with a very long task execution in a forked jvm. The test framework will spawn a new gradle deamon which we will pin to a different gradle version to find in the process list of macOS. The tests will run with multiple kill signals to verify the shutdown hook execution.

This whole logic only works for normal kill signals like `TERM` but won't work for a hard `KILL` signal.

I though about to add more tests to check if the behavior of adding and removing the shutdown hook works as expected. But in the end it is only important that it runs correctly during these process shutdown scenarios and that the plugin behaves normal under normal execution which the other tests already cover.

## Changes

* ![IMPROVE] ![MACOS] keychain cleanup after gradle process kill

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
