### PR TITLE
Improve exported APIs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,11 +59,11 @@ repositories {
 
 dependencies {
     implementation "org.gradle:gradle-tooling-api:+"
-    implementation 'gradle.plugin.net.wooga.gradle:atlas-unity:2.0.0-rc.5'
-    implementation 'gradle.plugin.net.wooga.gradle:atlas-secrets:1.0.0-rc.1'
+    api 'gradle.plugin.net.wooga.gradle:atlas-unity:2.0.0-rc.5'
+    api 'gradle.plugin.net.wooga.gradle:atlas-secrets:1.0.0-rc.1'
     implementation 'xmlwise:xmlwise:1.2.11'
     implementation 'commons-codec:commons-codec:1.14'
-    implementation 'software.amazon.awssdk:secretsmanager:(2.16,3]'
+    api 'software.amazon.awssdk:secretsmanager:(2.16,3]'
     implementation('com.wooga.xcodebuild:xcpretty:(1,2]')
     implementation'com.googlecode.plist:dd-plist:1.23'
     implementation 'org.apache.commons:commons-text:1.8'


### PR DESCRIPTION
## Description

With the move to gradle 6 we also had to adjust the dependency components. The `compile` component is no longer available and one needs to use the `implementation` in most cases. I moved some dependencies to the `api` component so they can be directly used by the user of this plugin.

## Changes

* ![IMPROVE] exported API

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
