### PR TITLE
Updated atlas plugin to 2.2.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,7 @@ withCredentials([
                     string(credentialsId: 'atlas_build_unity_coveralls_token', variable: 'coveralls_token'),
                     string(credentialsId: 'aws.secretsmanager.integration.accesskey', variable: 'accesskey'),
                     string(credentialsId: 'aws.secretsmanager.integration.secretkey', variable: 'secretkey'),
+                    string(credentialsId: 'atlas_plugins_sonar_token', variable: 'sonar_token')
                 ])
 {
     def env = [
@@ -26,5 +27,5 @@ withCredentials([
     def testLabels = [
         'macos': 'xcode_12'
     ]
-    buildGradlePlugin plaforms: ['macos','windows', 'linux'], coverallsToken: coveralls_token, testEnvironment:env, testLabels: testLabels
+    buildGradlePlugin platforms: ['macos','windows', 'linux'], coverallsToken: coveralls_token, sonarToken: sonar_token, testEnvironment:env, testLabels: testLabels
 }

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
 }
 
 plugins {
-    id 'net.wooga.plugins' version '2.1.1'
+    id 'net.wooga.plugins' version '2.2.0'
 }
 
 group 'net.wooga.gradle'

--- a/src/integrationTest/groovy/wooga/gradle/xcodebuild/tasks/ExportArchiveIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/xcodebuild/tasks/ExportArchiveIntegrationSpec.groovy
@@ -32,7 +32,6 @@ class ExportArchiveIntegrationSpec extends AbstractXcodeArchiveTaskIntegrationSp
     XcodeTestProject xcodeProject = new XcodeTestProject()
 
     Class taskType = ExportArchive
-
     String archiveTaskName = "xcodeArchive"
     String testTaskName = archiveTaskName + "Export"
 


### PR DESCRIPTION
## Description
atlas plugin gradle plugin updated to 2.2.0, and added Sonarqube support on Jenkinsfile.

## Changes
* ![UPDATE] `atlas-plugin` gradle plugin to `2.2.0`
* ![NEW] Sonarqube project being uploaded on Jenkinsfile execution



[NEW]:https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"