### PR TITLE
Add Sonarqube task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,10 +23,11 @@ buildscript {
 
 plugins {
     id 'net.wooga.plugins' version '2.2.0'
+    id 'java-gradle-plugin'
 }
-
 group 'net.wooga.gradle'
 description = 'a Unity 3d build helper.'
+
 
 pluginBundle {
     website = 'https://wooga.github.io/atlas-unity/'
@@ -58,8 +59,10 @@ repositories {
 }
 
 dependencies {
+    implementation "gradle.plugin.net.wooga.gradle:atlas-dotnet-sonarqube:0.0.2"
+    implementation "gradle.plugin.net.wooga.gradle:atlas-unity:2.2.0-rc00001"
+    implementation 'com.wooga.gradle:gradle-commons:[0, 1)'
     implementation "org.gradle:gradle-tooling-api:+"
-    api 'gradle.plugin.net.wooga.gradle:atlas-unity:2.0.0-rc.6'
     api 'gradle.plugin.net.wooga.gradle:atlas-secrets:1.0.0-rc.1'
     implementation 'xmlwise:xmlwise:1.2.11'
     implementation 'commons-codec:commons-codec:1.14'

--- a/build.gradle
+++ b/build.gradle
@@ -59,8 +59,8 @@ repositories {
 }
 
 dependencies {
-    implementation "gradle.plugin.net.wooga.gradle:atlas-dotnet-sonarqube:0.0.2"
-    implementation "gradle.plugin.net.wooga.gradle:atlas-unity:2.2.0-rc.1"
+    implementation "gradle.plugin.net.wooga.gradle:atlas-dotnet-sonarqube:0.1.0"
+    implementation "gradle.plugin.net.wooga.gradle:atlas-unity:2.2.0"
     implementation 'com.wooga.gradle:gradle-commons:0.1.0'
     implementation "org.gradle:gradle-tooling-api:+"
     api 'gradle.plugin.net.wooga.gradle:atlas-secrets:1.0.0-rc.1'

--- a/build.gradle
+++ b/build.gradle
@@ -22,9 +22,9 @@ buildscript {
 }
 
 plugins {
-    id 'net.wooga.plugins' version '2.2.0'
-    id 'java-gradle-plugin'
+    id 'net.wooga.plugins' version '2.2.1'
 }
+
 group 'net.wooga.gradle'
 description = 'a Unity 3d build helper.'
 
@@ -60,8 +60,8 @@ repositories {
 
 dependencies {
     implementation "gradle.plugin.net.wooga.gradle:atlas-dotnet-sonarqube:0.0.2"
-    implementation "gradle.plugin.net.wooga.gradle:atlas-unity:2.2.0-rc00001"
-    implementation 'com.wooga.gradle:gradle-commons:[0, 1)'
+    implementation "gradle.plugin.net.wooga.gradle:atlas-unity:2.2.0-rc.1"
+    implementation 'com.wooga.gradle:gradle-commons:0.1.0'
     implementation "org.gradle:gradle-tooling-api:+"
     api 'gradle.plugin.net.wooga.gradle:atlas-secrets:1.0.0-rc.1'
     implementation 'xmlwise:xmlwise:1.2.11'

--- a/src/main/groovy/wooga/gradle/build/unity/SonarQubeConfiguration.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/SonarQubeConfiguration.groovy
@@ -54,8 +54,7 @@ class SonarQubeConfiguration {
     private static Action<? extends SonarQubeProperties> sonarqubeUnityDefaults(String assetsDir, String reportsDir) {
         return {
 
-            addPropertyIfNotExists(it, "sonar.exclusions", "${assetsDir}/Paket.Unity3D")
-            addPropertyIfNotExists(it, "sonar.cpd.exclusions", "${assetsDir}/Paket.Unity3D")
+            addPropertyIfNotExists(it, "sonar.exclusions", "${assetsDir}/Paket.Unity3D/**")
             addPropertyIfNotExists(it, "sonar.cs.nunit.reportsPaths", "${reportsDir}/**/*.xml")
             addPropertyIfNotExists(it, "sonar.cs.opencover.reportsPaths", "${reportsDir}/**/*.xml")
         }

--- a/src/main/groovy/wooga/gradle/build/unity/SonarQubeConfiguration.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/SonarQubeConfiguration.groovy
@@ -1,0 +1,69 @@
+package wooga.gradle.build.unity
+
+import org.gradle.api.Action
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.tasks.TaskProvider
+import org.sonarqube.gradle.SonarQubeExtension
+import org.sonarqube.gradle.SonarQubeProperties
+import wooga.gradle.dotnetsonar.tasks.BuildSolution
+import wooga.gradle.unity.UnityPlugin
+import wooga.gradle.unity.UnityPluginExtension
+
+class SonarQubeConfiguration {
+
+    private Project project
+    public String sonarTaskName
+    public String buildTaskName
+
+
+    SonarQubeConfiguration(Project project) {
+        this.project = project
+        this.sonarTaskName = "sonarqube"
+        this.buildTaskName = "sonarBuildUnity"
+    }
+
+    void configure(UnityPluginExtension unityExt,
+                   SonarQubeExtension sonarExt) {
+        def unityTestTask = project.tasks.named(UnityPlugin.Tasks.test.toString())
+        def createSolutionTask = project.tasks.named(UnityPlugin.Tasks.generateSolution.toString())
+
+        unityExt.enableTestCodeCoverage = true
+        def sonarBuild = project.tasks.register(buildTaskName, BuildSolution) {task ->
+            task.dependsOn(createSolutionTask)
+            task.mustRunAfter(unityTestTask)
+            setupSonarBuildUnityDefaults(task, unityExt)
+        }
+        project.tasks.register(sonarTaskName) {task ->
+            task.dependsOn(unityTestTask, sonarBuild)
+            task.mustRunAfter(unityTestTask)
+        }
+        project.afterEvaluate { //needs to be done after evaluate to be able to fill reportsDir property
+            def assetsDir = unityExt.assetsDir.get().asFile.path
+            def reportsDir = unityExt.reportsDir.get().asFile.path
+            sonarExt.properties(sonarqubeUnityDefaults(assetsDir, reportsDir))
+        }
+    }
+    private void setupSonarBuildUnityDefaults(BuildSolution task, UnityPluginExtension unityExt) {
+        task.solution.convention(project.layout.projectDirectory.file("${project.name}.sln"))
+        task.dotnetExecutable.convention(unityExt.dotnetExecutable)
+        task.addEnvironment("FrameworkPathOverride",
+                unityExt.monoFrameworkDir.map{it.asFile.absolutePath} )
+    }
+
+    private static Action<? extends SonarQubeProperties> sonarqubeUnityDefaults(String assetsDir, String reportsDir) {
+        return {
+
+            addPropertyIfNotExists(it, "sonar.exclusions", "${assetsDir}/Paket.Unity3D")
+            addPropertyIfNotExists(it, "sonar.cpd.exclusions", "${assetsDir}/Paket.Unity3D")
+            addPropertyIfNotExists(it, "sonar.cs.nunit.reportsPaths", "${reportsDir}/**/*.xml")
+            addPropertyIfNotExists(it, "sonar.cs.opencover.reportsPaths", "${reportsDir}/**/*.xml")
+        }
+    }
+
+    private static void addPropertyIfNotExists(SonarQubeProperties properties, String key, Object value) {
+        if(!properties.properties.containsKey(key)) {
+            properties.property(key, value)
+        }
+    }
+}

--- a/src/main/groovy/wooga/gradle/build/unity/UnityBuildPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/UnityBuildPlugin.groovy
@@ -23,12 +23,10 @@ import org.gradle.api.Project
 import org.gradle.api.file.FileTreeElement
 import org.gradle.api.plugins.BasePlugin
 import org.gradle.api.publish.plugins.PublishingPlugin
-import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.StopExecutionException
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.sonarqube.gradle.SonarQubeExtension
-import org.sonarqube.gradle.SonarQubeProperties
 import wooga.gradle.build.unity.internal.DefaultUnityBuildPluginExtension
 import wooga.gradle.build.unity.ios.internal.utils.PropertyUtils
 import wooga.gradle.build.unity.tasks.GradleBuild
@@ -162,6 +160,7 @@ class UnityBuildPlugin implements Plugin<Project> {
         project.tasks.withType(GradleBuild).configureEach({GradleBuild t ->
             t.gradleVersion.convention(project.provider({ project.gradle.gradleVersion }))
         })
+
         configureSonarqubeTasks(project)
 
         project.afterEvaluate {

--- a/src/main/groovy/wooga/gradle/build/unity/UnityBuildPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/UnityBuildPlugin.groovy
@@ -18,7 +18,6 @@
 package wooga.gradle.build.unity
 
 import org.apache.commons.io.FilenameUtils
-import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.file.FileTreeElement
@@ -28,10 +27,14 @@ import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.StopExecutionException
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.language.base.plugins.LifecycleBasePlugin
+import org.sonarqube.gradle.SonarQubeExtension
+import org.sonarqube.gradle.SonarQubeProperties
 import wooga.gradle.build.unity.internal.DefaultUnityBuildPluginExtension
 import wooga.gradle.build.unity.ios.internal.utils.PropertyUtils
 import wooga.gradle.build.unity.tasks.GradleBuild
 import wooga.gradle.build.unity.tasks.UnityBuildPlayerTask
+import wooga.gradle.dotnetsonar.DotNetSonarqubePlugin
+import wooga.gradle.dotnetsonar.tasks.BuildSolution
 import wooga.gradle.secrets.SecretsPlugin
 import wooga.gradle.secrets.SecretsPluginExtension
 import wooga.gradle.secrets.tasks.FetchSecrets
@@ -49,6 +52,7 @@ class UnityBuildPlugin implements Plugin<Project> {
         project.pluginManager.apply(PublishingPlugin.class)
         project.pluginManager.apply(UnityPlugin.class)
         project.pluginManager.apply(SecretsPlugin.class)
+        project.pluginManager.apply(DotNetSonarqubePlugin.class)
 
         def extension = project.extensions.create(UnityBuildPluginExtension, EXTENSION_NAME, DefaultUnityBuildPluginExtension, project)
         configureExtension(extension, project)
@@ -112,40 +116,32 @@ class UnityBuildPlugin implements Plugin<Project> {
                 def assetsDir = t.projectDirectory.dir("Assets")
                 def assetsFileTree = project.fileTree(assetsDir)
 
-                def includeSpec = new Spec<FileTreeElement>() {
-                    @Override
-                    boolean isSatisfiedBy(FileTreeElement element) {
-                        def path = element.getRelativePath().getPathString().toLowerCase()
-                        def name = element.name.toLowerCase()
-                        def status = true
-                        if (path.contains("plugins")
-                                && !((name == "plugins") || (name == "plugins.meta"))) {
-                            /*
-                             Why can we use / here? Because {@code element} is a {@code FileTreeElement} object.
-                             The getPath() method is not the same as {@code File.getPath()}
-                             From the docs:
+                def includeSpec = { FileTreeElement element ->
+                    def path = element.getRelativePath().getPathString().toLowerCase()
+                    def name = element.name.toLowerCase()
+                    def status = true
+                    if (path.contains("plugins") && !((name == "plugins") || (name == "plugins.meta"))) {
+                        /*
+                         Why can we use / here? Because {@code element} is a {@code FileTreeElement} object.
+                         The getPath() method is not the same as {@code File.getPath()}
+                         From the docs:
 
-                             * Returns the path of this file, relative to the root of the containing file tree. Always uses '/' as the hierarchy
-                             * separator, regardless of platform file separator. Same as calling <code>getRelativePath().getPathString()</code>.
-                             *
-                             * @return The path. Never returns null.
-                             */
-                            if (t.getBuildPlatform()) {
-                                status = path.contains("plugins/" + t.getBuildPlatform().get())
-                            } else {
-                                status = true
-                            }
+                         * Returns the path of this file, relative to the root of the containing file tree. Always uses '/' as the hierarchy
+                         * separator, regardless of platform file separator. Same as calling <code>getRelativePath().getPathString()</code>.
+                         *
+                         * @return The path. Never returns null.
+                         */
+                        if (t.getBuildPlatform()) {
+                            status = path.contains("plugins/" + t.getBuildPlatform().get())
+                        } else {
+                            status = true
                         }
-
-                        status
                     }
+                    return status
                 }
 
-                def excludeSpec = new Spec<FileTreeElement>() {
-                    @Override
-                    boolean isSatisfiedBy(FileTreeElement element) {
-                        return extension.ignoreFilesForExportUpToDateCheck.contains(element.getFile())
-                    }
+                def excludeSpec = { FileTreeElement element  ->
+                    return extension.ignoreFilesForExportUpToDateCheck.contains(element.getFile())
                 }
 
                 assetsFileTree.include(includeSpec)
@@ -166,6 +162,7 @@ class UnityBuildPlugin implements Plugin<Project> {
         project.tasks.withType(GradleBuild).configureEach({GradleBuild t ->
             t.gradleVersion.convention(project.provider({ project.gradle.gradleVersion }))
         })
+        configureSonarqubeTasks(project)
 
         project.afterEvaluate {
             def defaultAppConfigName = extension.getDefaultAppConfigName().getOrNull()
@@ -220,7 +217,19 @@ class UnityBuildPlugin implements Plugin<Project> {
                         project.tasks.getByName(taskName).dependsOn(gradleBuild)
                     }
                 }
+
             }
         }
+    }
+
+    static void configureSonarqubeTasks(Project project) {
+        def unityExt = project.extensions.findByType(UnityPluginExtension)
+        def sonarExt = project.extensions.findByType(SonarQubeExtension)
+
+        new SonarQubeConfiguration(project).with {
+            sonarTaskName = "sonarqube"
+            buildTaskName = "sonarBuildUnity"
+            return it
+        }.configure(unityExt, sonarExt)
     }
 }

--- a/src/main/groovy/wooga/gradle/build/unity/UnityBuildPluginConventions.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/UnityBuildPluginConventions.groovy
@@ -16,8 +16,9 @@
  */
 
 package wooga.gradle.build.unity
+import com.wooga.gradle.PropertyLookup
 
-import wooga.gradle.unity.utils.PropertyLookup
+//import wooga.gradle.unity.utils.PropertyLookup
 
 
 class UnityBuildPluginConventions {

--- a/src/main/groovy/wooga/gradle/fastlane/FastlanePluginConventions.groovy
+++ b/src/main/groovy/wooga/gradle/fastlane/FastlanePluginConventions.groovy
@@ -16,7 +16,7 @@
 
 package wooga.gradle.fastlane
 
-import wooga.gradle.unity.utils.PropertyLookup
+import com.wooga.gradle.PropertyLookup
 
 
 class FastlanePluginConventions {

--- a/src/main/groovy/wooga/gradle/xcodebuild/XcodeBuildPluginConventions.groovy
+++ b/src/main/groovy/wooga/gradle/xcodebuild/XcodeBuildPluginConventions.groovy
@@ -16,7 +16,7 @@
 
 package wooga.gradle.xcodebuild
 
-import wooga.gradle.unity.utils.PropertyLookup
+import com.wooga.gradle.PropertyLookup
 
 
 class XcodeBuildPluginConventions {

--- a/src/main/resources/atlas-build-unity.project-fixes.props
+++ b/src/main/resources/atlas-build-unity.project-fixes.props
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Our wooga projects get falsely flagged as test projects due to `nunit` reference. -->
+    <SonarQubeTestProject>false</SonarQubeTestProject>
+    <!-- Unity default .sln export adds the Unity installed CSC tools which have issues to work with `.editoconfig` -->
+    <CscToolPath></CscToolPath>
+    <CscToolExe></CscToolExe>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- Unity 2020 default export disables all it's references. (known bug: https://issuetracker.unity3d.com/issues/referenceoutputassembly-key-is-set-to-false-in-project-references)  -->
+    <ProjectReference Update="*.csproj">
+      <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
+</Project>

--- a/src/test/groovy/wooga/gradle/build/unity/UnityBuildPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/build/unity/UnityBuildPluginSpec.groovy
@@ -19,10 +19,16 @@ package wooga.gradle.build.unity
 
 import nebula.test.ProjectSpec
 import org.gradle.api.DefaultTask
+import org.gradle.launcher.daemon.protocol.Build
+import org.sonarqube.gradle.SonarPropertyComputer
+import org.sonarqube.gradle.SonarQubeExtension
 import spock.lang.Ignore
 import spock.lang.Unroll
 import wooga.gradle.build.unity.internal.DefaultUnityBuildPluginExtension
 import wooga.gradle.build.unity.tasks.UnityBuildPlayerTask
+import wooga.gradle.dotnetsonar.SonarScannerExtension
+import wooga.gradle.dotnetsonar.tasks.BuildSolution
+import wooga.gradle.unity.UnityPluginExtension
 
 class UnityBuildPluginSpec extends ProjectSpec {
     public static final String PLUGIN_NAME = 'net.wooga.build-unity'
@@ -34,6 +40,7 @@ class UnityBuildPluginSpec extends ProjectSpec {
 
         when:
         project.plugins.apply(PLUGIN_NAME)
+
 
         then:
         def extension = project.extensions.findByName(UnityBuildPlugin.EXTENSION_NAME)
@@ -63,6 +70,8 @@ class UnityBuildPluginSpec extends ProjectSpec {
         "assemble"                            | DefaultTask
         "build"                               | DefaultTask
         "check"                               | DefaultTask
+        "sonarqube"                           | DefaultTask
+        "sonarBuildUnity"                     | BuildSolution
     }
 
     @Unroll
@@ -79,5 +88,41 @@ class UnityBuildPluginSpec extends ProjectSpec {
 
         where:
         pluginToAdd << ['base', 'net.wooga.unity']
+    }
+
+    def "configures sonarqube extension"() {
+        given: "project without plugin applied"
+        assert !project.plugins.hasPlugin(PLUGIN_NAME)
+
+        when: "applying atlas-build-unity plugin"
+        project.plugins.apply(PLUGIN_NAME)
+        project.evaluate()
+
+        then:
+        def sonarExt = project.extensions.getByType(SonarScannerExtension)
+        def unityExt = project.extensions.getByType(UnityPluginExtension)
+        and: "sonarqube extension is configured with defaults"
+        def properties = sonarExt.computeSonarProperties(project)
+        def assetsDir = unityExt.assetsDir.get().asFile.path
+        def reportsDir = unityExt.reportsDir.get().asFile.path
+        properties["sonar.exclusions"] == "${assetsDir}/Paket.Unity3D"
+        properties["sonar.cpd.exclusions"] == "${assetsDir}/Paket.Unity3D"
+        properties["sonar.cs.nunit.reportsPaths"] == "${reportsDir}/**/*.xml"
+        properties["sonar.cs.opencover.reportsPaths"] == "${reportsDir}/**/*.xml"
+    }
+
+    def "configures sonarBuildUnity task"() {
+        given: "project without plugin applied"
+        assert !project.plugins.hasPlugin(PLUGIN_NAME)
+
+        when: "applying atlas-build-unity plugin"
+        project.plugins.apply(PLUGIN_NAME)
+
+        then:
+        def unityExt = project.extensions.getByType(UnityPluginExtension)
+        def buildTask = project.tasks.getByName("sonarBuildUnity") as BuildSolution
+        buildTask.solution.get().asFile == new File(projectDir, "${project.name}.sln")
+        buildTask.dotnetExecutable.getOrElse(null) == unityExt.dotnetExecutable.getOrElse(null)
+        buildTask.environment.getting("FrameworkPathOverride").getOrElse(null) == unityExt.monoFrameworkDir.getOrElse(null)
     }
 }

--- a/src/test/groovy/wooga/gradle/build/unity/UnityBuildPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/build/unity/UnityBuildPluginSpec.groovy
@@ -123,6 +123,7 @@ class UnityBuildPluginSpec extends ProjectSpec {
         def buildTask = project.tasks.getByName("sonarBuildUnity") as BuildSolution
         buildTask.solution.get().asFile == new File(projectDir, "${project.name}.sln")
         buildTask.dotnetExecutable.getOrElse(null) == unityExt.dotnetExecutable.getOrElse(null)
-        buildTask.environment.getting("FrameworkPathOverride").getOrElse(null) == unityExt.monoFrameworkDir.getOrElse(null)
+        buildTask.environment.getting("FrameworkPathOverride").getOrElse(null) ==
+                unityExt.monoFrameworkDir.map { it.asFile.absolutePath}.getOrElse(null)
     }
 }


### PR DESCRIPTION
## Description

Added new unity-opinionated `sonarqube` task, associated `sonarBuildUnity` task and integration with the `atlas-dotnet-sonarqube` plugin. Updated `atlas-unity` as well, it's latest version is needed to run sonarqube. More details on how to use the task in the `atlas-dotnet-sonarqube` project README file.


## Changes
* ![ADD] This plugin now applies the `atlas-dotnet-sonarqube` plugin.
* ![ADD] sonarqube integration using the `atlas-dotnet-sonarqube` plugin.
* ![CHANGE] unity test code coverage enabled by default



[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
