### PR TITLE
Fixed exclusions path [ATLAS-388]

### DIFF
--- a/src/main/groovy/wooga/gradle/build/unity/SonarQubeConfiguration.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/SonarQubeConfiguration.groovy
@@ -43,8 +43,8 @@ class SonarQubeConfiguration {
             task.mustRunAfter(unityTestTask)
         }
         project.afterEvaluate { //needs to be done after evaluate to be able to fill reportsDir property
-            def assetsDir = unityExt.assetsDir.get().asFile.path
-            def reportsDir = unityExt.reportsDir.get().asFile.path
+            def assetsDir = unityExt.assetsDir.get().asFile
+            def reportsDir = unityExt.reportsDir.get().asFile
             sonarExt.properties(sonarqubeUnityDefaults(assetsDir, reportsDir))
         }
     }
@@ -63,13 +63,14 @@ class SonarQubeConfiguration {
 
     }
 
-    private static Action<? extends SonarQubeProperties> sonarqubeUnityDefaults(String assetsDir, String reportsDir) {
+    private Action<? extends SonarQubeProperties> sonarqubeUnityDefaults(File assetsDir, File reportsDir) {
+       def relativeAssetsDir = project.projectDir.relativePath(assetsDir)
         return {
-            addPropertyIfNotExists(it, "sonar.cpd.exclusions", "${assetsDir}/**/Tests/**")
-            addPropertyIfNotExists(it, "sonar.coverage.exclusions", "${assetsDir}/**/Tests/**")
-            addPropertyIfNotExists(it, "sonar.exclusions", "${assetsDir}/Paket.Unity3D/**")
-            addPropertyIfNotExists(it, "sonar.cs.nunit.reportsPaths", "${reportsDir}/**/*.xml")
-            addPropertyIfNotExists(it, "sonar.cs.opencover.reportsPaths", "${reportsDir}/**/*.xml")
+            addPropertyIfNotExists(it, "sonar.cpd.exclusions", "${relativeAssetsDir}/**/Tests/**")
+            addPropertyIfNotExists(it, "sonar.coverage.exclusions", "${relativeAssetsDir}/**/Tests/**")
+            addPropertyIfNotExists(it, "sonar.exclusions", "${relativeAssetsDir}/Paket.Unity3D/**")
+            addPropertyIfNotExists(it, "sonar.cs.nunit.reportsPaths", "${reportsDir.path}/**/*.xml")
+            addPropertyIfNotExists(it, "sonar.cs.opencover.reportsPaths", "${reportsDir.path}/**/*.xml")
         }
     }
 

--- a/src/test/groovy/wooga/gradle/build/unity/UnityBuildPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/build/unity/UnityBuildPluginSpec.groovy
@@ -107,11 +107,10 @@ class UnityBuildPluginSpec extends ProjectSpec {
         def unityExt = project.extensions.getByType(UnityPluginExtension)
         and: "sonarqube extension is configured with defaults"
         def properties = sonarExt.computeSonarProperties(project)
-        def assetsDir = unityExt.assetsDir.get().asFile.path
         def reportsDir = unityExt.reportsDir.get().asFile.path
-        properties["sonar.exclusions"] == "${assetsDir}/Paket.Unity3D/**"
-        properties["sonar.cpd.exclusions"] == "${assetsDir}/**/Tests/**"
-        properties["sonar.coverage.exclusions"] == "${assetsDir}/**/Tests/**"
+        properties["sonar.exclusions"] == "Assets/Paket.Unity3D/**"
+        properties["sonar.cpd.exclusions"] == "Assets/**/Tests/**"
+        properties["sonar.coverage.exclusions"] == "Assets/**/Tests/**"
         properties["sonar.cs.nunit.reportsPaths"] == "${reportsDir}/**/*.xml"
         properties["sonar.cs.opencover.reportsPaths"] == "${reportsDir}/**/*.xml"
     }


### PR DESCRIPTION
## Description
Path to sonarqube exclusions are now relative to `project.projectDir`. If `unity.assetsDir` is not in the project directory file tree (which shouldn't happen), the path will continue to be absolute, as there is no way to know how which directory it is relative to.

## Changes
* ![FIX] path to sonarqube exclusion properties are now relative


[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
