### PR TITLE
Add FetchSecret task from net.wooga.security

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     implementation "gradle.plugin.net.wooga.gradle:atlas-unity:(2.2,3]"
     implementation 'com.wooga.gradle:gradle-commons:0.3.0'
     implementation "org.gradle:gradle-tooling-api:+"
-    api 'gradle.plugin.net.wooga.gradle:atlas-secrets:1.0.0-rc.1'
+    api 'gradle.plugin.net.wooga.gradle:atlas-secrets:1.0.0-rc.3'
     implementation 'xmlwise:xmlwise:1.2.11'
     implementation 'commons-codec:commons-codec:1.14'
     api 'software.amazon.awssdk:secretsmanager:(2.16,3]'

--- a/src/integrationTest/groovy/wooga/gradle/build/unity/tasks/FetchSecretsTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/unity/tasks/FetchSecretsTaskIntegrationSpec.groovy
@@ -1,0 +1,282 @@
+/*
+ * Copyright 2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wooga.gradle.build.unity.tasks
+
+
+import spock.lang.Unroll
+import wooga.gradle.build.IntegrationSpec
+import wooga.gradle.build.unity.UnityBuildPlugin
+import wooga.gradle.secrets.Secret
+import wooga.gradle.secrets.SecretResolver
+import wooga.gradle.secrets.SecretsPlugin
+import wooga.gradle.secrets.internal.DefaultSecret
+import wooga.gradle.secrets.internal.EncryptionSpecHelper
+import wooga.gradle.secrets.internal.Resolver
+
+class FetchSecretsTaskIntegrationSpec extends IntegrationSpec {
+    def setup() {
+        buildFile << """
+            ${applyPlugin(UnityBuildPlugin)}
+
+            import ${Resolver.name}
+            import ${DefaultSecret.name}
+            import ${SecretResolver.name}
+            import ${Secret.name}
+
+            task("fetchSecretsCustom", type: ${FetchSecrets.name}) {
+                secretIds = [   
+                                'net_wooga_testCredential',
+                                'net_wooga_testCredential2',
+                                'net_wooga_testCredential3',
+                                'net_wooga_testCredential4'
+                            ]
+            }
+        """.stripIndent()
+    }
+
+    def "task is Up-To-Date when secret key is cached"() {
+        given: "a secret key"
+        def key = EncryptionSpecHelper.createSecretKey(this.class.name)
+        def keyFile = createFile("secrets.key", projectDir)
+        keyFile.bytes = key.encoded
+
+        and: "the key configured"
+        buildFile << """
+            fetchSecretsCustom.secretsKey = file("${escapedPath(keyFile.path)}")
+        """
+
+        and: "a fake resolver"
+        buildFile << """
+            fetchSecretsCustom.resolver = Resolver.withClosure {
+                if(it == "net_wooga_testCredential2") {
+                    return it.toUpperCase().bytes
+                } else {
+                    return it.toUpperCase()
+                } 
+            }
+        """.stripIndent()
+
+        and: "a future secrets file"
+        def secretsFile = new File(projectDir, "build/secret/fetchSecretsCustom/secrets.yml")
+        assert !secretsFile.exists()
+
+        when:
+        def result = runTasksSuccessfully("fetchSecretsCustom")
+
+        then:
+        !result.wasUpToDate("fetchSecretsCustom")
+
+        when:
+        result = runTasksSuccessfully("fetchSecretsCustom")
+
+        then:
+        result.wasUpToDate("fetchSecretsCustom")
+        secretsFile.exists()
+
+        when:
+        secretsFile.delete()
+        result = runTasksSuccessfully("fetchSecretsCustom")
+
+        then:
+        !result.wasUpToDate("fetchSecretsCustom")
+    }
+
+    def "task is not Up-To-Date when resolver changes"() {
+        given: "a secret key"
+        def key = EncryptionSpecHelper.createSecretKey(this.class.name)
+        def keyFile = createFile("secrets.key", projectDir)
+        keyFile.bytes = key.encoded
+
+        and: "the key configured"
+        buildFile << """
+            fetchSecretsCustom.secretsKey = file("${escapedPath(keyFile.path)}")
+        """
+
+        and: "a fake resolver"
+        buildFile << """
+            class Resolver1 implements SecretResolver {
+                @Override
+                Secret<?> resolve(String secretId) {
+                    if(secretId == "net_wooga_testCredential2") {
+                        return new DefaultSecret(secretId.toUpperCase().bytes)
+                    } else {
+                        return new DefaultSecret(secretId.toUpperCase())
+                    } 
+                }            
+            }
+            
+            class Resolver2 implements SecretResolver {
+                @Override
+                Secret<?> resolve(String secretId) {
+                    if(secretId == "net_wooga_testCredential3") {
+                        return new DefaultSecret(secretId.toUpperCase().bytes)
+                    } else {
+                        return new DefaultSecret(secretId.toUpperCase())
+                    } 
+                }            
+            }
+            
+            fetchSecretsCustom.resolver = new Resolver1()
+        """.stripIndent()
+
+        and: "a future secrets file"
+        def secretsFile = new File(projectDir, "build/secret/fetchSecretsCustom/secrets.yml")
+        assert !secretsFile.exists()
+
+        when: "first run"
+        def result = runTasksSuccessfully("fetchSecretsCustom")
+
+        then:
+        !result.wasUpToDate("fetchSecretsCustom")
+        secretsFile.exists()
+
+        when: "second run"
+        result = runTasksSuccessfully("fetchSecretsCustom")
+
+        then:
+        result.wasUpToDate("fetchSecretsCustom")
+        secretsFile.exists()
+
+        when: "changing the resolver"
+        buildFile << """
+            fetchSecretsCustom.resolver = new Resolver2()
+        """.stripIndent()
+        result = runTasksSuccessfully("fetchSecretsCustom")
+
+        then:
+        !result.wasUpToDate("fetchSecretsCustom")
+    }
+
+
+    def "Second task can depend on secret output file"() {
+        given: "a fake resolver"
+        buildFile << """
+            fetchSecretsCustom.resolver = Resolver.withClosure {
+                if(it == "net_wooga_testCredential2") {
+                    return it.toUpperCase().bytes
+                } else {
+                    return it.toUpperCase()
+                } 
+            }
+        """.stripIndent()
+
+        and: "a task to use the secrets"
+        buildFile << """
+            class Consumer extends DefaultTask {
+                @InputFile
+                final RegularFileProperty inputFile = project.objects.fileProperty()
+            
+                @TaskAction
+                void consume() {
+                    def input = inputFile.get().asFile
+                    def message = input.text
+                }
+            }
+            
+            task secretConsumer(type: Consumer) {
+                inputFile = fetchSecretsCustom.secretsFile
+            }
+        """.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully("secretConsumer")
+
+        then:
+        result.wasExecuted("fetchSecretsCustom")
+    }
+
+
+    @Unroll
+    def "can set property #property with #method"() {
+        given: "a custom fetch secrets task"
+        buildFile << """
+            task("fetchSecretsCustom2", type: ${FetchSecrets.name})
+        """.stripIndent()
+
+        and: "a task to read back the value"
+        buildFile << """
+            task("readValue") {
+                doLast {
+                    println("secretIds: " + fetchSecretsCustom2.${property}.get())
+                }
+            }
+        """.stripIndent()
+
+        and: "a set property"
+        buildFile << """
+            fetchSecretsCustom2.${method}($value)
+        """.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully("readValue")
+
+        then:
+        outputContains(result, "secretIds: " + expectedValue.toString())
+
+        where:
+        property    | method         | rawValue           | type
+        "secretIds" | "secretIds"    | ["Test1"]          | "List<String>"
+        "secretIds" | "secretId"     | "Test1"            | "String"
+        "secretIds" | "secretIds"    | ["Test1", "Test2"] | "List<String>"
+        "secretIds" | "secretIds"    | ["Test1", "Test2"] | "String..."
+        "secretIds" | "setSecretIds" | ["Test1", "Test2"] | "List<String>"
+        "secretIds" | "setSecretIds" | ["Test1", "Test2"] | "String..."
+        value = wrapValueBasedOnType(rawValue, type)
+        expectedValue = [rawValue].flatten()
+    }
+
+    @Unroll
+    def "#method will #setType value"() {
+        given: "a custom fetch secrets task"
+        buildFile << """
+            task("fetchSecretsCustom2", type: ${FetchSecrets.name}) {
+                secretIds = ['secret1']
+            }
+        """.stripIndent()
+
+        and: "a task to read back the value"
+        buildFile << """
+            task("readValue") {
+                doLast {
+                    println("secretIds: " + fetchSecretsCustom2.${property}.get())
+                }
+            }
+        """.stripIndent()
+
+        and: "a set property"
+        buildFile << """
+            fetchSecretsCustom2.${method}($value)
+        """.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully("readValue")
+
+        then:
+        outputContains(result, "secretIds: " + expectedValue.toString())
+
+        where:
+        property    | method         | rawValue           | type           | append | expectedValue
+        "secretIds" | "secretIds"    | ["Test1"]          | "List<String>" | true   | ['secret1', 'Test1']
+        "secretIds" | "secretId"     | "Test1"            | "String"       | true   | ['secret1', 'Test1']
+        "secretIds" | "secretIds"    | ["Test1", "Test2"] | "List<String>" | true   | ['secret1', 'Test1', 'Test2']
+        "secretIds" | "secretIds"    | ["Test1", "Test2"] | "String..."    | true   | ['secret1', 'Test1', 'Test2']
+        "secretIds" | "setSecretIds" | ["Test1", "Test2"] | "List<String>" | false  | ['Test1', 'Test2']
+        "secretIds" | "setSecretIds" | ["Test1", "Test2"] | "String..."    | false  | ['Test1', 'Test2']
+        setType = (append) ? 'append' : 'replace'
+        value = wrapValueBasedOnType(rawValue, type)
+    }
+}

--- a/src/integrationTest/groovy/wooga/gradle/build/unity/tasks/SecretSpecIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/unity/tasks/SecretSpecIntegrationSpec.groovy
@@ -22,8 +22,6 @@ class SecretSpecIntegrationSpec extends UnityIntegrationSpec {
             value = "new javax.crypto.spec.SecretKeySpec(project.file('${keyPath}').bytes, 'AES')"
         } else if (type == "keyFile") {
             value = "project.file('${keyPath}')"
-        } else if (type == "keyPath") {
-            value = "'${keyPath}'"
         }
 
         and: "the key configured"
@@ -68,16 +66,12 @@ class SecretSpecIntegrationSpec extends UnityIntegrationSpec {
         GradleBuild                      | "secretsKey.set" | "key"     | false
         GradleBuild                      | "secretsKey"     | "keyFile" | false
         GradleBuild                      | "secretsKey"     | "keyFile" | true
-        GradleBuild                      | "secretsKey"     | "keyPath" | false
-        GradleBuild                      | "secretsKey"     | "keyPath" | true
 
         UnityBuildPlayerTask             | "secretsKey"     | "key"     | false
         UnityBuildPlayerTask             | "secretsKey"     | "key"     | true
         UnityBuildPlayerTask             | "secretsKey.set" | "key"     | false
         UnityBuildPlayerTask             | "secretsKey"     | "keyFile" | false
         UnityBuildPlayerTask             | "secretsKey"     | "keyFile" | true
-        UnityBuildPlayerTask             | "secretsKey"     | "keyPath" | false
-        UnityBuildPlayerTask             | "secretsKey"     | "keyPath" | true
 
         method = (useSetter) ? "set${property.capitalize()}" : property
         containerTypeName = Task.isAssignableFrom(containerType) ? "task" : "extension"

--- a/src/main/groovy/wooga/gradle/build/unity/tasks/FetchSecrets.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/tasks/FetchSecrets.groovy
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wooga.gradle.build.unity.tasks
+
+
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import wooga.gradle.secrets.Secret
+import wooga.gradle.secrets.SecretResolverException
+import wooga.gradle.secrets.internal.Resolver
+import wooga.gradle.secrets.internal.Secrets
+import wooga.gradle.secrets.tasks.SecretsTask
+
+class FetchSecrets extends SecretsTask {
+
+    @Input
+    private final ListProperty<String> secretIds
+
+    ListProperty<String> getSecretIds() {
+        secretIds
+    }
+
+    void setSecretIds(Iterable<String> value) {
+        secretIds.set(value)
+    }
+
+    void setSecretIds(String... value) {
+        secretIds.set(value.toList())
+    }
+
+    FetchSecrets secretIds(String... value) {
+        secretIds.addAll(project.provider({ value.toList() }))
+    }
+
+    FetchSecrets secretIds(Iterable<String> value) {
+        secretIds.addAll(project.provider({ value.toList() }))
+    }
+
+    FetchSecrets secretId(String value) {
+        secretIds.add(value)
+    }
+
+    @Optional
+    @Input
+    protected Class<Resolver> getResolverType() {
+        if(resolver.present) {
+            resolver.get().class as Class<Resolver>
+        }
+    }
+
+    @OutputFile
+    private final RegularFileProperty secretsFile
+
+    RegularFileProperty getSecretsFile(){
+        secretsFile
+    }
+
+    FetchSecrets() {
+        secretIds = project.objects.listProperty(String)
+        secretsFile = project.objects.fileProperty()
+    }
+
+    @TaskAction
+    protected void fetchSecrets() {
+        logger.info("Fetch secrets ${secretIds.get().join(", ")}")
+        Secrets secrets = new Secrets()
+        def resolver = resolver.getOrNull()
+        def key = secretsKey.get()
+
+        if(resolver) {
+            for(String secretId in secretIds.get()) {
+                logger.info("Fetch secret: ${secretId}")
+                try {
+                    Secret secret = resolver.resolve(secretId)
+                    secrets.putSecret(secretId, secret, key)
+                } catch(SecretResolverException e){
+                    throw new ScriptException("unable to fetch secret ${secretId}", e)
+                }
+            }
+        }
+        this.secretsFile.get().asFile.text = secrets.encode()
+    }
+}

--- a/src/main/groovy/wooga/gradle/build/unity/tasks/GradleBuild.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/tasks/GradleBuild.groovy
@@ -111,41 +111,6 @@ class GradleBuild extends DefaultTask implements SecretSpec {
         gradleVersion
     }
 
-    private final Property<SecretKeySpec> secretsKey
-
-    @Optional
-    @Input
-    Property<SecretKeySpec> getSecretsKey() {
-        secretsKey
-    }
-
-    void setSecretsKey(SecretKeySpec key) {
-        secretsKey.set(key)
-    }
-
-    GradleBuild setSecretsKey(String keyFile) {
-        setSecretsKey(project.file(keyFile))
-    }
-
-    GradleBuild setSecretsKey(File keyFile) {
-        setSecretsKey(new SecretKeySpec(keyFile.bytes, "AES"))
-    }
-
-    @Override
-    GradleBuild secretsKey(SecretKeySpec key) {
-        setSecretsKey(key)
-    }
-
-    @Override
-    GradleBuild secretsKey(String keyFile) {
-        return setSecretsKey(keyFile)
-    }
-
-    @Override
-    GradleBuild secretsKey(File keyFile) {
-        return setSecretsKey(keyFile)
-    }
-
     private final RegularFileProperty secretsFile
 
     @Optional

--- a/src/main/groovy/wooga/gradle/build/unity/tasks/UnityBuildPlayerTask.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/tasks/UnityBuildPlayerTask.groovy
@@ -117,47 +117,12 @@ class UnityBuildPlayerTask extends UnityTask implements SecretSpec {
         versionCode
     }
 
-    private final Property<SecretKeySpec> secretsKey
-
-    @Optional
-    @Input
-    Property<SecretKeySpec> getSecretsKey() {
-        secretsKey
-    }
-
-    void setSecretsKey(SecretKeySpec key) {
-        secretsKey.set(key)
-    }
-
     private final MapProperty<String, ?> customArguments
 
     @Optional
     @Input
     MapProperty<String, ?> getCustomArguments() {
         customArguments
-    }
-
-    UnityBuildPlayerTask setSecretsKey(String keyFile) {
-        setSecretsKey(project.file(keyFile))
-    }
-
-    UnityBuildPlayerTask setSecretsKey(File keyFile) {
-        setSecretsKey(new SecretKeySpec(keyFile.bytes, "AES"))
-    }
-
-    @Override
-    UnityBuildPlayerTask secretsKey(SecretKeySpec key) {
-        setSecretsKey(key)
-    }
-
-    @Override
-    UnityBuildPlayerTask secretsKey(String keyFile) {
-        return setSecretsKey(keyFile)
-    }
-
-    @Override
-    UnityBuildPlayerTask secretsKey(File keyFile) {
-        return setSecretsKey(keyFile)
     }
 
     private final RegularFileProperty secretsFile

--- a/src/test/groovy/wooga/gradle/secrets/internal/EncryptionSpecHelper.groovy
+++ b/src/test/groovy/wooga/gradle/secrets/internal/EncryptionSpecHelper.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wooga.gradle.secrets.internal
+
+import javax.crypto.SecretKeyFactory
+import javax.crypto.spec.PBEKeySpec
+import javax.crypto.spec.SecretKeySpec
+import java.security.SecureRandom
+import java.security.spec.KeySpec
+
+class EncryptionSpecHelper {
+    static SecretKeySpec createSecretKey(String passphrase) {
+        SecureRandom random = new SecureRandom()
+        byte[] salt = new byte[16]
+        random.nextBytes(salt)
+
+        KeySpec spec = new PBEKeySpec(passphrase.chars, salt, 65536, 256)
+        SecretKeyFactory f = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA1");
+        byte[] key = f.generateSecret(spec).getEncoded();
+        new SecretKeySpec(key, "AES");
+    }
+}


### PR DESCRIPTION
## Description

This patch add the removed task type `FetchSecrets` to this plugin. In the future this tasks won't be needed anymore. This move is just for backwards compatibility to be able to use the secrets plugin directly in other projects.

## Changes

* ![ADD] removed `FetchSecrets` task from `net.wooga.secrets`


[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
