### PR TITLE
Improve build unity ios plugin extension [ATLAS-437]

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/build/unity/ios/tasks/KeychainTaskSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/unity/ios/tasks/KeychainTaskSpec.groovy
@@ -71,7 +71,7 @@ class KeychainTaskSpec extends IntegrationSpec {
             ${applyPlugin(IOSBuildPlugin)}
 
             iosBuild {
-                certificatePassphrase = "$certPassword"
+                codeSigningIdentityFilePassphrase = "$certPassword"
                 keychainPassword = "$certPassword"
             }
         """.stripIndent()
@@ -101,7 +101,7 @@ class KeychainTaskSpec extends IntegrationSpec {
     def "fails with security stderr printed to error log"() {
         given: "wrong certificatePassphrase"
         buildFile << """
-            iosBuild.certificatePassphrase = "randomPassphrase"
+            iosBuild.codeSigningIdentityFilePassphrase = "randomPassphrase"
         """.stripIndent()
 
         when:

--- a/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginExtension.groovy
@@ -1,69 +1,216 @@
-/*
- * Copyright 2018 Wooga GmbH
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- */
-
 package wooga.gradle.build.unity.ios
 
+import com.wooga.gradle.BaseSpec
 import org.gradle.api.Action
 import org.gradle.api.credentials.PasswordCredentials
+import org.gradle.api.file.RegularFile
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Input
 
-interface IOSBuildPluginExtension {
+trait IOSBuildPluginExtension extends BaseSpec {
 
-    PasswordCredentials getFastlaneCredentials()
-    void setFastlaneCredentials(PasswordCredentials cred)
+    @Deprecated
+    abstract PasswordCredentials getFastlaneCredentials()
 
-    IOSBuildPluginExtension fastlaneCredentials(Closure configuration)
-    IOSBuildPluginExtension fastlaneCredentials(Action<PasswordCredentials> action)
-    IOSBuildPluginExtension fastlaneCredentials(PasswordCredentials cred)
+    @Deprecated
+    abstract void setFastlaneCredentials(PasswordCredentials cred)
 
+    @Deprecated
+    abstract IOSBuildPluginExtension fastlaneCredentials(Closure configuration)
 
-    String getKeychainPassword()
-    void setKeychainPassword(String value)
-    IOSBuildPluginExtension keychainPassword(String password)
+    @Deprecated
+    abstract IOSBuildPluginExtension fastlaneCredentials(Action<PasswordCredentials> action)
 
-    String getCertificatePassphrase()
-    void setCertificatePassphrase(String passphrase)
-    IOSBuildPluginExtension certificatePassphrase(String passphrase)
+    @Deprecated
+    abstract IOSBuildPluginExtension fastlaneCredentials(PasswordCredentials cred)
 
-    String getAppIdentifier()
-    void setAppIdentifier(String identifier)
-    IOSBuildPluginExtension appIdentifier(String identifier)
+    private final Property<String> keychainPassword = objects.property(String)
 
-    String getTeamId()
-    void setTeamId(String id)
-    IOSBuildPluginExtension teamId(String id)
+    Property<String> getKeychainPassword() {
+        keychainPassword
+    }
 
-    String getScheme()
-    void setScheme(String scheme)
-    IOSBuildPluginExtension scheme(String scheme)
+    void setKeychainPassword(Provider<String> value) {
+        keychainPassword.set(value)
+    }
 
-    String getConfiguration()
-    void setConfiguration(String configuration)
-    IOSBuildPluginExtension configuration(String configuration)
+    void setKeychainPassword(String value) {
+        keychainPassword.set(value)
+    }
 
-    String getProvisioningName()
-    void setProvisioningName(String provisioningName)
-    IOSBuildPluginExtension provisioningName(String provisioningName)
+    private final ListProperty<String> signingIdentities = objects.listProperty(String)
 
-    Boolean getAdhoc()
-    void setAdhoc(Boolean value)
-    IOSBuildPluginExtension adhoc(Boolean value)
+    @Input
+    ListProperty<String> getSigningIdentities() {
+        signingIdentities
+    }
 
-    Boolean getPublishToTestFlight()
-    void setPublishToTestFlight(Boolean value)
-    IOSBuildPluginExtension publishToTestFlight(Boolean value)
+    void setSigningIdentities(Provider<List<String>> value) {
+        signingIdentities.set(value)
+    }
+
+    void setSigningIdentities(List<String> value) {
+        signingIdentities.set(value)
+    }
+
+    void setSigningIdentity(String value) {
+        signingIdentities.empty().add(value)
+    }
+
+    void setSigningIdentity(Provider<String> value) {
+        signingIdentities.empty().add(value)
+    }
+
+    void signingIdentity(String value) {
+        signingIdentities.add(value)
+    }
+
+    void signingIdentity(Provider<String> value) {
+        signingIdentities.add(value)
+    }
+
+    private final RegularFileProperty codeSigningIdentityFile = objects.fileProperty()
+
+    Property<RegularFile> getCodeSigningIdentityFile() {
+        codeSigningIdentityFile
+    }
+
+    void setCodeSigningIdentityFile(Provider<RegularFile> value) {
+        codeSigningIdentityFile.set(value)
+    }
+
+    void setCodeSigningIdentityFile(File value) {
+        codeSigningIdentityFile.set(value)
+    }
+
+    private final Property<String> codeSigningIdentityFilePassphrase = objects.property(String)
+
+    Property<String> getCodeSigningIdentityFilePassphrase() {
+        codeSigningIdentityFilePassphrase
+    }
+
+    void setCodeSigningIdentityFilePassphrase(Provider<String> value) {
+        codeSigningIdentityFilePassphrase.set(value)
+    }
+
+    void setCodeSigningIdentityFilePassphrase(String value) {
+        codeSigningIdentityFilePassphrase.set(value)
+    }
+
+    private final Property<String> appIdentifier = objects.property(String)
+
+    Property<String> getAppIdentifier() {
+        appIdentifier
+    }
+
+    void setAppIdentifier(Provider<String> value) {
+        appIdentifier.set(value)
+    }
+
+    void setAppIdentifier(String value) {
+        appIdentifier.set(value)
+    }
+
+    private final Property<String> teamId = objects.property(String)
+
+    Property<String> getTeamId() {
+        teamId
+    }
+
+    void setTeamId(Provider<String> value) {
+        teamId.set(value)
+    }
+
+    void setTeamId(String value) {
+        teamId.set(value)
+    }
+
+    private final Property<String> scheme = objects.property(String)
+
+    Property<String> getScheme() {
+        scheme
+    }
+
+    void setScheme(Provider<String> value) {
+        scheme.set(value)
+    }
+
+    void setScheme(String value) {
+        scheme.set(value)
+    }
+
+    private final Property<String> configuration = objects.property(String)
+
+    Property<String> getConfiguration() {
+        configuration
+    }
+
+    void setConfiguration(Provider<String> value) {
+        configuration.set(value)
+    }
+
+    void setConfiguration(String value) {
+        configuration.set(value)
+    }
+
+    private final Property<String> provisioningName = objects.property(String)
+
+    Property<String> getProvisioningName() {
+        provisioningName
+    }
+
+    void setProvisioningName(Provider<String> value) {
+        provisioningName.set(value)
+    }
+
+    void setProvisioningName(String value) {
+        provisioningName.set(value)
+    }
+
+    private final Property<Boolean> adhoc = objects.property(Boolean)
+
+    Property<Boolean> getAdhoc() {
+        adhoc
+    }
+
+    void setAdhoc(Provider<Boolean> value) {
+        adhoc.set(value)
+    }
+
+    void setAdhoc(Boolean value) {
+        adhoc.set(value)
+    }
+
+    private final Property<Boolean> publishToTestFlight = objects.property(Boolean)
+
+    Property<Boolean> getPublishToTestFlight() {
+        publishToTestFlight
+    }
+
+    void setPublishToTestFlight(Provider<Boolean> value) {
+        publishToTestFlight.set(value)
+    }
+
+    void setPublishToTestFlight(Boolean value) {
+        publishToTestFlight.set(value)
+    }
+
+    private final RegularFileProperty exportOptionsPlist = objects.fileProperty()
+
+    @Input
+    RegularFileProperty getExportOptionsPlist() {
+        exportOptionsPlist
+    }
+
+    void setExportOptionsPlist(Provider<RegularFile> value) {
+        exportOptionsPlist.set(value)
+    }
+
+    void setExportOptionsPlist(File value) {
+        exportOptionsPlist.set(value)
+    }
 
 }

--- a/src/main/groovy/wooga/gradle/build/unity/ios/internal/DefaultIOSBuildPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/internal/DefaultIOSBuildPluginExtension.groovy
@@ -24,24 +24,15 @@ import static org.gradle.util.ConfigureUtil.configureUsing
 
 class DefaultIOSBuildPluginExtension implements IOSBuildPluginExtension {
 
-    private final org.gradle.api.credentials.PasswordCredentials fastlaneCredentials
-    private String keychainPassword
-    private String certificatePassphrase
-    private String applicationIdentifier
-    private String teamId
-    private String scheme
-    private String configuration
-    private String provisioningName
-    private Boolean adhoc = false
-    private Boolean publishToTestFlight = false
+    private final PasswordCredentials fastlaneCredentials
 
     @Override
-    org.gradle.api.credentials.PasswordCredentials getFastlaneCredentials() {
+    PasswordCredentials getFastlaneCredentials() {
         fastlaneCredentials
     }
 
     @Override
-    void setFastlaneCredentials(org.gradle.api.credentials.PasswordCredentials cred) {
+    void setFastlaneCredentials(PasswordCredentials cred) {
         fastlaneCredentials.setUsername(cred.username)
         fastlaneCredentials.setPassword(cred.password)
         this
@@ -54,159 +45,15 @@ class DefaultIOSBuildPluginExtension implements IOSBuildPluginExtension {
     }
 
     @Override
-    IOSBuildPluginExtension fastlaneCredentials(Action<org.gradle.api.credentials.PasswordCredentials> action) {
+    IOSBuildPluginExtension fastlaneCredentials(Action<PasswordCredentials> action) {
         action.execute(fastlaneCredentials)
         this
     }
 
     @Override
-    IOSBuildPluginExtension fastlaneCredentials(org.gradle.api.credentials.PasswordCredentials cred) {
+    IOSBuildPluginExtension fastlaneCredentials(PasswordCredentials cred) {
         setFastlaneCredentials(cred)
         this
-    }
-
-    @Override
-    String getKeychainPassword() {
-        keychainPassword
-    }
-
-    @Override
-    void setKeychainPassword(String value) {
-        keychainPassword = value
-    }
-
-    @Override
-    IOSBuildPluginExtension keychainPassword(String password) {
-        setKeychainPassword(password)
-        this
-    }
-
-    @Override
-    String getCertificatePassphrase() {
-        certificatePassphrase
-    }
-
-    @Override
-    void setCertificatePassphrase(String passphrase) {
-        certificatePassphrase = passphrase
-    }
-
-    @Override
-    IOSBuildPluginExtension certificatePassphrase(String passphrase) {
-        setCertificatePassphrase(passphrase)
-        this
-    }
-
-    @Override
-    String getAppIdentifier() {
-        return applicationIdentifier
-    }
-
-    @Override
-    void setAppIdentifier(String identifier) {
-        applicationIdentifier = identifier
-    }
-
-    @Override
-    IOSBuildPluginExtension appIdentifier(String identifier) {
-        setAppIdentifier(identifier)
-        return this
-    }
-
-    @Override
-    String getTeamId() {
-        return teamId
-    }
-
-    @Override
-    void setTeamId(String id) {
-        teamId = id
-    }
-
-    @Override
-    IOSBuildPluginExtension teamId(String id) {
-        setTeamId(id)
-        return this
-    }
-
-    @Override
-    String getScheme() {
-        scheme
-    }
-
-    @Override
-    void setScheme(String scheme) {
-        this.scheme = scheme
-    }
-
-    @Override
-    IOSBuildPluginExtension scheme(String scheme) {
-        setScheme(scheme)
-        this
-    }
-
-    @Override
-    String getConfiguration() {
-        configuration
-    }
-
-    @Override
-    void setConfiguration(String configuration) {
-        this.configuration = configuration
-    }
-
-    @Override
-    IOSBuildPluginExtension configuration(String configuration) {
-        setConfiguration(configuration)
-        this
-    }
-
-    @Override
-    String getProvisioningName() {
-        this.provisioningName
-    }
-
-    @Override
-    void setProvisioningName(String provisioningName) {
-        this.provisioningName = provisioningName
-    }
-
-    @Override
-    IOSBuildPluginExtension provisioningName(String provisioningName) {
-        setProvisioningName(provisioningName)
-        this
-    }
-
-    @Override
-    Boolean getAdhoc() {
-        return adhoc
-    }
-
-    @Override
-    void setAdhoc(Boolean value) {
-        adhoc = value
-    }
-
-    @Override
-    IOSBuildPluginExtension adhoc(Boolean value) {
-        setAdhoc(value)
-        return this
-    }
-
-    @Override
-    Boolean getPublishToTestFlight() {
-        return publishToTestFlight
-    }
-
-    @Override
-    void setPublishToTestFlight(Boolean value) {
-        publishToTestFlight = value
-    }
-
-    @Override
-    IOSBuildPluginExtension publishToTestFlight(Boolean value) {
-        setPublishToTestFlight(value)
-        return this
     }
 
     DefaultIOSBuildPluginExtension() {

--- a/src/test/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginSpec.groovy
@@ -157,7 +157,7 @@ class IOSBuildPluginSpec extends ProjectSpec {
         and: "a project with property set"
         project.plugins.apply(PLUGIN_NAME)
         IOSBuildPluginExtension extension = project.extensions.findByName(IOSBuildPlugin.EXTENSION_NAME) as IOSBuildPluginExtension
-        extension.publishToTestFlight(publishToTestflight)
+        extension.setPublishToTestFlight(publishToTestflight)
 
         and: "a dummpy xcode project"
         xcProject = new File(projectDir, "test.xcodeproj")
@@ -178,27 +178,5 @@ class IOSBuildPluginSpec extends ProjectSpec {
         message = (dependsOnTask) ? "depends" : "depends not"
     }
 
-    @Unroll
-    def 'extension returns #defaultValue value for property #property'() {
-        given:
-        project.plugins.apply(PLUGIN_NAME)
 
-        and: "the extension"
-        DefaultIOSBuildPluginExtension extension = project.extensions.findByName(IOSBuildPlugin.EXTENSION_NAME) as DefaultIOSBuildPluginExtension
-
-        expect:
-        extension.getProperty(property) == defaultValue
-
-        where:
-        property                | defaultValue
-        "keychainPassword"      | null
-        "certificatePassphrase" | null
-        "appIdentifier"         | null
-        "teamId"                | null
-        "scheme"                | null
-        "configuration"         | null
-        "provisioningName"      | null
-        "adhoc"                 | false
-        "publishToTestFlight"   | false
-    }
 }


### PR DESCRIPTION
## Description

The plugin extension for `net.wooga.build-unity-ios` was not setup to use `Property`/`Provider` APIs. I changed this and moved the interface into a trait object. I had to implement some brealing changes to make the interface clearer

## Changes

* ![IMPROVE] build-unity-ios plugin extension


[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
