### PR TITLE
Fix adding buildkeychain flag multiple times to OTHER_CODE_SIGN_FLAGS [ATLAS-468]

### DIFF
--- a/src/main/groovy/wooga/gradle/xcodebuild/config/BuildSettings.groovy
+++ b/src/main/groovy/wooga/gradle/xcodebuild/config/BuildSettings.groovy
@@ -19,9 +19,10 @@
 
 package wooga.gradle.xcodebuild.config
 
+import org.gradle.api.internal.changedetection.state.BuildSessionScopeFileTimeStampInspector
 import sun.invoke.empty.Empty
 
-class BuildSettings implements GroovyInterceptable {
+class BuildSettings implements GroovyInterceptable, Cloneable {
 
     private final Map<String, List<String>> rawSettings
 
@@ -44,7 +45,7 @@ class BuildSettings implements GroovyInterceptable {
     }
 
     BuildSettings clone() {
-        new BuildSettings(rawSettings)
+        new BuildSettings(rawSettings.clone() as Map<String, List<String>>)
     }
 
     BuildSettings otherCodeSignFlags(String flag, String value) {

--- a/src/main/groovy/wooga/gradle/xcodebuild/tasks/XcodeArchive.groovy
+++ b/src/main/groovy/wooga/gradle/xcodebuild/tasks/XcodeArchive.groovy
@@ -255,7 +255,7 @@ class XcodeArchive extends AbstractXcodeArchiveTask implements XcodeArchiveActio
 
         buildArguments = project.provider({
             List<String> arguments = new ArrayList<String>()
-            BuildSettings settings = buildSettings.getOrElse(BuildSettings.EMPTY)
+            BuildSettings settings = buildSettings.getOrElse(BuildSettings.EMPTY).clone()
             arguments << "xcodebuild"
 
             if (clean.present && clean.get()) {


### PR DESCRIPTION
## Description

Small fix for an issue which made no real harm at runtime at the moment but needs a fix in any case. The `Provider` for build arguments in `XcodeArchive` is mutating the `Buildsettings` object of the task while constructing the argument `List`. The provider itself gets called multiple times and manipulates the BuildSettings again and again and again. I decided to go with the `clone` approuch here instead of memorizing the whole closure. First I'm not always sure if the first invocation is already late enough so that all fields are set correctly.

While testing this I saw that my initial `clone` implementation in `BuildSettings` had a major bug. I also need to clone the underlying `HashMap` which holds all passed values. This fix allows to call `buildArguments.get()` multiple times without multiplying the keychain flags

## Changes

* ![FIX] adding buildkeychain flag multiple times to OTHER_CODE_SIGN_FLAGS

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
