### PR TITLE
Implement continueOnFailure passthrough/property for GradleBuild task

### DIFF
--- a/src/main/groovy/wooga/gradle/build/unity/tasks/GradleBuild.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/tasks/GradleBuild.groovy
@@ -87,6 +87,23 @@ class GradleBuild extends DefaultTask implements SecretSpec {
         buildArguments
     }
 
+    private final Property<Boolean> continueOnFailure = project.objects.property(Boolean)
+
+    @Input
+    @Optional
+    Property<Boolean> getContinueOnFailure() {
+        continueOnFailure
+    }
+
+    void setContinueOnFailure(Provider<Boolean> value) {
+        continueOnFailure.set(value)
+    }
+
+    void setContinueOnFailure(Boolean value) {
+        continueOnFailure.set(value)
+    }
+
+
     private final Property<String> gradleVersion = project.objects.property(String.class)
 
     @Input
@@ -249,6 +266,10 @@ class GradleBuild extends DefaultTask implements SecretSpec {
                     args << '--quiet'
                     break
             }
+        }
+
+        if(!args.contains('--continue') && continueOnFailure.getOrElse(this.project.gradle.startParameter.continueOnFailure)) {
+            args << '--continue'
         }
 
         ProjectConnection connection = GradleConnector.newConnector()


### PR DESCRIPTION
## Description

This patch adds a new input property `continueOnFailure` which will set a the matching property on the `GradleBuild` launcher. If this property is not set, the task will check the start parameter of the running gradle instance if it has the flag set which means it will by default pass the flag through analog to the loglevel.

If the `--continue` flag is already set in the tasks buildarguments it will be used instead.

## Changes

* ![IMPROVE] `GraddleBuild` continueOnFailure flag/passthrough



[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
