### PR TITLE
Remove the need for special xcode version during tests [ATLAS-498]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ withCredentials([
     ]
 
     def testLabels = [
-        'macos': 'xcode_12'
+        'macos': 'xcode'
     ]
     buildGradlePlugin platforms: ['macos','windows', 'linux'], coverallsToken: coveralls_token, sonarToken: sonar_token, testEnvironment:env, testLabels: testLabels
 }

--- a/src/integrationTest/groovy/wooga/gradle/xcodebuild/tasks/AbstractXcodeTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/xcodebuild/tasks/AbstractXcodeTaskIntegrationSpec.groovy
@@ -16,10 +16,13 @@
 
 package wooga.gradle.xcodebuild.tasks
 
+import com.wooga.gradle.test.run.result.GradleRunResult
 import spock.lang.Unroll
 import wooga.gradle.xcodebuild.ConsoleSettings
 import wooga.gradle.xcodebuild.XcodeBuildIntegrationSpec
 import wooga.gradle.xcodebuild.config.BuildSettings
+
+import java.util.regex.Pattern
 
 abstract class AbstractXcodeTaskIntegrationSpec extends XcodeBuildIntegrationSpec {
 
@@ -216,8 +219,8 @@ abstract class AbstractXcodeTaskIntegrationSpec extends XcodeBuildIntegrationSpe
             expectedPrintOutput = expectedPrettyLogOutput
         }
 
-        outputContains(result, expectedPrintOutput)
-        outputContains(result, logFile.text) == !usePrettyPrint
+        def log = new GradleRunResult(result).getAt(testTaskName).getTaskLog()
+        log.contains(expectedPrintOutput)
 
         where:
         usePrettyPrint | useUniCode | colorize                           | logType                 | reason

--- a/src/integrationTest/groovy/wooga/gradle/xcodebuild/tasks/ExportArchiveIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/xcodebuild/tasks/ExportArchiveIntegrationSpec.groovy
@@ -66,7 +66,7 @@ class ExportArchiveIntegrationSpec extends AbstractXcodeArchiveTaskIntegrationSp
             return "▸ \u001B[39;1mExport\u001B[0m Succeeded"
         }
 
-        return """error: exportArchive: No signing certificate "iOS Development" found"""
+        "\u001B[31m❌  error: exportArchive: No signing certificate \"iOS Development\" found\u001B[0m"
     }
 
     @Override
@@ -75,7 +75,8 @@ class ExportArchiveIntegrationSpec extends AbstractXcodeArchiveTaskIntegrationSp
         if (System.getenv("TEST_TEAM_ID")) {
             return "> Export Succeeded"
         }
-        return """error: exportArchive: No signing certificate "iOS Development" found"""
+        "[x] error: exportArchive: No signing certificate \"iOS Development\""
+
     }
 
     @Override
@@ -84,7 +85,7 @@ class ExportArchiveIntegrationSpec extends AbstractXcodeArchiveTaskIntegrationSp
         if (System.getenv("TEST_TEAM_ID")) {
             return "▸ Export Succeeded"
         }
-        return """error: exportArchive: No signing certificate "iOS Development" found"""
+        return """❌  error: exportArchive: No signing certificate "iOS Development" found"""
     }
 
     File exportOptions

--- a/src/integrationTest/groovy/wooga/gradle/xcodebuild/tasks/XcodeArchiveIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/xcodebuild/tasks/XcodeArchiveIntegrationSpec.groovy
@@ -19,7 +19,7 @@
 
 package wooga.gradle.xcodebuild.tasks
 
-import nebula.test.IntegrationBase
+
 import net.wooga.test.xcode.XcodeTestProject
 import org.junit.ClassRule
 import spock.lang.Requires
@@ -52,29 +52,16 @@ class XcodeArchiveIntegrationSpec extends AbstractXcodeTaskIntegrationSpec {
     }
     """.stripIndent()
 
-
     String expectedPrettyColoredUnicodeLogOutput = """
         ▸ \u001B[39;1mLinking\u001B[0m xcodebuildPluginTest
-        ▸ \u001B[39;1mProcessing\u001B[0m Info.plist
-        ▸ \u001B[39;1mGenerating 'xcodebuildPluginTest.app.dSYM'\u001B[0m
-        ▸ \u001B[39;1mTouching\u001B[0m xcodebuildPluginTest.app (in target 'xcodebuildPluginTest' from project 'xcodebuildPluginTest')
-        ▸ \u001B[39;1mArchive\u001B[0m Succeeded
     """.stripIndent().trim()
 
     String expectedPrettyUnicodeLogOutput = """
         ▸ Linking xcodebuildPluginTest
-        ▸ Processing Info.plist
-        ▸ Generating 'xcodebuildPluginTest.app.dSYM'
-        ▸ Touching xcodebuildPluginTest.app (in target 'xcodebuildPluginTest' from project 'xcodebuildPluginTest')
-        ▸ Archive Succeeded
         """.stripIndent().trim()
 
     String expectedPrettyLogOutput = """
         > Linking xcodebuildPluginTest
-        > Processing Info.plist
-        > Generating 'xcodebuildPluginTest.app.dSYM'
-        > Touching xcodebuildPluginTest.app (in target 'xcodebuildPluginTest' from project 'xcodebuildPluginTest')
-        > Archive Succeeded
         """.stripIndent().trim()
 
     @Unroll

--- a/src/main/groovy/wooga/gradle/xcodebuild/internal/XcodeBuildAction.groovy
+++ b/src/main/groovy/wooga/gradle/xcodebuild/internal/XcodeBuildAction.groovy
@@ -46,6 +46,7 @@ class XcodeBuildAction implements XcodeAction {
         TextStream handler = new ForkTextStream()
 
         def outStream = new LineBufferingOutputStream(handler)
+        def errStream = new LineBufferingOutputStream(handler)
         def logWriter = System.out.newPrintWriter()
         if (logFile) {
             logFile.parentFile.mkdirs()
@@ -65,6 +66,7 @@ class XcodeBuildAction implements XcodeAction {
                     executable "/usr/bin/xcrun"
                     args = buildArguments
                     standardOutput = outStream
+                    errorOutput = errStream
                 }
             }
         })


### PR DESCRIPTION
## Description

The old tests had to force a testrun with xcode 12 setup. XCode 13 changed it's output and the tests won't be able to cover over multiple versions. I decided to make the test case simpler by only testing a single line of the output for the formatting instead of trying to match the whole output with regex. I also needed to adjust the output handling from xcodebuild because error lines are not printed to stderr instead of stdout as before with Xcode12. I simply merge both streams together for a single log file.

## Changes

* ![IMPROVE] simplify xcode format check to be version agnostic
* ![FIX] XCode13 error output handling


[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
