### PR TITLE
Relax net.wooga.unity dependency version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ repositories {
 
 dependencies {
     implementation "gradle.plugin.net.wooga.gradle:atlas-dotnet-sonarqube:(0.2,0.3]"
-    implementation "gradle.plugin.net.wooga.gradle:atlas-unity:2.2.0"
+    implementation "gradle.plugin.net.wooga.gradle:atlas-unity:(2.2,3]"
     implementation 'com.wooga.gradle:gradle-commons:0.3.0'
     implementation "org.gradle:gradle-tooling-api:+"
     api 'gradle.plugin.net.wooga.gradle:atlas-secrets:1.0.0-rc.1'


### PR DESCRIPTION
## Description

Relax the version requirement for `net.wooga.unity` to include version from `2.2.0` - `3.0.0`

## Changes

* ![IMPROVE] `net.wooga.unity` version requirement


[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
