### PR TITLE
Fix missing dependency to importProvisioningProfiles for xcodeArchive [ATLAS-580]

### DIFF
--- a/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPlugin.groovy
@@ -255,7 +255,7 @@ class IOSBuildPlugin implements Plugin<Project> {
         }
 
         def xcodeArchive = tasks.create(maybeBaseName(baseName, "xcodeArchive"), XcodeArchive) {
-            it.dependsOn addKeychain, unlockKeychain, podInstall, buildKeychain
+            it.dependsOn addKeychain, unlockKeychain, importProvisioningProfiles, podInstall, buildKeychain
             it.projectPath.set(project.provider({
                 def d = project.layout.buildDirectory.get()
                 if (podInstall.workspace.exists()) {


### PR DESCRIPTION
## Description

The dependecy declaration got removed in one of the last patches. This yields issues when the host system doesn't privide the provisioning profiles to sign.

## Changes

* ![FIX] missing dependency to `importProvisioningProfiles` task for xcodeArchive

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
