### PR TITLE
Improve net.wooga.build-unity-ios xcode task setup

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginIntegrationSpec.groovy
@@ -378,91 +378,133 @@ class IOSBuildPluginIntegrationSpec extends IOSBuildIntegrationSpec {
         query.matches(result, testValue)
 
         where:
-        property                            | method                      | rawValue                       | expectedValue                               | type                     | location
-        "keychainPassword"                  | _                           | _                              | null                                        | "Provider<String>"       | PropertyLocation.none
-        "keychainPassword"                  | toSetter(property)          | "password1"                    | _                                           | "Provider<String>"       | PropertyLocation.script
-        "keychainPassword"                  | toSetter(property)          | "password1"                    | _                                           | "String"                 | PropertyLocation.script
-        "keychainPassword"                  | toProviderSet(property)     | "password1"                    | _                                           | "Provider<String>"       | PropertyLocation.script
-        "keychainPassword"                  | toProviderSet(property)     | "password1"                    | _                                           | "String"                 | PropertyLocation.script
+        property                            | method                      | rawValue                                | expectedValue                               | type                     | location
+        "keychainPassword"                  | _                           | _                                       | null                                        | "Provider<String>"       | PropertyLocation.none
+        "keychainPassword"                  | toSetter(property)          | "password1"                             | _                                           | "Provider<String>"       | PropertyLocation.script
+        "keychainPassword"                  | toSetter(property)          | "password1"                             | _                                           | "String"                 | PropertyLocation.script
+        "keychainPassword"                  | toProviderSet(property)     | "password1"                             | _                                           | "Provider<String>"       | PropertyLocation.script
+        "keychainPassword"                  | toProviderSet(property)     | "password1"                             | _                                           | "String"                 | PropertyLocation.script
 
-        "signingIdentities"                 | _                           | _                              | []                                          | _                        | PropertyLocation.none
-        "signingIdentities"                 | toSetter(property)          | ["ID1", "ID2"]                 | _                                           | "List<String>"           | PropertyLocation.script
-        "signingIdentities"                 | toSetter(property)          | ["ID3", "ID4"]                 | _                                           | "Provider<List<String>>" | PropertyLocation.script
-        "signingIdentities"                 | toProviderSet(property)     | ["ID5", "ID6"]                 | _                                           | "List<String>"           | PropertyLocation.script
-        "signingIdentities"                 | toProviderSet(property)     | ["ID7", "ID8"]                 | _                                           | "Provider<List<String>>" | PropertyLocation.script
-        "signingIdentities"                 | toSetter("signingIdentity") | "code sign: ID3"               | [rawValue]                                  | "String"                 | PropertyLocation.script
-        "signingIdentities"                 | toSetter("signingIdentity") | "code sign: ID4"               | [rawValue]                                  | "Provider<String>"       | PropertyLocation.script
+        "signingIdentities"                 | _                           | _                                       | []                                          | _                        | PropertyLocation.none
+        "signingIdentities"                 | toSetter(property)          | ["ID1", "ID2"]                          | _                                           | "List<String>"           | PropertyLocation.script
+        "signingIdentities"                 | toSetter(property)          | ["ID3", "ID4"]                          | _                                           | "Provider<List<String>>" | PropertyLocation.script
+        "signingIdentities"                 | toProviderSet(property)     | ["ID5", "ID6"]                          | _                                           | "List<String>"           | PropertyLocation.script
+        "signingIdentities"                 | toProviderSet(property)     | ["ID7", "ID8"]                          | _                                           | "Provider<List<String>>" | PropertyLocation.script
+        "signingIdentities"                 | toSetter("signingIdentity") | "code sign: ID3"                        | [rawValue]                                  | "String"                 | PropertyLocation.script
+        "signingIdentities"                 | toSetter("signingIdentity") | "code sign: ID4"                        | [rawValue]                                  | "Provider<String>"       | PropertyLocation.script
 
-        "codeSigningIdentityFile"           | _                           | _                              | null                                        | "Provider<RegularFile>"  | PropertyLocation.none
-        "codeSigningIdentityFile"           | property                    | "/path/to/p12"                 | _                                           | "File"                   | PropertyLocation.script
-        "codeSigningIdentityFile"           | property                    | "/path/to/p12"                 | _                                           | "Provider<RegularFile>"  | PropertyLocation.script
-        "codeSigningIdentityFile"           | toProviderSet(property)     | "/path/to/p12"                 | _                                           | "File"                   | PropertyLocation.script
-        "codeSigningIdentityFile"           | toProviderSet(property)     | "/path/to/p12"                 | _                                           | "Provider<RegularFile>"  | PropertyLocation.script
-        "codeSigningIdentityFile"           | toSetter(property)          | "/path/to/p12"                 | _                                           | "File"                   | PropertyLocation.script
-        "codeSigningIdentityFile"           | toSetter(property)          | "/path/to/p12"                 | _                                           | "Provider<RegularFile>"  | PropertyLocation.script
+        "codeSigningIdentityFile"           | _                           | _                                       | null                                        | "Provider<RegularFile>"  | PropertyLocation.none
+        "codeSigningIdentityFile"           | property                    | "/path/to/p12"                          | _                                           | "File"                   | PropertyLocation.script
+        "codeSigningIdentityFile"           | property                    | "/path/to/p12"                          | _                                           | "Provider<RegularFile>"  | PropertyLocation.script
+        "codeSigningIdentityFile"           | toProviderSet(property)     | "/path/to/p12"                          | _                                           | "File"                   | PropertyLocation.script
+        "codeSigningIdentityFile"           | toProviderSet(property)     | "/path/to/p12"                          | _                                           | "Provider<RegularFile>"  | PropertyLocation.script
+        "codeSigningIdentityFile"           | toSetter(property)          | "/path/to/p12"                          | _                                           | "File"                   | PropertyLocation.script
+        "codeSigningIdentityFile"           | toSetter(property)          | "/path/to/p12"                          | _                                           | "Provider<RegularFile>"  | PropertyLocation.script
 
-        "codeSigningIdentityFilePassphrase" | _                           | _                              | null                                        | "Provider<String>"       | PropertyLocation.none
-        "codeSigningIdentityFilePassphrase" | property                    | "testPassphrase1"              | _                                           | "String"                 | PropertyLocation.script
-        "codeSigningIdentityFilePassphrase" | property                    | "testPassphrase2"              | _                                           | "Provider<String>"       | PropertyLocation.script
-        "codeSigningIdentityFilePassphrase" | toProviderSet(property)     | "testPassphrase3"              | _                                           | "String"                 | PropertyLocation.script
-        "codeSigningIdentityFilePassphrase" | toProviderSet(property)     | "testPassphrase4"              | _                                           | "Provider<String>"       | PropertyLocation.script
-        "codeSigningIdentityFilePassphrase" | toSetter(property)          | "testPassphrase5"              | _                                           | "String"                 | PropertyLocation.script
-        "codeSigningIdentityFilePassphrase" | toSetter(property)          | "testPassphrase6"              | _                                           | "Provider<String>"       | PropertyLocation.script
+        "codeSigningIdentityFilePassphrase" | _                           | _                                       | null                                        | "Provider<String>"       | PropertyLocation.none
+        "codeSigningIdentityFilePassphrase" | property                    | "testPassphrase1"                       | _                                           | "String"                 | PropertyLocation.script
+        "codeSigningIdentityFilePassphrase" | property                    | "testPassphrase2"                       | _                                           | "Provider<String>"       | PropertyLocation.script
+        "codeSigningIdentityFilePassphrase" | toProviderSet(property)     | "testPassphrase3"                       | _                                           | "String"                 | PropertyLocation.script
+        "codeSigningIdentityFilePassphrase" | toProviderSet(property)     | "testPassphrase4"                       | _                                           | "Provider<String>"       | PropertyLocation.script
+        "codeSigningIdentityFilePassphrase" | toSetter(property)          | "testPassphrase5"                       | _                                           | "String"                 | PropertyLocation.script
+        "codeSigningIdentityFilePassphrase" | toSetter(property)          | "testPassphrase6"                       | _                                           | "Provider<String>"       | PropertyLocation.script
 
-        "appIdentifier"                     | property                    | "com.test.app.1"               | _                                           | "String"                 | PropertyLocation.script
-        "appIdentifier"                     | property                    | "com.test.app.2"               | _                                           | "Provider<String>"       | PropertyLocation.script
-        "appIdentifier"                     | toProviderSet(property)     | "com.test.app.3"               | _                                           | "String"                 | PropertyLocation.script
-        "appIdentifier"                     | toProviderSet(property)     | "com.test.app.4"               | _                                           | "Provider<String>"       | PropertyLocation.script
-        "appIdentifier"                     | toSetter(property)          | "com.test.app.5"               | _                                           | "String"                 | PropertyLocation.script
-        "appIdentifier"                     | toSetter(property)          | "com.test.app.6"               | _                                           | "Provider<String>"       | PropertyLocation.script
+        "appIdentifier"                     | property                    | "com.test.app.1"                        | _                                           | "String"                 | PropertyLocation.script
+        "appIdentifier"                     | property                    | "com.test.app.2"                        | _                                           | "Provider<String>"       | PropertyLocation.script
+        "appIdentifier"                     | toProviderSet(property)     | "com.test.app.3"                        | _                                           | "String"                 | PropertyLocation.script
+        "appIdentifier"                     | toProviderSet(property)     | "com.test.app.4"                        | _                                           | "Provider<String>"       | PropertyLocation.script
+        "appIdentifier"                     | toSetter(property)          | "com.test.app.5"                        | _                                           | "String"                 | PropertyLocation.script
+        "appIdentifier"                     | toSetter(property)          | "com.test.app.6"                        | _                                           | "Provider<String>"       | PropertyLocation.script
 
-        "teamId"                            | property                    | "team1"                        | _                                           | "String"                 | PropertyLocation.script
-        "teamId"                            | property                    | "team2"                        | _                                           | "Provider<String>"       | PropertyLocation.script
-        "teamId"                            | toProviderSet(property)     | "team3"                        | _                                           | "String"                 | PropertyLocation.script
-        "teamId"                            | toProviderSet(property)     | "team4"                        | _                                           | "Provider<String>"       | PropertyLocation.script
-        "teamId"                            | toSetter(property)          | "team5"                        | _                                           | "String"                 | PropertyLocation.script
-        "teamId"                            | toSetter(property)          | "team6"                        | _                                           | "Provider<String>"       | PropertyLocation.script
+        "teamId"                            | property                    | "team1"                                 | _                                           | "String"                 | PropertyLocation.script
+        "teamId"                            | property                    | "team2"                                 | _                                           | "Provider<String>"       | PropertyLocation.script
+        "teamId"                            | toProviderSet(property)     | "team3"                                 | _                                           | "String"                 | PropertyLocation.script
+        "teamId"                            | toProviderSet(property)     | "team4"                                 | _                                           | "Provider<String>"       | PropertyLocation.script
+        "teamId"                            | toSetter(property)          | "team5"                                 | _                                           | "String"                 | PropertyLocation.script
+        "teamId"                            | toSetter(property)          | "team6"                                 | _                                           | "Provider<String>"       | PropertyLocation.script
 
-        "scheme"                            | property                    | "value1"                       | _                                           | "String"                 | PropertyLocation.script
-        "scheme"                            | property                    | "value2"                       | _                                           | "Provider<String>"       | PropertyLocation.script
-        "scheme"                            | toProviderSet(property)     | "value3"                       | _                                           | "String"                 | PropertyLocation.script
-        "scheme"                            | toProviderSet(property)     | "value4"                       | _                                           | "Provider<String>"       | PropertyLocation.script
-        "scheme"                            | toSetter(property)          | "value5"                       | _                                           | "String"                 | PropertyLocation.script
-        "scheme"                            | toSetter(property)          | "value6"                       | _                                           | "Provider<String>"       | PropertyLocation.script
+        "scheme"                            | property                    | "value1"                                | _                                           | "String"                 | PropertyLocation.script
+        "scheme"                            | property                    | "value2"                                | _                                           | "Provider<String>"       | PropertyLocation.script
+        "scheme"                            | toProviderSet(property)     | "value3"                                | _                                           | "String"                 | PropertyLocation.script
+        "scheme"                            | toProviderSet(property)     | "value4"                                | _                                           | "Provider<String>"       | PropertyLocation.script
+        "scheme"                            | toSetter(property)          | "value5"                                | _                                           | "String"                 | PropertyLocation.script
+        "scheme"                            | toSetter(property)          | "value6"                                | _                                           | "Provider<String>"       | PropertyLocation.script
 
-        "configuration"                     | property                    | "value1"                       | _                                           | "String"                 | PropertyLocation.script
-        "configuration"                     | property                    | "value2"                       | _                                           | "Provider<String>"       | PropertyLocation.script
-        "configuration"                     | toProviderSet(property)     | "value3"                       | _                                           | "String"                 | PropertyLocation.script
-        "configuration"                     | toProviderSet(property)     | "value4"                       | _                                           | "Provider<String>"       | PropertyLocation.script
-        "configuration"                     | toSetter(property)          | "value5"                       | _                                           | "String"                 | PropertyLocation.script
-        "configuration"                     | toSetter(property)          | "value6"                       | _                                           | "Provider<String>"       | PropertyLocation.script
+        "configuration"                     | property                    | "value1"                                | _                                           | "String"                 | PropertyLocation.script
+        "configuration"                     | property                    | "value2"                                | _                                           | "Provider<String>"       | PropertyLocation.script
+        "configuration"                     | toProviderSet(property)     | "value3"                                | _                                           | "String"                 | PropertyLocation.script
+        "configuration"                     | toProviderSet(property)     | "value4"                                | _                                           | "Provider<String>"       | PropertyLocation.script
+        "configuration"                     | toSetter(property)          | "value5"                                | _                                           | "String"                 | PropertyLocation.script
+        "configuration"                     | toSetter(property)          | "value6"                                | _                                           | "Provider<String>"       | PropertyLocation.script
 
-        "provisioningName"                  | property                    | "value1"                       | _                                           | "String"                 | PropertyLocation.script
-        "provisioningName"                  | property                    | "value2"                       | _                                           | "Provider<String>"       | PropertyLocation.script
-        "provisioningName"                  | toProviderSet(property)     | "value3"                       | _                                           | "String"                 | PropertyLocation.script
-        "provisioningName"                  | toProviderSet(property)     | "value4"                       | _                                           | "Provider<String>"       | PropertyLocation.script
-        "provisioningName"                  | toSetter(property)          | "value5"                       | _                                           | "String"                 | PropertyLocation.script
-        "provisioningName"                  | toSetter(property)          | "value6"                       | _                                           | "Provider<String>"       | PropertyLocation.script
+        "provisioningName"                  | property                    | "value1"                                | _                                           | "String"                 | PropertyLocation.script
+        "provisioningName"                  | property                    | "value2"                                | _                                           | "Provider<String>"       | PropertyLocation.script
+        "provisioningName"                  | toProviderSet(property)     | "value3"                                | _                                           | "String"                 | PropertyLocation.script
+        "provisioningName"                  | toProviderSet(property)     | "value4"                                | _                                           | "Provider<String>"       | PropertyLocation.script
+        "provisioningName"                  | toSetter(property)          | "value5"                                | _                                           | "String"                 | PropertyLocation.script
+        "provisioningName"                  | toSetter(property)          | "value6"                                | _                                           | "Provider<String>"       | PropertyLocation.script
 
-        "adhoc"                             | property                    | true                           | _                                           | "Boolean"                | PropertyLocation.script
-        "adhoc"                             | property                    | true                           | _                                           | "Provider<Boolean>"      | PropertyLocation.script
-        "adhoc"                             | toProviderSet(property)     | true                           | _                                           | "Boolean"                | PropertyLocation.script
-        "adhoc"                             | toProviderSet(property)     | true                           | _                                           | "Provider<Boolean>"      | PropertyLocation.script
-        "adhoc"                             | toSetter(property)          | true                           | _                                           | "Boolean"                | PropertyLocation.script
-        "adhoc"                             | toSetter(property)          | true                           | _                                           | "Provider<Boolean>"      | PropertyLocation.script
+        "adhoc"                             | property                    | true                                    | _                                           | "Boolean"                | PropertyLocation.script
+        "adhoc"                             | property                    | true                                    | _                                           | "Provider<Boolean>"      | PropertyLocation.script
+        "adhoc"                             | toProviderSet(property)     | true                                    | _                                           | "Boolean"                | PropertyLocation.script
+        "adhoc"                             | toProviderSet(property)     | true                                    | _                                           | "Provider<Boolean>"      | PropertyLocation.script
+        "adhoc"                             | toSetter(property)          | true                                    | _                                           | "Boolean"                | PropertyLocation.script
+        "adhoc"                             | toSetter(property)          | true                                    | _                                           | "Provider<Boolean>"      | PropertyLocation.script
 
-        "publishToTestFlight"               | property                    | true                           | _                                           | "Boolean"                | PropertyLocation.script
-        "publishToTestFlight"               | property                    | true                           | _                                           | "Provider<Boolean>"      | PropertyLocation.script
-        "publishToTestFlight"               | toProviderSet(property)     | true                           | _                                           | "Boolean"                | PropertyLocation.script
-        "publishToTestFlight"               | toProviderSet(property)     | true                           | _                                           | "Provider<Boolean>"      | PropertyLocation.script
-        "publishToTestFlight"               | toSetter(property)          | true                           | _                                           | "Boolean"                | PropertyLocation.script
-        "publishToTestFlight"               | toSetter(property)          | true                           | _                                           | "Provider<Boolean>"      | PropertyLocation.script
+        "publishToTestFlight"               | property                    | true                                    | _                                           | "Boolean"                | PropertyLocation.script
+        "publishToTestFlight"               | property                    | true                                    | _                                           | "Provider<Boolean>"      | PropertyLocation.script
+        "publishToTestFlight"               | toProviderSet(property)     | true                                    | _                                           | "Boolean"                | PropertyLocation.script
+        "publishToTestFlight"               | toProviderSet(property)     | true                                    | _                                           | "Provider<Boolean>"      | PropertyLocation.script
+        "publishToTestFlight"               | toSetter(property)          | true                                    | _                                           | "Boolean"                | PropertyLocation.script
+        "publishToTestFlight"               | toSetter(property)          | true                                    | _                                           | "Provider<Boolean>"      | PropertyLocation.script
 
-        "exportOptionsPlist"                | _                           | "exportOptions.plist"          | "#projectDir#/${rawValue}".toString()       | "File"                   | PropertyLocation.script
-        "exportOptionsPlist"                | toProviderSet(property)     | "path/to/exportOptions1.plist" | "#projectDir#/${rawValue}".toString()       | "File"                   | PropertyLocation.script
-        "exportOptionsPlist"                | toProviderSet(property)     | "path/to/exportOptions1.plist" | "#projectDir#/build/${rawValue}".toString() | "Provider<RegularFile>"  | PropertyLocation.script
-        "exportOptionsPlist"                | toSetter(property)          | "path/to/exportOptions1.plist" | "#projectDir#/${rawValue}".toString()       | "File"                   | PropertyLocation.script
-        "exportOptionsPlist"                | toSetter(property)          | "path/to/exportOptions1.plist" | "#projectDir#/build/${rawValue}".toString() | "Provider<RegularFile>"  | PropertyLocation.script
+        "exportOptionsPlist"                | _                           | "exportOptions.plist"                   | "#projectDir#/${rawValue}".toString()       | "File"                   | PropertyLocation.script
+        "exportOptionsPlist"                | toProviderSet(property)     | "path/to/exportOptions1.plist"          | "#projectDir#/${rawValue}".toString()       | "File"                   | PropertyLocation.script
+        "exportOptionsPlist"                | toProviderSet(property)     | "path/to/exportOptions1.plist"          | "#projectDir#/build/${rawValue}".toString() | "Provider<RegularFile>"  | PropertyLocation.script
+        "exportOptionsPlist"                | toSetter(property)          | "path/to/exportOptions1.plist"          | "#projectDir#/${rawValue}".toString()       | "File"                   | PropertyLocation.script
+        "exportOptionsPlist"                | toSetter(property)          | "path/to/exportOptions1.plist"          | "#projectDir#/build/${rawValue}".toString() | "Provider<RegularFile>"  | PropertyLocation.script
+
+        "projectBaseName"                   | property                    | "Unity-iPhone"                          | _                                           | "String"                 | PropertyLocation.none
+        "projectBaseName"                   | property                    | "value1"                                | _                                           | "String"                 | PropertyLocation.script
+        "projectBaseName"                   | property                    | "value2"                                | _                                           | "Provider<String>"       | PropertyLocation.script
+        "projectBaseName"                   | toProviderSet(property)     | "value3"                                | _                                           | "String"                 | PropertyLocation.script
+        "projectBaseName"                   | toProviderSet(property)     | "value4"                                | _                                           | "Provider<String>"       | PropertyLocation.script
+        "projectBaseName"                   | toSetter(property)          | "value5"                                | _                                           | "String"                 | PropertyLocation.script
+        "projectBaseName"                   | toSetter(property)          | "value6"                                | _                                           | "Provider<String>"       | PropertyLocation.script
+
+        "preferWorkspace"                   | property                    | true                                    | _                                           | "Boolean"                | PropertyLocation.none
+        "preferWorkspace"                   | property                    | false                                   | _                                           | "Boolean"                | PropertyLocation.script
+        "preferWorkspace"                   | property                    | true                                    | _                                           | "Provider<Boolean>"      | PropertyLocation.script
+        "preferWorkspace"                   | toProviderSet(property)     | false                                   | _                                           | "Boolean"                | PropertyLocation.script
+        "preferWorkspace"                   | toProviderSet(property)     | true                                    | _                                           | "Provider<Boolean>"      | PropertyLocation.script
+        "preferWorkspace"                   | toSetter(property)          | false                                   | _                                           | "Boolean"                | PropertyLocation.script
+        "preferWorkspace"                   | toSetter(property)          | true                                    | _                                           | "Provider<Boolean>"      | PropertyLocation.script
+
+        "xcodeProjectDirectory"             | _                           | "#projectDir#"                          | _                                           | "File"                   | PropertyLocation.none
+        "xcodeProjectDirectory"             | _                           | "path/to/project"                       | "#projectDir#/${rawValue}".toString()       | "File"                   | PropertyLocation.script
+        "xcodeProjectDirectory"             | toProviderSet(property)     | "path/to/project2"                      | "#projectDir#/${rawValue}".toString()       | "File"                   | PropertyLocation.script
+        "xcodeProjectDirectory"             | toProviderSet(property)     | "path/to/project3"                      | "#projectDir#/build/${rawValue}".toString() | "Provider<Directory>"    | PropertyLocation.script
+        "xcodeProjectDirectory"             | toSetter(property)          | "path/to/project4"                      | "#projectDir#/${rawValue}".toString()       | "File"                   | PropertyLocation.script
+        "xcodeProjectDirectory"             | toSetter(property)          | "path/to/project5"                      | "#projectDir#/build/${rawValue}".toString() | "Provider<Directory>"    | PropertyLocation.script
+
+        "xcodeProjectPath"                  | _                           | "#projectDir#/Unity-iPhone.xcodeproj"   | _                                           | "File"                   | PropertyLocation.none
+        "xcodeProjectPath"                  | _                           | "path/to/Unity-iPhone1.xcodeproj"       | "#projectDir#/${rawValue}".toString()       | "File"                   | PropertyLocation.script
+        "xcodeProjectPath"                  | toProviderSet(property)     | "path/to/Unity-iPhone2.xcodeproj"       | "#projectDir#/${rawValue}".toString()       | "File"                   | PropertyLocation.script
+        "xcodeProjectPath"                  | toProviderSet(property)     | "path/to/Unity-iPhone3.xcodeproj"       | "#projectDir#/build/${rawValue}".toString() | "Provider<Directory>"    | PropertyLocation.script
+        "xcodeProjectPath"                  | toSetter(property)          | "path/to/Unity-iPhone4.xcodeproj"       | "#projectDir#/${rawValue}".toString()       | "File"                   | PropertyLocation.script
+        "xcodeProjectPath"                  | toSetter(property)          | "path/to/Unity-iPhone5.xcodeproj"       | "#projectDir#/build/${rawValue}".toString() | "Provider<Directory>"    | PropertyLocation.script
+
+        "xcodeWorkspacePath"                | _                           | "#projectDir#/Unity-iPhone.xcworkspace" | _                                           | "File"                   | PropertyLocation.none
+        "xcodeWorkspacePath"                | _                           | "path/to/Unity-iPhone1.xcworkspace"     | "#projectDir#/${rawValue}".toString()       | "File"                   | PropertyLocation.script
+        "xcodeWorkspacePath"                | toProviderSet(property)     | "path/to/Unity-iPhone2.xcworkspace"     | "#projectDir#/${rawValue}".toString()       | "File"                   | PropertyLocation.script
+        "xcodeWorkspacePath"                | toProviderSet(property)     | "path/to/Unity-iPhone3.xcworkspace"     | "#projectDir#/build/${rawValue}".toString() | "Provider<Directory>"    | PropertyLocation.script
+        "xcodeWorkspacePath"                | toSetter(property)          | "path/to/Unity-iPhone4.xcworkspace"     | "#projectDir#/${rawValue}".toString()       | "File"                   | PropertyLocation.script
+        "xcodeWorkspacePath"                | toSetter(property)          | "path/to/Unity-iPhone5.xcworkspace"     | "#projectDir#/build/${rawValue}".toString() | "Provider<Directory>"    | PropertyLocation.script
+
+        "projectPath"                       | _                           | "#projectDir#/Unity-iPhone.xcodeproj"   | _                                           | "File"                   | PropertyLocation.none
+        "xcodeProjectFileName"              | _                           | "Unity-iPhone.xcodeproj"                | _                                           | "String"                 | PropertyLocation.none
+        "xcodeWorkspaceFileName"            | _                           | "Unity-iPhone.xcworkspace"              | _                                           | "String"                 | PropertyLocation.none
+        "preferredProjectFileName"          | _                           | "Unity-iPhone.xcworkspace"              | _                                           | "String"                 | PropertyLocation.none
 
         value = (type != _) ? wrapValueBasedOnType(rawValue, type.toString(), wrapValueFallback) : rawValue
         providedValue = (location == PropertyLocation.script) ? type : value

--- a/src/integrationTest/groovy/wooga/gradle/build/unity/ios/tasks/PodInstallTaskSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/unity/ios/tasks/PodInstallTaskSpec.groovy
@@ -1,6 +1,11 @@
 package wooga.gradle.build.unity.ios.tasks
 
+import com.wooga.gradle.test.PropertyQueryTaskWriter
 import spock.lang.Requires
+import spock.lang.Unroll
+
+import static com.wooga.gradle.test.PropertyUtils.toProviderSet
+import static com.wooga.gradle.test.PropertyUtils.toSetter
 
 /**
  * The test examples in this class are not 100% integration/functional tests.
@@ -9,16 +14,18 @@ import spock.lang.Requires
  * We only test the invocation of pod and its parameters.
  */
 @Requires({ os.macOs })
-class PodInstallTaskSpec extends CocoaPodSpec {
+class PodInstallTaskSpec extends CocoaPodSpec<PodInstallTask> {
     def setup() {
-        def xcodeProject = new File("test.xcodeproj")
+        projectBaseName = "test"
+        xcodeProject = new File(projectDir, "${projectBaseName}.xcodeproj")
         xcodeProject.mkdirs()
+        xcodeWorkspace = new File(projectDir, "${projectBaseName}.xcworkspace")
 
-        buildFile << """
-            task podInstall(type: wooga.gradle.build.unity.ios.tasks.PodInstallTask) {
-                projectPath = "${xcodeProject.path}"
-            }
-        """.stripIndent()
+        appendToSubjectTask("""
+        projectDirectory.set(file("${xcodeProject.parentFile}"))
+        xcodeProjectFileName = "test.xcodeproj"
+        xcodeWorkspaceFileName = "test.xcworkspace"
+        """.stripIndent())
     }
 
     def "task skips when no Pod file exist in project"() {
@@ -26,20 +33,17 @@ class PodInstallTaskSpec extends CocoaPodSpec {
         def podFile = createFile("Podfile")
 
         when:
-        def result = runTasksSuccessfully(taskName)
+        def result = runTasksSuccessfully(subjectUnderTestName)
 
         then:
-        result.wasExecuted(taskName)
+        result.wasExecuted(subjectUnderTestName)
 
         when:
         podFile.delete()
-        result = runTasksSuccessfully(taskName)
+        result = runTasksSuccessfully(subjectUnderTestName)
 
         then:
-        outputContains(result, "Task :${taskName} NO-SOURCE")
-
-        where:
-        taskName = "podInstall"
+        outputContains(result, "Task :${subjectUnderTestName} NO-SOURCE")
     }
 
     def "task executes 'repo update' before 'install'"() {
@@ -79,7 +83,7 @@ class PodInstallTaskSpec extends CocoaPodSpec {
 
         then:
         !result.wasUpToDate(taskName)
-        outputContains(result,"Input property 'inputFiles' file ${podFile.path} has changed.")
+        outputContains(result, "Input property 'inputFiles' file ${podFile.path} has changed.")
 
         when:
         lockFile << "a change"
@@ -87,9 +91,44 @@ class PodInstallTaskSpec extends CocoaPodSpec {
 
         then:
         !result.wasUpToDate(taskName)
-        outputContains(result,"Input property 'inputFiles' file ${lockFile.path} has changed.")
+        outputContains(result, "Input property 'inputFiles' file ${lockFile.path} has changed.")
 
         where:
-        taskName = "podInstall"
+        taskName = subjectUnderTestName
+    }
+
+    @Unroll("can set property #property with #method and type #type")
+    def "can set property"() {
+        given: "a task to read back the value"
+        def query = new PropertyQueryTaskWriter("${subjectUnderTestName}.${property}")
+        query.write(buildFile)
+
+        and: "a set property"
+        appendToSubjectTask("${method}($value)")
+
+        when:
+        def result = runTasksSuccessfully(query.taskName)
+
+        then:
+        query.matches(result, expectedValue)
+
+        where:
+        property                 | method                  | rawValue           | returnValue | type
+        "projectDirectory"       | toProviderSet(property) | "/path/to/project" | _           | "File"
+        "projectDirectory"       | toProviderSet(property) | "/path/to/project" | _           | "Provider<Directory>"
+        "projectDirectory"       | toSetter(property)      | "/path/to/project" | _           | "File"
+        "projectDirectory"       | toSetter(property)      | "/path/to/project" | _           | "Provider<Directory>"
+
+        "xcodeProjectFileName"   | toProviderSet(property) | "test.xcodeproj"   | _           | "String"
+        "xcodeProjectFileName"   | toProviderSet(property) | "test.xcodeproj"   | _           | "Provider<String>"
+        "xcodeProjectFileName"   | toSetter(property)      | "test.xcodeproj"   | _           | "String"
+        "xcodeProjectFileName"   | toSetter(property)      | "test.xcodeproj"   | _           | "Provider<String>"
+
+        "xcodeWorkspaceFileName" | toProviderSet(property) | "test.xcworkspace" | _           | "String"
+        "xcodeWorkspaceFileName" | toProviderSet(property) | "test.xcworkspace" | _           | "Provider<String>"
+        "xcodeWorkspaceFileName" | toSetter(property)      | "test.xcworkspace" | _           | "String"
+        "xcodeWorkspaceFileName" | toSetter(property)      | "test.xcworkspace" | _           | "Provider<String>"
+        value = wrapValueBasedOnType(rawValue, type, wrapValueFallback)
+        expectedValue = returnValue == _ ? rawValue : returnValue
     }
 }

--- a/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginExtension.groovy
@@ -3,6 +3,8 @@ package wooga.gradle.build.unity.ios
 import com.wooga.gradle.BaseSpec
 import org.gradle.api.Action
 import org.gradle.api.credentials.PasswordCredentials
+import org.gradle.api.file.Directory
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFile
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
@@ -213,4 +215,87 @@ trait IOSBuildPluginExtension extends BaseSpec {
         exportOptionsPlist.set(value)
     }
 
+    private final DirectoryProperty xcodeProjectPath = objects.directoryProperty()
+
+    DirectoryProperty getXcodeProjectPath() {
+        xcodeProjectPath
+    }
+
+    void setXcodeProjectPath(Provider<Directory> value) {
+        xcodeProjectPath.set(value)
+    }
+
+    void setXcodeProjectPath(File value) {
+        xcodeProjectPath.set(value)
+    }
+
+    private final DirectoryProperty xcodeWorkspacePath = objects.directoryProperty()
+
+    DirectoryProperty getXcodeWorkspacePath() {
+        xcodeWorkspacePath
+    }
+
+    void setXcodeWorkspacePath(Provider<Directory> value) {
+        xcodeWorkspacePath.set(value)
+    }
+
+    void setXcodeWorkspacePath(File value) {
+        xcodeWorkspacePath.set(value)
+    }
+
+    private final DirectoryProperty xcodeProjectDirectory = objects.directoryProperty()
+
+    DirectoryProperty getXcodeProjectDirectory() {
+        xcodeProjectDirectory
+    }
+
+    void setXcodeProjectDirectory(Provider<Directory> value) {
+        xcodeProjectDirectory.set(value)
+    }
+
+    void setXcodeProjectDirectory(File value) {
+        xcodeProjectDirectory.set(value)
+    }
+
+    private final Property<Boolean> preferWorkspace = objects.property(Boolean)
+
+    Property<Boolean> getPreferWorkspace() {
+        preferWorkspace
+    }
+
+    void setPreferWorkspace(Provider<Boolean> value) {
+        preferWorkspace.set(value)
+    }
+
+    void setPreferWorkspace(Boolean value) {
+        preferWorkspace.set(value)
+    }
+
+    private final Property<String> projectBaseName = objects.property(String)
+
+    Property<String> getProjectBaseName() {
+        projectBaseName
+    }
+
+    void setProjectBaseName(Provider<String> value) {
+        projectBaseName.set(value)
+    }
+
+    void setProjectBaseName(String value) {
+        projectBaseName.set(value)
+    }
+
+    Provider<String> xcodeProjectFileName = projectBaseName.map({ it + ".xcodeproj" })
+    Provider<String> xcodeWorkspaceFileName = projectBaseName.map({ it + ".xcworkspace" })
+    Provider<String> preferredProjectFileName = preferWorkspace.flatMap({
+        it ? xcodeWorkspaceFileName : xcodeProjectFileName
+    })
+
+    Provider<Directory> projectPath = xcodeProjectDirectory.flatMap({
+        def firstCheck = it.dir(preferredProjectFileName)
+        if (firstCheck.forUseAtConfigurationTime().get().asFile.exists()) {
+            return firstCheck
+        }
+        it.dir(xcodeProjectFileName)
+    })
 }

--- a/src/test/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginSpec.groovy
@@ -110,46 +110,6 @@ class IOSBuildPluginSpec extends ProjectSpec {
     }
 
     @Unroll()
-    def 'Creates xcode tasks #taskNames when project contains multiple xcode projects'() {
-        given: "a dummpy xcode project"
-        xcodeProjectNames.each {
-            xcProject = new File(projectDir, "${it}.xcodeproj")
-            xcProject.mkdirs()
-            xcProjectConfig = new File(xcProject, "project.pbxproj")
-            xcProjectConfig << ""
-        }
-
-        when:
-        project.plugins.apply(PLUGIN_NAME)
-        List<Task> tasks
-        project.afterEvaluate {
-            tasks = taskNames.collect { project.tasks.findByName(it) }
-        }
-
-        then:
-        project.evaluate()
-        tasks.every { taskType.isInstance(it) }
-
-        where:
-        taskName                     | taskType
-        "createKeychain"              | SecurityCreateKeychain
-        "importCodeSigningIdentities" | ImportCodeSigningIdentities
-        "unlockKeychain"             | SecurityUnlockKeychain
-        "lockKeychain"               | SecurityLockKeychain
-        "resetKeychains"             | SecurityResetKeychainSearchList
-        "addKeychain"                | SecuritySetKeychainSearchList
-        "removeKeychain"             | SecuritySetKeychainSearchList
-        "importProvisioningProfiles" | SighRenew
-        "xcodeArchive"               | XcodeArchive
-        "xcodeArchiveExport"         | ExportArchive
-        "xcodeArchiveDSYMs"          | ArchiveDebugSymbols
-        "publishTestFlight"          | PilotUpload
-
-        xcodeProjectNames = ["first", "second", "third"]
-        taskNames = ["first", "second", "third"].collect { it + taskName.capitalize() }
-    }
-
-    @Unroll()
     def "task #taskName #message on task #dependedTask when publishToTestflight is #publishToTestflight"() {
         given: "a dummpy xcode project"
         xcProject = new File(projectDir, "test.xcodeproj")


### PR DESCRIPTION
## Description

This patch changes drastically how the xcode related tasks are created, named and managed. The old implementation scanned the whole project directory tree for `.xcodeproj` directories. The idea was to be able to manage multiple projects with one plugin. I changed how this works to simplify the setup. In our opinioted view only a single xcode project is located in the project directory. We set a default value to `Unity-iPhone` as the base name forthis project. This and the xcode project directory property can be set in the extension. We now only setup tasks for this one project. This makes the base setup way simpler.

I'm still not happy how to handle xcodeproj and xcworkspace directories. I deciced to go the `xcodeProjectPath` + `xcodeProjectBaseName` + `extension` route. The downside is that one cannot simply set the path to an xcode project. In the old API without providers this would have been possible. But the convention mapping only really works from bottom to the top.

This should not be so dramatic at the moment.

Changes
=======

* ![IMPROVE] `net.wooga.build-unity-ios` xcode task setup
* ![IMPROVE] PodInstall task properties and test setup


[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
