### PR TITLE
Add export lifecycle task and skipExport logic

### DIFF
--- a/src/main/groovy/wooga/gradle/build/unity/UnityBuildPluginConventions.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/UnityBuildPluginConventions.groovy
@@ -69,6 +69,11 @@ class UnityBuildPluginConventions {
     static PropertyLookup CLEAN_BUILD_DIR_BEFORE_BUILD = new PropertyLookup("UNITY_BUILD_CLEAN_BUILD_DIR_BEFORE_BUILD", "unityBuild.cleanBuildDirBeforeBuild", false)
 
     /**
+     * Wheater to skip the default export task action
+     */
+    static PropertyLookup SKIP_EXPORT = new PropertyLookup("UNITY_BUILD_SKIP_EXPORT", "unityBuild.skipExport", false)
+
+    /**
      * The key used for looking up secrets in the AppConfig during a build
      */
     static PropertyLookup APP_CONFIG_SECRETS_KEY = new PropertyLookup("UNITY_BUILD_APP_CONFIG_SECRETS_KEY", "unityBuild.appConfigSecretsKey", "secretIds")

--- a/src/main/groovy/wooga/gradle/build/unity/UnityBuildPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/UnityBuildPluginExtension.groovy
@@ -39,8 +39,10 @@ interface UnityBuildPluginExtension<T extends UnityBuildPluginExtension> {
     RegularFileProperty getExportInitScript()
     Property<File> getExportBuildDirBase()
     Property<Boolean> getCleanBuildDirBeforeBuild()
+    Property<Boolean> getSkipExport()
     FileCollection getAppConfigs()
     DirectoryProperty getAssetsDir()
+
 
     ConfigurableFileCollection getIgnoreFilesForExportUpToDateCheck()
 

--- a/src/main/groovy/wooga/gradle/build/unity/internal/DefaultUnityBuildPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/internal/DefaultUnityBuildPluginExtension.groovy
@@ -51,6 +51,7 @@ class DefaultUnityBuildPluginExtension implements UnityBuildPluginExtension {
     final RegularFileProperty exportInitScript
     final Property<File> exportBuildDirBase
     final Property<Boolean> cleanBuildDirBeforeBuild
+    final Property<Boolean> skipExport
 
     private final Property<String> appConfigSecretsKey
     Property<String> getAppConfigSecretsKey() {
@@ -85,6 +86,7 @@ class DefaultUnityBuildPluginExtension implements UnityBuildPluginExtension {
         exportInitScript = project.objects.fileProperty()
         exportBuildDirBase = project.objects.property(File)
         cleanBuildDirBeforeBuild = project.objects.property(Boolean)
+        skipExport = project.objects.property(Boolean)
         appConfigSecretsKey = project.objects.property(String)
     }
 


### PR DESCRIPTION
## Description

The `net.wooga.build-unity` plugin defined dependencies to the basic lifecycle tasks `assemble, build, check, publish) when the `defaultAppConfigName` property was provided. The only missing key is the `export` method.

This patch adds the missing link and allows to call `export` on a project with `defaultAppConfigName` set to easily run and execute the correct `export` variant.

I also added a way of skipping the export action. This might become usefull/needed for teams who need to enforce that the export will be skipped. At the moment this has to be done since most Unity projects still alter the source files when building.

## Changes

* ![ADD] lifecycle task `export`
* ![ADD] `skipExport` logic for export task actions

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"