### PR TITLE
Improve exportOptions.plist handling [ATLAS-599]

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/build/unity/ios/IOSBuildIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/unity/ios/IOSBuildIntegrationSpec.groovy
@@ -1,6 +1,7 @@
 package wooga.gradle.build.unity.ios
 
 import com.wooga.gradle.test.IntegrationSpec
+import wooga.gradle.xcodebuild.config.ExportOptions
 
 abstract class IOSBuildIntegrationSpec extends IntegrationSpec {
 
@@ -18,6 +19,14 @@ abstract class IOSBuildIntegrationSpec extends IntegrationSpec {
 
     static wrapValueFallback = { Object rawValue, String type, Closure<String> fallback ->
         switch (type) {
+            case "ExportOptions.DistributionManifest":
+                def rawOptions = (ExportOptions.DistributionManifest) rawValue
+                def appUrl = wrapValueBasedOnType(rawOptions.appURL, String)
+                def displayImageURL = wrapValueBasedOnType(rawOptions.displayImageURL, String)
+                def fullSizeImageURL = wrapValueBasedOnType(rawOptions.fullSizeImageURL, String)
+                def assetPackManifestURL = wrapValueBasedOnType(rawOptions.assetPackManifestURL, String)
+
+                return "${ExportOptions.DistributionManifest.name}.distributionManifest(${appUrl}, ${displayImageURL}, ${fullSizeImageURL}, ${assetPackManifestURL})"
             default:
                 return rawValue.toString()
         }

--- a/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPlugin.groovy
@@ -61,6 +61,11 @@ class IOSBuildPlugin implements Plugin<Project> {
         def fastlaneExtension = project.getExtensions().getByType(FastlanePluginExtension)
 
         extension.exportOptionsPlist.convention(project.layout.projectDirectory.file("exportOptions.plist"))
+        extension.teamId.convention(extension.exportOptions.map({ it.teamID }))
+        extension.signingIdentities.convention(extension.exportOptions.map({it.signingCertificate ? [it.signingCertificate] : []}).orElse(project.provider({ new ArrayList<String>() })))
+        extension.adhoc.convention(extension.exportOptions.map({ it.method == 'ad-hoc' }).orElse(false))
+        extension.appIdentifier.convention(extension.exportOptions.map({ it.distributionBundleIdentifier }))
+
         extension.preferWorkspace.convention(true)
         extension.xcodeProjectDirectory.convention(project.layout.projectDirectory)
         extension.projectBaseName.convention("Unity-iPhone")
@@ -82,7 +87,7 @@ class IOSBuildPlugin implements Plugin<Project> {
         project.tasks.withType(ExportArchive.class, new Action<ExportArchive>() {
             @Override
             void execute(ExportArchive task) {
-                task.exportOptionsPlist.set(extension.exportOptionsPlist)
+                task.exportOptionsPlist.convention(extension.finalExportOptionsPlist)
             }
         })
 
@@ -128,7 +133,7 @@ class IOSBuildPlugin implements Plugin<Project> {
                 task.destinationDir.convention(project.layout.dir(project.provider({ task.getTemporaryDir() })))
                 task.provisioningName.convention(extension.getProvisioningName())
                 task.adhoc.convention(extension.adhoc)
-                task.fileName.convention('signing.mobileprovision')
+                task.fileName.convention(extension.appIdentifier.map({ "signing${it}.mobileprovision".toString() }).orElse("signing.mobileprovision"))
             }
         })
 

--- a/src/test/groovy/wooga/gradle/xcodebuild/config/ExportOptionsSpec.groovy
+++ b/src/test/groovy/wooga/gradle/xcodebuild/config/ExportOptionsSpec.groovy
@@ -19,6 +19,8 @@ package wooga.gradle.xcodebuild.config
 import spock.lang.Specification
 import spock.lang.Unroll
 
+import static wooga.gradle.xcodebuild.config.ExportOptions.DistributionManifest.distributionManifest
+
 class ExportOptionsSpec extends Specification {
 
     def plistFile = """
@@ -51,6 +53,8 @@ class ExportOptionsSpec extends Specification {
           <key>assetPackManifestURL</key>
           <string>http://some/url</string>
       </dict>
+      <key>manageAppVersionAndBuildNumber</key>
+      <false/>
       <key>method</key>
       <string>development</string>
       <key>onDemandResourcesAssetPacksBaseURL</key>
@@ -128,6 +132,7 @@ class ExportOptionsSpec extends Specification {
         file1.iCloudContainerEnvironment == file2.iCloudContainerEnvironment
         file1.installerSigningCertificate == file2.installerSigningCertificate
         file1.manifest == file2.manifest
+        file1.manageAppVersionAndBuildNumber == file2.manageAppVersionAndBuildNumber
         file1.method == file2.method
         file1.onDemandResourcesAssetPacksBaseURL == file2.onDemandResourcesAssetPacksBaseURL
         file1.provisioningProfiles == file2.provisioningProfiles
@@ -161,12 +166,13 @@ class ExportOptionsSpec extends Specification {
         expect:
         with(options) {
             compileBitcode
-            destination == null
+            destination == 'export'
             distributionBundleIdentifier == null
             embedOnDemandResourcesAssetPacksInBundle
             !generateAppStoreInformation
             iCloudContainerEnvironment == null
             installerSigningCertificate == null
+            manageAppVersionAndBuildNumber
             manifest == null
             method == null
             onDemandResourcesAssetPacksBaseURL == null
@@ -278,7 +284,7 @@ class ExportOptionsSpec extends Specification {
         def emptyOptions = new ExportOptions()
 
         and: "a custom distribution manifest"
-        def distributionManifest = new ExportOptions.DistributionManifest(emptyOptions, appURL, displayImageURL, fullSizeImageURL, assetPackManifestURL)
+        def distributionManifest = new ExportOptions.DistributionManifest(appURL, displayImageURL, fullSizeImageURL, assetPackManifestURL)
 
         when:
         emptyOptions.manifest = distributionManifest
@@ -305,7 +311,7 @@ class ExportOptionsSpec extends Specification {
         def emptyOptions = new ExportOptions()
 
         and: "a custom distribution manifest"
-        def distributionManifest = new ExportOptions.DistributionManifest(emptyOptions, appURL, displayImageURL, fullSizeImageURL, assetPackManifestURL)
+        def distributionManifest = distributionManifest(appURL, displayImageURL, fullSizeImageURL, assetPackManifestURL)
 
         when:
         emptyOptions.manifest = distributionManifest
@@ -329,7 +335,7 @@ class ExportOptionsSpec extends Specification {
         def emptyOptions = new ExportOptions()
 
         and: "a custom distribution manifest"
-        def distributionManifest = new ExportOptions.DistributionManifest(emptyOptions, "test", "test", "test", "test")
+        def distributionManifest = distributionManifest("test", "test", "test", "test")
         emptyOptions.manifest = distributionManifest
 
         when:


### PR DESCRIPTION
## Description

This patch adds a new way to configure the export options plist file needed during the archive command run. A lot of information we need for a complete build is tracked multiple times. This patch tries to make it easier to define these config values only once. On the other hand it gives a new way of configuring the content of the exportOptions.plist file in the build.gradle file.

The first change is the introduction of a new provider in the ios plugin extension:

`Provider<ExportOptions> getExportOptions()`

With this provider one can read and use the values in the `exportOptions.plist` file at runtime without additional parsing.

With this provider created I set some conventions to point to the matching value in this new provider

```groovy
  extension.teamId.convention(extension.exportOptions.map({ it.teamID }))
  extension.signingIdentities.convention(extension.exportOptions.map({it.signingCertificate ? [it.signingCertificate] : []}).orElse(project.provider({ new ArrayList<String>() })))
  extension.adhoc.convention(extension.exportOptions.map({ it.method == 'ad-hoc' }).orElse(false))
  extension.appIdentifier.convention(extension.exportOptions.map({ it.distributionBundleIdentifier }))
```

Means that `teamId`, `adhoc`, `appIdentifier` and the initial value for `signingIdenties` are all provided through the contents of the `exportOption.plist` file. These values can of course be overriden in the extension when needed.

On top of that, one can also issue additional overrides. This works only with configuration actions/closures due to the nature of the lazy evalution of the provider itself.

```groovy
iosBuild {
  exportOptions {
    teamID = "my team ID"
    method = 'ad-hoc'
  }
}
```

In this example the configuration action/closure would be saved and applied right before the value gets evaluated. It will also create a copy of the provided `exportOptions.plist` file and copy it along with the adjusted values to a new location within the `build` directory. For this I added yet another internal provider to the extension:

```groovy
Provider<RegularFile> getFinalExportOptionsPlist() {
  finalExportOptionsPlist.present ? finalExportOptionsPlist : baseExportOptionsPlist
}
```

It will either return the original plist file or a copy with adjusted values when configurations where registered in the `build.gradle` file.

I added some more documentation strings to the `ExportOptions` class and improved the `ExportOptions.DistributionManifest` constructor methods.

Changes
=======

* ![ADD] `exportOptions` provider in plugin extension
* ![IMPROVE] conventions for values declared through `exportOption.plist`
* ![ADD] logic to lazy configure export options and merge values into new config

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
