### PR TITLE
Improve build keychain default settings

### DIFF
--- a/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPlugin.groovy
@@ -17,6 +17,7 @@
 
 package wooga.gradle.build.unity.ios
 
+import com.wooga.security.Domain
 import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -97,6 +98,8 @@ class IOSBuildPlugin implements Plugin<Project> {
                 task.baseName.convention("build")
                 task.extension.convention("keychain")
                 task.password.convention(extension.keychainPassword)
+                task.lockKeychainAfterTimeout.convention(-1)
+                task.lockKeychainWhenSleep.convention(true)
                 task.destinationDir.convention(project.layout.buildDirectory.dir("sign/keychains"))
             }
         })
@@ -197,6 +200,7 @@ class IOSBuildPlugin implements Plugin<Project> {
 
         def addKeychain = tasks.create("addKeychain", SecuritySetKeychainSearchList) {
             it.dependsOn(buildKeychain)
+            it.domain.set(Domain.user)
             it.action = SecuritySetKeychainSearchList.Action.add
             it.keychain(buildKeychain.keychain.map({ it.asFile }))
             dependsOn(resetKeychains)
@@ -204,6 +208,7 @@ class IOSBuildPlugin implements Plugin<Project> {
 
         def removeKeychain = tasks.create("removeKeychain", SecuritySetKeychainSearchList) {
             it.dependsOn(buildKeychain)
+            it.domain.set(Domain.user)
             it.action = SecuritySetKeychainSearchList.Action.remove
             it.keychain(buildKeychain.keychain.map({ it.asFile }))
         }


### PR DESCRIPTION
## Description

A simple patch to set some basic conventions for the default settings for the build keychain. Without these the keychain would be created with the default settings (lock after sleep and lock after 5 minutes) This will ensure that longer builds still can access the keychain after a compile.

I also set a domain value for the keychain operation to not write into the system values etc. This is just a precauthion since the user in question can only set user keychains anyway. But the commandline arguments can be smaller and it is in general a better way.

## Changes

* ![IMPROVE] default build keychain settings
* ![IMPROVE] set domain value for keychain searchlist operations


[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
