### PR TITLE
Add empty plugin class for net.wooga.macos-security plugin [ATLAS-847]

### DIFF
--- a/src/main/groovy/wooga/gradle/macOS/security/SecurityPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/macOS/security/SecurityPlugin.groovy
@@ -1,0 +1,11 @@
+package wooga.gradle.macOS.security
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+class SecurityPlugin implements Plugin<Project> {
+    @Override
+    void apply(Project project) {
+
+    }
+}

--- a/src/main/resources/META-INF/gradle-plugins/net.wooga.macos-security.properties
+++ b/src/main/resources/META-INF/gradle-plugins/net.wooga.macos-security.properties
@@ -1,0 +1,20 @@
+#
+# Copyright 2022 Wooga GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+#
+#
+
+implementation-class=wooga.gradle.macOS.security.SecurityPlugin

--- a/src/test/groovy/wooga/gradle/macOS/security/SecurityPluginActivationSpec.groovy
+++ b/src/test/groovy/wooga/gradle/macOS/security/SecurityPluginActivationSpec.groovy
@@ -1,0 +1,10 @@
+package wooga.gradle.macOS.security
+
+import nebula.test.PluginProjectSpec
+
+class SecurityPluginActivationSpec  extends PluginProjectSpec {
+    @Override
+    String getPluginName() {
+        return 'net.wooga.macos-security'
+    }
+}


### PR DESCRIPTION
## Description

For the split of the internal plugin now named `net.wooga.macos-security` we need to declare a plugin class. The plugin itself brings in no auto added tasks or conventions at the moment. This is the reason why the plugin is empty. I have some ideas about use case conventions but I want to keep the plugin as generic as possible for the time being.

## Changes

* ![ADD] ![GRADLE] plugin class for `net.wooga.macos-security`

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"