### PR TITLE
Improve test setup for net.wooga.macos-security test

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/macOS/security/SecurityIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/macOS/security/SecurityIntegrationSpec.groovy
@@ -1,0 +1,20 @@
+package wooga.gradle.macOS.security
+
+import com.wooga.security.Domain
+import wooga.gradle.build.IntegrationSpec
+import wooga.gradle.macOS.security.tasks.SecuritySetKeychainSearchList
+
+abstract class SecurityIntegrationSpec extends IntegrationSpec {
+    static wrapValueFallback = { Object rawValue, String type, Closure<String> fallback ->
+        switch (type) {
+            case Domain.simpleName:
+                return "${Domain.class.name}.valueOf('${rawValue.toString()}')"
+            case SecuritySetKeychainSearchList.Action.simpleName:
+                return "${SecuritySetKeychainSearchList.Action.class.name}.valueOf('${rawValue.toString()}')"
+            default:
+                return rawValue.toString()
+        }
+    }
+
+
+}

--- a/src/integrationTest/groovy/wooga/gradle/macOS/security/SecurityTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/macOS/security/SecurityTaskIntegrationSpec.groovy
@@ -1,0 +1,37 @@
+package wooga.gradle.macOS.security
+
+import org.gradle.api.Task
+
+import java.lang.reflect.ParameterizedType
+
+abstract class SecurityTaskIntegrationSpec<T extends Task> extends SecurityIntegrationSpec {
+    Class<T> getSubjectUnderTestClass() {
+        if (!_sutClass) {
+            try {
+                this._sutClass = (Class<T>) ((ParameterizedType) this.getClass().getGenericSuperclass())
+                        .getActualTypeArguments()[0];
+            }
+            catch (Exception e) {
+                this._sutClass = (Class<T>) null
+            }
+        }
+        _sutClass
+    }
+    private Class<T> _sutClass
+
+    String getSubjectUnderTestName() {
+        "${subjectUnderTestClass.simpleName.uncapitalize()}Test"
+    }
+
+    String getSubjectUnderTestTypeName() {
+        subjectUnderTestClass.getTypeName()
+    }
+
+    void appendToSubjectTask(String... lines) {
+        buildFile << """
+        $subjectUnderTestName {
+            ${lines.join('\n')}
+        }
+        """.stripIndent()
+    }
+}

--- a/src/integrationTest/groovy/wooga/gradle/macOS/security/tasks/InteractiveSecurityTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/macOS/security/tasks/InteractiveSecurityTaskIntegrationSpec.groovy
@@ -1,0 +1,15 @@
+package wooga.gradle.macOS.security.tasks
+
+
+import wooga.gradle.macOS.security.SecurityTaskIntegrationSpec
+
+abstract class InteractiveSecurityTaskIntegrationSpec<T extends AbstractInteractiveSecurityTask> extends SecurityTaskIntegrationSpec<T> {
+    String keychainPassword = "123456"
+
+    def setup() {
+        buildFile << """
+        task ${subjectUnderTestName}(type: ${subjectUnderTestTypeName}) {
+        }
+        """.stripIndent()
+    }
+}

--- a/src/integrationTest/groovy/wooga/gradle/macOS/security/tasks/SecurityResetKeychainSearchListIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/macOS/security/tasks/SecurityResetKeychainSearchListIntegrationSpec.groovy
@@ -4,9 +4,7 @@ import jdk.nashorn.internal.ir.annotations.Ignore
 import spock.lang.Requires
 
 @Requires({ os.macOs && env['ATLAS_BUILD_UNITY_IOS_EXECUTE_KEYCHAIN_SPEC'] == 'YES' })
-class SecurityResetKeychainSearchListIntegrationSpec extends KeychainSearchListSpec {
-    String testTaskName = "resetKeychainSearchList"
-    Class taskType = SecurityResetKeychainSearchList
+class SecurityResetKeychainSearchListIntegrationSpec extends KeychainSearchListSpec<SecurityResetKeychainSearchList> {
 
     @Ignore
     def "can reset keychain lookup list"() {
@@ -20,10 +18,10 @@ class SecurityResetKeychainSearchListIntegrationSpec extends KeychainSearchListS
         keychainSearchList.addAll(keychains.collect { it.location })
 
         when:
-        def result = runTasksSuccessfully(testTaskName)
+        def result = runTasksSuccessfully(subjectUnderTestName)
 
         then:
-        !result.wasSkipped(testTaskName)
+        !result.wasSkipped(subjectUnderTestName)
         keychainSearchList.collect() == defaultLookupList
 
         where:
@@ -37,9 +35,9 @@ class SecurityResetKeychainSearchListIntegrationSpec extends KeychainSearchListS
         fork = true
 
         when:
-        def result = runTasksSuccessfully(testTaskName)
+        def result = runTasksSuccessfully(subjectUnderTestName)
 
         then:
-        result.wasSkipped(testTaskName)
+        result.wasSkipped(subjectUnderTestName)
     }
 }


### PR DESCRIPTION
## Description

This patch updates the test setup for the `net.wooga.macos-security` plugin to the latest conventions from gradle commons.

## Changes

* ![IMPROVE] `net.wooga.macos-security` test



[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
