### PR TITLE
Fix overload for task action for SighRenewBatch

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/fastlane/FastlaneIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/fastlane/FastlaneIntegrationSpec.groovy
@@ -16,7 +16,6 @@
 
 package wooga.gradle.fastlane
 
-import com.wooga.gradle.PlatformUtils
 
 import java.nio.file.Paths
 

--- a/src/integrationTest/groovy/wooga/gradle/fastlane/tasks/AbstractFastlaneTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/fastlane/tasks/AbstractFastlaneTaskIntegrationSpec.groovy
@@ -17,15 +17,10 @@
 package wooga.gradle.fastlane.tasks
 
 import com.wooga.gradle.PlatformUtils
-import com.wooga.gradle.io.FileUtils
 import com.wooga.gradle.test.PropertyQueryTaskWriter
 import spock.lang.Requires
 import spock.lang.Unroll
 import wooga.gradle.fastlane.FastlaneIntegrationSpec
-import wooga.gradle.xcodebuild.ConsoleSettings
-import wooga.gradle.xcodebuild.config.BuildSettings
-
-import javax.naming.spi.ObjectFactory
 
 abstract class AbstractFastlaneTaskIntegrationSpec extends FastlaneIntegrationSpec {
 
@@ -77,20 +72,7 @@ abstract class AbstractFastlaneTaskIntegrationSpec extends FastlaneIntegrationSp
         "apiKeyPath" | "setApiKeyPath"  | osPath("/some/path/key6.json") | _             | "Provider<RegularFile>"
 
         // TODO: Is this meant to be here?
-        value = wrapValueBasedOnType(rawValue, type, { type ->
-            switch (type) {
-                case ConsoleSettings.class.simpleName:
-                    return "${ConsoleSettings.class.name}.fromGradleOutput(org.gradle.api.logging.configuration.ConsoleOutput.${rawValue.toString().capitalize()})"
-
-                case BuildSettings.class.simpleName:
-                    return "new ${BuildSettings.class.name}()" + rawValue.replaceAll(/(\[|\])/, '').split(',').collect({
-                        List<String> parts = it.split("=")
-                        ".put('${parts[0].trim()}', '${parts[1].trim()}')"
-                    }).join("")
-                default:
-                    return rawValue
-            }
-        })
+        value = wrapValueBasedOnType(rawValue, type)
         path = PlatformUtils.escapedPath(osPath(value))
         invocation = (method == _) ? "${property} = ${path}" : "${method}(${path})"
         testValue = (expectedValue == _) ? rawValue : expectedValue

--- a/src/integrationTest/groovy/wooga/gradle/fastlane/tasks/PilotUploadIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/fastlane/tasks/PilotUploadIntegrationSpec.groovy
@@ -18,7 +18,6 @@ package wooga.gradle.fastlane.tasks
 
 import com.wooga.gradle.PlatformUtils
 import com.wooga.gradle.test.PropertyQueryTaskWriter
-import org.apache.commons.io.FileUtils
 import spock.lang.Requires
 import spock.lang.Unroll
 

--- a/src/main/groovy/wooga/gradle/fastlane/models/FastLaneTaskSpec.groovy
+++ b/src/main/groovy/wooga/gradle/fastlane/models/FastLaneTaskSpec.groovy
@@ -1,14 +1,9 @@
 package wooga.gradle.fastlane.models
 
-import com.wooga.gradle.BaseSpec
-import org.gradle.api.file.RegularFile
-import org.gradle.api.file.RegularFileProperty
+
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
-import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.Optional
-
 
 trait FastLaneTaskSpec extends FastLaneSpec {
 

--- a/src/main/groovy/wooga/gradle/fastlane/models/PilotUploadSpec.groovy
+++ b/src/main/groovy/wooga/gradle/fastlane/models/PilotUploadSpec.groovy
@@ -1,18 +1,11 @@
 package wooga.gradle.fastlane.models
 
 import com.wooga.gradle.BaseSpec
-import org.gradle.api.file.Directory
-import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFile
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
-import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.OutputFile
-import org.gradle.api.tasks.SkipWhenEmpty
-
 
 trait PilotUploadSpec extends BaseSpec {
 

--- a/src/main/groovy/wooga/gradle/fastlane/models/SighRenewSpec.groovy
+++ b/src/main/groovy/wooga/gradle/fastlane/models/SighRenewSpec.groovy
@@ -3,13 +3,9 @@ package wooga.gradle.fastlane.models
 import com.wooga.gradle.BaseSpec
 import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.file.FileCollection
-import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.OutputFile
-import org.gradle.api.tasks.OutputFiles
 
 trait SighRenewSpec extends BaseSpec {
 

--- a/src/main/groovy/wooga/gradle/fastlane/tasks/SighRenewBatch.groovy
+++ b/src/main/groovy/wooga/gradle/fastlane/tasks/SighRenewBatch.groovy
@@ -6,7 +6,6 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
-import org.gradle.api.tasks.TaskAction
 
 /**
  * Batch version of {@code SighRenew} to import multiple
@@ -65,8 +64,8 @@ class SighRenewBatch extends SighRenew {
         })
     }
 
-    @TaskAction
-    protected importProfiles() {
+    @Override
+    protected void exec() {
         def profiles = new HashMap<String, String>()
         profiles.putAll(this.profiles.getOrElse([:]))
         if ((appIdentifier.present && !profiles.containsKey(appIdentifier.get())) && (provisioningName.present && !profiles.containsValue(provisioningName.get()))) {
@@ -82,7 +81,7 @@ class SighRenewBatch extends SighRenew {
             fileName.set("${name}.mobileprovision")
 
             logger.info("import provisioning profile '${name}' for bundleIdentifier '${appId}' to file '${fileName.get()}'")
-            exec()
+            super.exec()
         }
     }
 }


### PR DESCRIPTION
## Description

I was under the assumption what when one overrides a gradle task type which contains an `TaskAction` annotated method that if one annotates another new method that the original action is no longer executed. That is not the case. So I fixed this here to override the `exec` method rather than declaring another action to be executed.

## Changes

* ![FIX] overload for task action in `SighRenewBatch` task


[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
