### PR TITLE
Improve net.wooga.build-unity-ios with configuration avoidance API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ dependencies {
     api 'net.wooga.gradle:secrets:1.0.0-rc.6'
     api 'net.wooga.gradle:xcodebuild:[1,2['
     api "net.wooga.gradle:macos-security:[1.0.1,2["
-    api "net.wooga.gradle:fastlane:[1,2["
+    api "net.wooga.gradle:fastlane:[1.0.1,2["
     api 'software.amazon.awssdk:secretsmanager:[2.16,3['
     implementation 'xmlwise:xmlwise:1.2.11'
     implementation 'commons-codec:commons-codec:1.14'

--- a/src/test/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginSpec.groovy
@@ -2,7 +2,6 @@ package wooga.gradle.build.unity.ios
 
 import nebula.test.ProjectSpec
 import org.gradle.api.DefaultTask
-import org.gradle.api.Task
 import spock.lang.Requires
 import spock.lang.Shared
 import spock.lang.Unroll
@@ -132,7 +131,8 @@ class IOSBuildPluginSpec extends ProjectSpec {
         project.evaluate()
         def task1 = project.tasks.getByName(taskName)
         def task2 = project.tasks.getByName(dependedTask)
-        task1.dependsOn.contains(task2) == dependsOnTask
+
+        task1.dependsOn.collect({ it.name }).contains(task2.name) == dependsOnTask
 
         where:
         taskName  | dependedTask        | publishToTestflight | dependsOnTask
@@ -140,6 +140,4 @@ class IOSBuildPluginSpec extends ProjectSpec {
         "publish" | "publishTestFlight" | false               | false
         message = (dependsOnTask) ? "depends" : "depends not"
     }
-
-
 }


### PR DESCRIPTION
## Description

The plan is to split the `net.wooga.build-unity-ios` plugin out of this repo. I looked over the Plugin class and saw that we still used the static task creation setup. I switched all over to the `tasks.register` methods and updated the calls to work with this new setup. The speed gain should not be super high because we need all tasks in the run anyway but it is the cleaner setup overall.

## Changes

* ![IMPROVE] `net.wooga.build-unity-ios` plugin with configuration avoidance API

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
