### PR TITLE
Improve property mapping for net.wooga.build-unity-ios

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/build/unity/ios/tasks/CocoaPodSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/unity/ios/tasks/CocoaPodSpec.groovy
@@ -37,20 +37,20 @@ abstract class CocoaPodSpec<T extends Task> extends IOSBuildIntegrationSpec {
     }
 
     def setup() {
-        setupPodMock()
         buildFile << """
         task $subjectUnderTestName(type: ${subjectUnderTestTypeName})
         """.stripIndent()
+        setupPodMock()
     }
 
     def setupPodMock() {
         podMockPath = File.createTempDir("pod", "mock")
 
-        def path = System.getenv("PATH")
-        environmentVariables.clear("PATH")
-        String newPath = "${podMockPath}${File.pathSeparator}${path}"
-        environmentVariables.set("PATH", newPath)
-        assert System.getenv("PATH") == newPath
+        buildFile << """
+        $subjectUnderTestName {
+            executableDirectory.set(${wrapValueBasedOnType(podMockPath, "File")})
+        } 
+        """.stripIndent()
 
         podMock = createFile("pod", podMockPath)
         podMock.executable = true

--- a/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginConventions.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginConventions.groovy
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2022 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package wooga.gradle.build.unity.ios
+
+import com.wooga.gradle.PropertyLookup
+
+class IOSBuildPluginConventions {
+    static final PropertyLookup cocoaPodsExecutableName = new PropertyLookup(
+            "IOS_BUILD_COCOAPODS_EXECUTABLE_NAME",
+            "iosBuild.cocoapods.executableName",
+            "pod")
+
+    static final PropertyLookup cocoaPodsExecutableDirectory = new PropertyLookup(
+            "IOS_BUILD_COCOAPODS_EXECUTABLE_DIRECTORY",
+            "iosBuild.cocoapods.executableDirectory",
+            null)
+
+    static final PropertyLookup xcodeProjectDirectory = new PropertyLookup(
+            "IOS_BUILD_XCODE_PROJECT_DIRECTORY",
+            "iosBuild.xcodeProjectDirectory",
+            null)
+
+    static final PropertyLookup xcodeProjectPath = new PropertyLookup(
+            "IOS_BUILD_XCODE_PROJECT_PATH",
+            "iosBuild.xcodeProjectPath",
+            null)
+
+    static final PropertyLookup xcodeWorkspacePath = new PropertyLookup(
+            "IOS_BUILD_XCODE_WORKSPACE_PATH",
+            "iosBuild.xcodeWorkspacePath",
+            null)
+
+
+    static final PropertyLookup projectBaseName = new PropertyLookup(
+            "IOS_BUILD_PROJECT_BASE_NAME",
+            "iosBuild.projectBaseName",
+            "Unity-iPhone")
+
+    static final PropertyLookup preferWorkspace = new PropertyLookup(
+            "IOS_BUILD_PREFER_WORKSPACE",
+            "iosBuild.preferWorkspace",
+            true)
+
+    static final PropertyLookup exportOptionsPlist = new PropertyLookup(
+            "IOS_BUILD_EXPORT_OPTIONS_PLIST",
+            "iosBuild.exportOptionsPlist",
+            null)
+
+    static final PropertyLookup publishToTestFlight = new PropertyLookup(
+            "IOS_BUILD_PUBLISH_TO_TEST_FLIGHT",
+            ["iosBuild.publishToTestFlight", "publishToTestFlight"],
+            false)
+
+    static final PropertyLookup adhoc = new PropertyLookup(
+            "IOS_BUILD_ADHOC",
+            "iosBuild.adhoc",
+            false)
+
+    static final PropertyLookup keychainPassword = new PropertyLookup(
+            "IOS_BUILD_KEYCHAIN_PASSWORD",
+            "iosBuild.keychainPassword",
+            null)
+
+    static final PropertyLookup codeSigningIdentityFile = new PropertyLookup(
+            "IOS_BUILD_CODE_SIGNING_IDENTITY_FILE",
+            "iosBuild.codeSigningIdentityFile",
+            null)
+
+    static final PropertyLookup codeSigningIdentityFilePassphrase = new PropertyLookup(
+            "IOS_BUILD_CODE_SIGNING_IDENTITY_FILE_PASSPHRASE",
+            "iosBuild.codeSigningIdentityFilePassphrase",
+            null)
+
+    static final PropertyLookup scheme = new PropertyLookup(
+            "IOS_BUILD_SCHEME",
+            "iosBuild.scheme",
+            null)
+
+    static final PropertyLookup teamId = new PropertyLookup(
+            "IOS_BUILD_TEAM_ID",
+            ["iosBuild.teamId", "teamId"],
+            null)
+
+    static final PropertyLookup configuration = new PropertyLookup(
+            "IOS_BUILD_CONFIGURATION",
+            "iosBuild.configuration",
+            null)
+
+    static final PropertyLookup provisioningName = new PropertyLookup(
+            "IOS_BUILD_PROVISIONING_NAME",
+            "iosBuild.provisioningName",
+            null)
+
+    static final PropertyLookup signingIdentities = new PropertyLookup(
+            "IOS_BUILD_SIGNING_IDENTITIES",
+            "iosBuild.signingIdentities",
+            null)
+
+    static final PropertyLookup appIdentifier = new PropertyLookup(
+            "IOS_BUILD_APP_IDENTIFIER",
+            ["iosBuild.appIdentifier", "appIdentifier"],
+            null)
+}

--- a/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/ios/IOSBuildPluginExtension.groovy
@@ -1,6 +1,25 @@
+/*
+ * Copyright 2018-22 Wooga GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package wooga.gradle.build.unity.ios
 
 import com.wooga.gradle.BaseSpec
+import com.wooga.gradle.io.ExecSpec
+import groovy.transform.stc.ClosureParams
+import groovy.transform.stc.FromString
 import org.gradle.api.Action
 import org.gradle.api.credentials.PasswordCredentials
 import org.gradle.api.file.Directory
@@ -11,6 +30,7 @@ import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
+import org.gradle.util.ConfigureUtil
 import wooga.gradle.xcodebuild.config.ExportOptions
 
 import static org.gradle.util.ConfigureUtil.configureUsing
@@ -332,4 +352,16 @@ trait IOSBuildPluginExtension extends BaseSpec {
         }
         it.dir(xcodeProjectFileName)
     })
+
+    private static class CocoaPods implements ExecSpec {}
+
+    ExecSpec cocoapods = objects.newInstance(CocoaPods)
+
+    void cocoapods(Action<ExecSpec> action) {
+        action.execute(cocoapods)
+    }
+
+    void cocoapods(@ClosureParams(value = FromString.class, options = ["com.wooga.gradle.io.ExecSpec"])Closure configure) {
+        cocoapods(configureUsing(configure))
+    }
 }


### PR DESCRIPTION
## Description

This patch includes three kind of related changes.

1. use new `ExecSpec` for `PodInstall` task
2. bind cocoapods executable name / path to extension
3. bind extension properties to conventions (env, property)

### Pod Install

The cocoapods task used a utility class to find the nearest `pod` executable in the `PATH`. This system works but is not future proof. We are in the works to provide a way to lazy install the tool during a build and need an internal property to set the executable name / path. We developed the `ExecSpec` class which we also already used in the `net.wooga.fastlane` plugin for the same reason.

### Bind to extension

To make this new value easily setable, also in case we create more cocoapod task types, I added a new nested object inside the `IOSBuildPluginExtension` called 'cocoapods` which interally is also just an `ExecSpec` to set the values for executable name and path etc.

```groovy
iosBuild {
    cocoapods {
        executableDirectory = file("/yada/yada/yada")
	executableName = "pod"
    }
}
```

### Bind to conventions

Most of our plugins provide a way to fetch default / convention values from the gradle properties / system environment. We never did this for the `net.wooga.build-unity-ios` plugin. I decided to implement this now before we split and release this plugin.

## Changes

* ![IMPROVE] use `ExecSpec` in `PodInstall` task
* ![ADD] `cocoapods` nested object to plugin extension
* ![IMPROVE] convention mappings to extension values



[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
