### PR TITLE
Remove the appConfigFile property

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/build/unity/tasks/UnityBuildPlayerIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/build/unity/tasks/UnityBuildPlayerIntegrationSpec.groovy
@@ -38,16 +38,15 @@ class UnityBuildPlayerIntegrationSpec extends UnityIntegrationSpec {
         hasKeyValue("--${argName}".toString(), actualConfigValue, customArgsParts)
         hasKeyValue("--version", version, customArgsParts)
         hasKeyValue("--outputPath",
-                new File(projectDir, "build/export/${appConfigName}/project").path, customArgsParts)
+            new File(projectDir, "build/export/${appConfigName}/project").path, customArgsParts)
         if (argName == "configPath") {
             hasKeyValue("-buildTarget", "android", customArgsParts)
         }
 
         where:
-        configProperty  | argName      | configValue                         | configValueType
-        "config"        | "config"     | "configName"                        | String
-        "configPath"    | "configPath" | "Assets/CustomConfigs/custom.asset" | File
-        "appConfigFile" | "configPath" | "Assets/CustomConfigs/custom.asset" | File
+        configProperty | argName      | configValue                         | configValueType
+        "config"       | "config"     | "configName"                        | String
+        "configPath"   | "configPath" | "Assets/CustomConfigs/custom.asset" | File
     }
 
     @Unroll
@@ -98,7 +97,7 @@ class UnityBuildPlayerIntegrationSpec extends UnityIntegrationSpec {
         buildFile << """
             task("customExport", type: ${UnityBuildPlayer.class.name}) {
                 ubsCompatibilityVersion = ${wrapValueBasedOnType(compatibility, "UBSVersion", wrapValueFallback)}
-                appConfigFile = ${wrapValueBasedOnType("Assets/CustomConfigs/custom.asset", "File")}
+                configPath = ${wrapValueBasedOnType("Assets/CustomConfigs/custom.asset", "File")}
                 ${property} = ${wrapValueBasedOnType(expectedValue, "String")}
             }           
         """.stripIndent()
@@ -114,8 +113,8 @@ class UnityBuildPlayerIntegrationSpec extends UnityIntegrationSpec {
         "version"     | "--version"            | "1.0.0"       | UBSVersion.v100
         "version"     | "--version"            | "2.0.0"       | UBSVersion.v120
         "version"     | "--build-version"      | "3.0.0"       | UBSVersion.v160
-        "versionCode" | "--versionCode"       | "1"           | UBSVersion.v100
-        "versionCode" | "--versionCode"       | "2"           | UBSVersion.v120
+        "versionCode" | "--versionCode"        | "1"           | UBSVersion.v100
+        "versionCode" | "--versionCode"        | "2"           | UBSVersion.v120
         "versionCode" | "--build-version-code" | "3"           | UBSVersion.v160
     }
 }

--- a/src/main/groovy/wooga/gradle/build/unity/UnityBuildPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/UnityBuildPlugin.groovy
@@ -208,10 +208,6 @@ class UnityBuildPlugin implements Plugin<Project> {
             task.commitHash.convention(extension.commitHash)
             task.version.convention(extension.version)
             task.versionCode.convention(extension.versionCode)
-            task.buildTarget.convention(task.appConfigFile.map({
-                def config = new GenericUnityAssetFile(it.asFile)
-                return config["batchModeBuildTarget"]?.toString()?.toLowerCase()
-            }))
         }
 
         project.tasks.withType(GradleBuild).configureEach({ GradleBuild t ->

--- a/src/main/groovy/wooga/gradle/build/unity/models/UnityBuildEngineSpec.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/models/UnityBuildEngineSpec.groovy
@@ -79,6 +79,9 @@ trait UnityBuildEngineSpec extends UnityBuildBaseSpec {
 
     private final Property<String> config = objects.property(String)
 
+    /**
+     * @return The name of the configuration file to use. This should be used when no path is specified in {@code configPath}.
+     */
     @Optional
     @Input
     Property<String> getConfig() {
@@ -91,6 +94,9 @@ trait UnityBuildEngineSpec extends UnityBuildBaseSpec {
 
     private final RegularFileProperty configPath = objects.fileProperty()
 
+    /**
+     * @return The path to the configuration file for the build. This should be used when no name is specified in {@code config}
+     */
     @Optional
     @InputFile
     RegularFileProperty getConfigPath() {

--- a/src/main/groovy/wooga/gradle/build/unity/tasks/UnityBuildPlayer.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/tasks/UnityBuildPlayer.groovy
@@ -29,18 +29,4 @@ class UnityBuildPlayer extends UnityBuildEngineTask implements VersionSpec {
         }
         super.setupExecution(exportArgs)
     }
-
-    @Optional
-    @InputFile
-    RegularFileProperty getAppConfigFile() {
-        return configPath
-    }
-
-    void setAppConfigFile(String appConfigFile) {
-        this.configPath.set(new File(appConfigFile))
-    }
-
-    void setAppConfigFile(File appConfigFile) {
-        this.configPath.set(appConfigFile)
-    }
 }

--- a/src/main/groovy/wooga/gradle/build/unity/tasks/UnityBuildPlayerTask.groovy
+++ b/src/main/groovy/wooga/gradle/build/unity/tasks/UnityBuildPlayerTask.groovy
@@ -26,6 +26,7 @@ import org.gradle.api.file.RegularFile
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.*
+import wooga.gradle.build.unity.UnityBuildPlugin
 import wooga.gradle.build.unity.models.UnityBuildSpec
 import wooga.gradle.build.unity.models.VersionSpec
 import wooga.gradle.secrets.internal.Secrets
@@ -41,7 +42,7 @@ import javax.crypto.spec.SecretKeySpec
 @Deprecated
 class UnityBuildPlayerTask extends UnityTask implements SecretSpec, UnityBuildSpec, VersionSpec {
 
-    static String BUILD_TARGET_KEY = "batchModeBuildTarget"
+    static String BUILD_TARGET_KEY = UnityBuildPlugin.appConfigBuildTarget
 
     private final ConfigurableFileCollection inputFiles
 


### PR DESCRIPTION
## Description

The property `UnityBuildPlayer.appConfigFile` was duplicating `configPath`, and applying a convention twice to `buildTarget`.  We can safely remove it, partly due to it not being used and because `AppConfig` will be deprecated in UBS 2x.

## Changes
* ![REMOVE] `UnityBuildPlayer.appConfigFile`

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
